### PR TITLE
feat: RegexParser, ParserGroup, ParserFactory implementation

### DIFF
--- a/crates/scouty/src/parser/factory.rs
+++ b/crates/scouty/src/parser/factory.rs
@@ -1,2 +1,101 @@
-//! Parser factory — auto-selects parser group based on loader info.
-//! Full implementation in Phase 2.
+//! Parser factory — auto-selects or builds a parser group based on loader info.
+
+#[cfg(test)]
+#[path = "factory_tests.rs"]
+mod factory_tests;
+
+use crate::parser::group::ParserGroup;
+use crate::parser::regex_parser::RegexParser;
+use crate::traits::{LoaderInfo, LoaderType};
+
+/// Built-in parser definitions that the factory can produce.
+pub struct ParserFactory;
+
+impl ParserFactory {
+    /// Create a default parser group for the given loader info.
+    ///
+    /// Uses the loader type and sample lines to pick appropriate parsers.
+    /// Returns a parser group with a fallback chain.
+    pub fn create_parser_group(info: &LoaderInfo) -> ParserGroup {
+        let mut group = ParserGroup::new(format!("auto:{}", info.id));
+
+        match info.loader_type {
+            LoaderType::Syslog => {
+                // Syslog-specific parsers
+                Self::add_syslog_parsers(&mut group);
+            }
+            LoaderType::Otlp => {
+                // OTLP records are structured — future phase
+            }
+            LoaderType::TextFile | LoaderType::Archive => {
+                // Try to auto-detect from sample lines
+                if Self::looks_like_syslog(&info.sample_lines) {
+                    Self::add_syslog_parsers(&mut group);
+                }
+                // Add common log format parsers
+                Self::add_common_parsers(&mut group);
+            }
+        }
+
+        // Always add a catch-all parser as final fallback
+        Self::add_fallback_parser(&mut group);
+
+        group
+    }
+
+    fn looks_like_syslog(sample_lines: &[String]) -> bool {
+        // Simple heuristic: check if lines start with month abbreviation (e.g. "Jan 15")
+        let syslog_re = regex::Regex::new(
+            r"^(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}",
+        )
+        .unwrap();
+        sample_lines.iter().take(5).any(|l| syslog_re.is_match(l))
+    }
+
+    fn add_syslog_parsers(group: &mut ParserGroup) {
+        // BSD syslog format: "Jan 15 10:30:00 hostname process[pid]: message"
+        if let Ok(p) = RegexParser::new(
+            "syslog-bsd",
+            r"^(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?P<process>\S+)\s+(?P<component>\S+?)(?:\[(?P<pid>\d+)\])?:\s+(?P<message>.*)",
+            Some("%b %d %H:%M:%S".to_string()),
+        ) {
+            group.add_parser(Box::new(p));
+        }
+    }
+
+    fn add_common_parsers(group: &mut ParserGroup) {
+        // ISO timestamp + level + message: "2024-01-15 10:30:00 INFO message"
+        if let Ok(p) = RegexParser::new(
+            "iso-level-msg",
+            r"^(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<level>TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL|CRITICAL)\s+(?P<message>.*)",
+            None,
+        ) {
+            group.add_parser(Box::new(p));
+        }
+
+        // ISO timestamp + bracketed level: "2024-01-15 10:30:00 [INFO] message"
+        if let Ok(p) = RegexParser::new(
+            "iso-bracket-level-msg",
+            r"^(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+\[(?P<level>\w+)\]\s+(?P<message>.*)",
+            None,
+        ) {
+            group.add_parser(Box::new(p));
+        }
+
+        // Level first: "INFO 2024-01-15 10:30:00 message"
+        if let Ok(p) = RegexParser::new(
+            "level-iso-msg",
+            r"^(?P<level>TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL|CRITICAL)\s+(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<message>.*)",
+            None,
+        ) {
+            group.add_parser(Box::new(p));
+        }
+    }
+
+    fn add_fallback_parser(group: &mut ParserGroup) {
+        // Catch-all: entire line as message
+        if let Ok(p) = RegexParser::new("fallback", r"(?P<message>.+)", None) {
+            group.add_parser(Box::new(p));
+        }
+    }
+}

--- a/crates/scouty/src/parser/factory_tests.rs
+++ b/crates/scouty/src/parser/factory_tests.rs
@@ -79,7 +79,6 @@ mod tests {
             sample_lines: vec![],
         };
         let group = ParserFactory::create_parser_group(&info);
-        // Should have syslog parsers + fallback
         assert!(group.parsers.len() >= 2);
     }
 }

--- a/crates/scouty/src/parser/group.rs
+++ b/crates/scouty/src/parser/group.rs
@@ -1,2 +1,40 @@
-//! Parser group (re-exported from session for now).
-//! Full implementation in Phase 2.
+//! Parser group — an ordered fallback chain of parsers.
+
+#[cfg(test)]
+#[path = "group_tests.rs"]
+mod group_tests;
+
+use crate::record::LogRecord;
+use crate::traits::LogParser;
+
+/// A parser group: an ordered list of parsers tried in sequence (fallback chain).
+#[derive(Debug)]
+pub struct ParserGroup {
+    /// Human-readable name of this group.
+    pub name: String,
+    /// Ordered list of parsers; tried first-to-last.
+    pub parsers: Vec<Box<dyn LogParser>>,
+}
+
+impl ParserGroup {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            parsers: Vec::new(),
+        }
+    }
+
+    pub fn add_parser(&mut self, parser: Box<dyn LogParser>) {
+        self.parsers.push(parser);
+    }
+
+    /// Try each parser in order. Returns the first successful parse, or None.
+    pub fn parse(&self, raw: &str, source: &str, loader_id: &str, id: u64) -> Option<LogRecord> {
+        for parser in &self.parsers {
+            if let Some(record) = parser.parse(raw, source, loader_id, id) {
+                return Some(record);
+            }
+        }
+        None
+    }
+}

--- a/crates/scouty/src/parser/group_tests.rs
+++ b/crates/scouty/src/parser/group_tests.rs
@@ -25,11 +25,9 @@ mod tests {
     #[test]
     fn test_fallback_to_second_parser() {
         let mut group = ParserGroup::new("fallback-group");
-        // First parser: strict format that won't match
         group.add_parser(Box::new(
             RegexParser::new("strict", r"^STRICT (?P<message>.*)", None).unwrap(),
         ));
-        // Second parser: loose catch-all
         group.add_parser(Box::new(
             RegexParser::new("loose", r"(?P<message>.+)", None).unwrap(),
         ));

--- a/crates/scouty/src/parser/regex_parser.rs
+++ b/crates/scouty/src/parser/regex_parser.rs
@@ -1,1 +1,137 @@
-//! Regex-based log parser (skeleton for Phase 2).
+//! Regex-based log parser.
+//!
+//! Uses named capture groups to extract fields from log lines.
+//! Supported named groups: `timestamp`, `level`, `message`, `pid`, `tid`,
+//! `component`, `process`, and any others go into `metadata`.
+
+#[cfg(test)]
+#[path = "regex_parser_tests.rs"]
+mod regex_parser_tests;
+
+use crate::record::{LogLevel, LogRecord};
+use crate::traits::LogParser;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use regex::Regex;
+use std::collections::HashMap;
+
+/// A log parser driven by a single regex with named capture groups.
+#[derive(Debug)]
+pub struct RegexParser {
+    name: String,
+    pattern: Regex,
+    /// Optional timestamp format string (chrono strftime) for parsing the `timestamp` group.
+    /// If None, tries ISO 8601 by default.
+    timestamp_format: Option<String>,
+}
+
+impl RegexParser {
+    /// Create a new RegexParser.
+    ///
+    /// `pattern` must be a valid regex with named capture groups.
+    /// Common groups: `(?P<timestamp>...)`, `(?P<level>...)`, `(?P<message>...)`.
+    pub fn new(
+        name: impl Into<String>,
+        pattern: &str,
+        timestamp_format: Option<String>,
+    ) -> Result<Self, regex::Error> {
+        let regex = Regex::new(pattern)?;
+        Ok(Self {
+            name: name.into(),
+            pattern: regex,
+            timestamp_format,
+        })
+    }
+
+    fn parse_timestamp(&self, s: &str) -> Option<DateTime<Utc>> {
+        if let Some(fmt) = &self.timestamp_format {
+            NaiveDateTime::parse_from_str(s, fmt)
+                .ok()
+                .map(|dt| dt.and_utc())
+        } else {
+            // Try ISO 8601 first
+            s.parse::<DateTime<Utc>>()
+                .ok()
+                .or_else(|| {
+                    NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+                        .ok()
+                        .map(|dt| dt.and_utc())
+                })
+                .or_else(|| {
+                    NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
+                        .ok()
+                        .map(|dt| dt.and_utc())
+                })
+        }
+    }
+}
+
+/// Well-known capture group names that map to LogRecord fields.
+const KNOWN_FIELDS: &[&str] = &[
+    "timestamp",
+    "level",
+    "message",
+    "pid",
+    "tid",
+    "component",
+    "process",
+];
+
+impl LogParser for RegexParser {
+    fn parse(&self, raw: &str, source: &str, loader_id: &str, id: u64) -> Option<LogRecord> {
+        let caps = self.pattern.captures(raw)?;
+
+        let timestamp = caps
+            .name("timestamp")
+            .and_then(|m| self.parse_timestamp(m.as_str()))
+            .unwrap_or_else(|| Utc::now());
+
+        let level = caps
+            .name("level")
+            .and_then(|m| LogLevel::from_str_loose(m.as_str()));
+
+        let message = caps
+            .name("message")
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+
+        let pid = caps
+            .name("pid")
+            .and_then(|m| m.as_str().parse::<u32>().ok());
+
+        let tid = caps
+            .name("tid")
+            .and_then(|m| m.as_str().parse::<u32>().ok());
+
+        let component_name = caps.name("component").map(|m| m.as_str().to_string());
+        let process_name = caps.name("process").map(|m| m.as_str().to_string());
+
+        // Collect any extra named groups into metadata
+        let mut metadata = HashMap::new();
+        for name in self.pattern.capture_names().flatten() {
+            if !KNOWN_FIELDS.contains(&name) {
+                if let Some(m) = caps.name(name) {
+                    metadata.insert(name.to_string(), m.as_str().to_string());
+                }
+            }
+        }
+
+        Some(LogRecord {
+            id,
+            timestamp,
+            level,
+            source: source.to_string(),
+            pid,
+            tid,
+            component_name,
+            process_name,
+            message,
+            raw: raw.to_string(),
+            metadata,
+            loader_id: loader_id.to_string(),
+        })
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}

--- a/crates/scouty/src/session.rs
+++ b/crates/scouty/src/session.rs
@@ -1,41 +1,9 @@
 //! LogSession — top-level orchestrator for a log viewing session.
 
 use crate::filter::engine::FilterEngine;
-use crate::record::LogRecord;
+use crate::parser::group::ParserGroup;
 use crate::store::LogStore;
-use crate::traits::{LogLoader, LogParser, LogProcessor, Result};
-
-/// A parser group: an ordered list of parsers tried in sequence (fallback chain).
-#[derive(Debug)]
-pub struct ParserGroup {
-    /// Human-readable name of this group.
-    pub name: String,
-    /// Ordered list of parsers; tried first-to-last.
-    pub parsers: Vec<Box<dyn LogParser>>,
-}
-
-impl ParserGroup {
-    pub fn new(name: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            parsers: Vec::new(),
-        }
-    }
-
-    pub fn add_parser(&mut self, parser: Box<dyn LogParser>) {
-        self.parsers.push(parser);
-    }
-
-    /// Try each parser in order. Returns the first successful parse, or None.
-    pub fn parse(&self, raw: &str, source: &str, loader_id: &str, id: u64) -> Option<LogRecord> {
-        for parser in &self.parsers {
-            if let Some(record) = parser.parse(raw, source, loader_id, id) {
-                return Some(record);
-            }
-        }
-        None
-    }
-}
+use crate::traits::{LogLoader, LogProcessor, Result};
 
 /// Represents a registered loader paired with its parser group.
 struct LoaderSlot {

--- a/crates/scouty/src/session_tests.rs
+++ b/crates/scouty/src/session_tests.rs
@@ -3,7 +3,8 @@
 #[cfg(test)]
 mod tests {
     use crate::record::{LogLevel, LogRecord};
-    use crate::session::{LogSession, ParserGroup};
+    use crate::parser::group::ParserGroup;
+    use crate::session::LogSession;
     use crate::traits::{LoaderInfo, LoaderType, LogLoader, LogParser, Result};
     use chrono::Utc;
     use std::collections::HashMap;


### PR DESCRIPTION
## Summary

Implements task 2.3 — Regex Parser, Parser Group, and Parser Factory.

### Changes
- **RegexParser** (`parser/regex_parser.rs`): Regex-based parser using named capture groups. Maps `timestamp`, `level`, `message`, `pid`, `tid`, `component`, `process` to LogRecord fields. Extra named groups go to metadata. Configurable timestamp format.
- **ParserGroup** (`parser/group.rs`): Moved from session.rs. Ordered fallback chain of parsers.
- **ParserFactory** (`parser/factory.rs`): Auto-creates parser groups based on LoaderType and sample lines. Built-in patterns for syslog BSD, ISO timestamp formats, and catch-all fallback.
- Updated `session.rs` to import ParserGroup from `parser::group`.

### Tests (15 new)
- 6 RegexParser tests
- 4 ParserGroup tests
- 5 ParserFactory tests

All 31 tests pass.

Closes #6