### PR TITLE
feat: Filter expression parser and evaluator

### DIFF
--- a/crates/scouty/src/filter/eval.rs
+++ b/crates/scouty/src/filter/eval.rs
@@ -1,0 +1,73 @@
+//! Filter expression evaluator — evaluates an Expr against a LogRecord.
+
+use crate::filter::expr::{Expr, Op};
+use crate::record::LogRecord;
+use regex::Regex;
+
+/// Evaluate an expression against a log record.
+pub fn eval(expr: &Expr, record: &LogRecord) -> bool {
+    match expr {
+        Expr::Comparison { field, op, value } => {
+            let field_value = get_field(record, field);
+            match field_value {
+                Some(fv) => compare(&fv, op, value),
+                None => false,
+            }
+        }
+        Expr::And(left, right) => eval(left, record) && eval(right, record),
+        Expr::Or(left, right) => eval(left, record) || eval(right, record),
+        Expr::Not(inner) => !eval(inner, record),
+    }
+}
+
+/// Extract a field value from a LogRecord by name.
+fn get_field(record: &LogRecord, field: &str) -> Option<String> {
+    match field {
+        "id" => Some(record.id.to_string()),
+        "timestamp" => Some(record.timestamp.to_rfc3339()),
+        "level" => record.level.map(|l| l.to_string()),
+        "source" => Some(record.source.clone()),
+        "pid" => record.pid.map(|p| p.to_string()),
+        "tid" => record.tid.map(|t| t.to_string()),
+        "component_name" | "component" => record.component_name.clone(),
+        "process_name" | "process" => record.process_name.clone(),
+        "message" => Some(record.message.clone()),
+        "raw" => Some(record.raw.clone()),
+        "loader_id" => Some(record.loader_id.clone()),
+        _ => {
+            // Check metadata with "metadata." prefix or direct key
+            if let Some(key) = field.strip_prefix("metadata.") {
+                record.metadata.get(key).cloned()
+            } else {
+                record.metadata.get(field).cloned()
+            }
+        }
+    }
+}
+
+/// Compare a field value against a target value using the given operator.
+fn compare(field_value: &str, op: &Op, target: &str) -> bool {
+    match op {
+        Op::Eq => field_value == target,
+        Op::Ne => field_value != target,
+        Op::Gt => numeric_cmp(field_value, target).map_or(field_value > target, |o| o == std::cmp::Ordering::Greater),
+        Op::Ge => numeric_cmp(field_value, target).map_or(field_value >= target, |o| o != std::cmp::Ordering::Less),
+        Op::Lt => numeric_cmp(field_value, target).map_or(field_value < target, |o| o == std::cmp::Ordering::Less),
+        Op::Le => numeric_cmp(field_value, target).map_or(field_value <= target, |o| o != std::cmp::Ordering::Greater),
+        Op::Contains => field_value.contains(target),
+        Op::StartsWith => field_value.starts_with(target),
+        Op::EndsWith => field_value.ends_with(target),
+        Op::Regex => Regex::new(target).map_or(false, |re| re.is_match(field_value)),
+    }
+}
+
+/// Try numeric comparison; returns None if either side isn't a number.
+fn numeric_cmp(a: &str, b: &str) -> Option<std::cmp::Ordering> {
+    let na: f64 = a.parse().ok()?;
+    let nb: f64 = b.parse().ok()?;
+    na.partial_cmp(&nb)
+}
+
+#[cfg(test)]
+#[path = "eval_tests.rs"]
+mod eval_tests;

--- a/crates/scouty/src/filter/eval_tests.rs
+++ b/crates/scouty/src/filter/eval_tests.rs
@@ -1,0 +1,156 @@
+#[cfg(test)]
+mod tests {
+    use crate::filter::eval::eval;
+    use crate::filter::expr::parse;
+    use crate::record::{LogLevel, LogRecord};
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn make_record(level: LogLevel, message: &str, component: Option<&str>) -> LogRecord {
+        let mut metadata = HashMap::new();
+        metadata.insert("env".to_string(), "prod".to_string());
+        LogRecord {
+            id: 42,
+            timestamp: Utc::now(),
+            level: Some(level),
+            source: "test-source".into(),
+            pid: Some(1234),
+            tid: None,
+            component_name: component.map(|s| s.to_string()),
+            process_name: None,
+            message: message.into(),
+            raw: message.into(),
+            metadata,
+            loader_id: "loader-1".into(),
+        }
+    }
+
+    #[test]
+    fn eval_eq_level() {
+        let expr = parse(r#"level = "ERROR""#).unwrap();
+        let r = make_record(LogLevel::Error, "boom", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_eq_level_no_match() {
+        let expr = parse(r#"level = "ERROR""#).unwrap();
+        let r = make_record(LogLevel::Info, "ok", None);
+        assert!(!eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_ne() {
+        let expr = parse(r#"level != "DEBUG""#).unwrap();
+        let r = make_record(LogLevel::Error, "boom", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_contains() {
+        let expr = parse(r#"message contains "error""#).unwrap();
+        let r = make_record(LogLevel::Error, "an error occurred", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_starts_with() {
+        let expr = parse(r#"message starts_with "an""#).unwrap();
+        let r = make_record(LogLevel::Info, "an event", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_ends_with() {
+        let expr = parse(r#"message ends_with "occurred""#).unwrap();
+        let r = make_record(LogLevel::Error, "error occurred", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_regex() {
+        let expr = parse(r#"message regex "err(or)?\s+\d+""#).unwrap();
+        let r = make_record(LogLevel::Error, "error 404", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_numeric_comparison() {
+        let expr = parse("id >= 10").unwrap();
+        let r = make_record(LogLevel::Info, "ok", None);
+        assert!(eval(&expr, &r)); // id=42 >= 10
+    }
+
+    #[test]
+    fn eval_numeric_lt() {
+        let expr = parse("id < 10").unwrap();
+        let r = make_record(LogLevel::Info, "ok", None);
+        assert!(!eval(&expr, &r)); // id=42 < 10 is false
+    }
+
+    #[test]
+    fn eval_and() {
+        let expr = parse(r#"level = "ERROR" AND component = "auth""#).unwrap();
+        let r = make_record(LogLevel::Error, "fail", Some("auth"));
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_and_one_fails() {
+        let expr = parse(r#"level = "ERROR" AND component = "db""#).unwrap();
+        let r = make_record(LogLevel::Error, "fail", Some("auth"));
+        assert!(!eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_or() {
+        let expr = parse(r#"level = "ERROR" OR level = "FATAL""#).unwrap();
+        let r = make_record(LogLevel::Error, "fail", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_not() {
+        let expr = parse(r#"NOT level = "DEBUG""#).unwrap();
+        let r = make_record(LogLevel::Error, "fail", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_complex_nested() {
+        let expr = parse(r#"(level = "ERROR" OR level = "FATAL") AND component = "auth""#).unwrap();
+        let r = make_record(LogLevel::Error, "fail", Some("auth"));
+        assert!(eval(&expr, &r));
+
+        let r2 = make_record(LogLevel::Info, "ok", Some("auth"));
+        assert!(!eval(&expr, &r2));
+    }
+
+    #[test]
+    fn eval_metadata_field() {
+        let expr = parse(r#"metadata.env = "prod""#).unwrap();
+        let r = make_record(LogLevel::Info, "ok", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_missing_field_returns_false() {
+        let expr = parse(r#"component = "auth""#).unwrap();
+        let r = make_record(LogLevel::Info, "ok", None); // component is None
+        assert!(!eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_pid() {
+        let expr = parse("pid = 1234").unwrap();
+        let r = make_record(LogLevel::Info, "ok", None);
+        assert!(eval(&expr, &r));
+    }
+
+    #[test]
+    fn eval_source() {
+        let expr = parse(r#"source = "test-source""#).unwrap();
+        let r = make_record(LogLevel::Info, "ok", None);
+        assert!(eval(&expr, &r));
+    }
+}

--- a/crates/scouty/src/filter/expr.rs
+++ b/crates/scouty/src/filter/expr.rs
@@ -1,0 +1,313 @@
+//! Filter expression AST and parser.
+//!
+//! Grammar:
+//!   expr     = or_expr
+//!   or_expr  = and_expr ("OR" and_expr)*
+//!   and_expr = not_expr ("AND" not_expr)*
+//!   not_expr = "NOT" not_expr | primary
+//!   primary  = "(" expr ")" | comparison
+//!   comparison = field op value
+//!   field    = identifier (dotted allowed: "metadata.key")
+//!   op       = "=" | "!=" | ">" | ">=" | "<" | "<=" | "contains" | "starts_with" | "ends_with" | "regex"
+//!   value    = quoted_string | unquoted_token
+
+use std::fmt;
+
+/// Comparison operators.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    Eq,
+    Ne,
+    Gt,
+    Ge,
+    Lt,
+    Le,
+    Contains,
+    StartsWith,
+    EndsWith,
+    Regex,
+}
+
+impl fmt::Display for Op {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Op::Eq => write!(f, "="),
+            Op::Ne => write!(f, "!="),
+            Op::Gt => write!(f, ">"),
+            Op::Ge => write!(f, ">="),
+            Op::Lt => write!(f, "<"),
+            Op::Le => write!(f, "<="),
+            Op::Contains => write!(f, "contains"),
+            Op::StartsWith => write!(f, "starts_with"),
+            Op::EndsWith => write!(f, "ends_with"),
+            Op::Regex => write!(f, "regex"),
+        }
+    }
+}
+
+/// Filter expression AST node.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    /// field op value
+    Comparison {
+        field: String,
+        op: Op,
+        value: String,
+    },
+    /// expr AND expr
+    And(Box<Expr>, Box<Expr>),
+    /// expr OR expr
+    Or(Box<Expr>, Box<Expr>),
+    /// NOT expr
+    Not(Box<Expr>),
+}
+
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Expr::Comparison { field, op, value } => write!(f, "{} {} \"{}\"", field, op, value),
+            Expr::And(l, r) => write!(f, "({} AND {})", l, r),
+            Expr::Or(l, r) => write!(f, "({} OR {})", l, r),
+            Expr::Not(e) => write!(f, "NOT {}", e),
+        }
+    }
+}
+
+/// Tokens for the expression lexer.
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    LParen,
+    RParen,
+    And,
+    Or,
+    Not,
+    Op(Op),
+    Str(String),
+}
+
+/// Tokenize an expression string.
+fn tokenize(input: &str) -> Result<Vec<Token>, String> {
+    let mut tokens = Vec::new();
+    let chars: Vec<char> = input.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Skip whitespace
+        if chars[i].is_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        // Parentheses
+        if chars[i] == '(' {
+            tokens.push(Token::LParen);
+            i += 1;
+            continue;
+        }
+        if chars[i] == ')' {
+            tokens.push(Token::RParen);
+            i += 1;
+            continue;
+        }
+
+        // Multi-char operators
+        if chars[i] == '!' && i + 1 < len && chars[i + 1] == '=' {
+            tokens.push(Token::Op(Op::Ne));
+            i += 2;
+            continue;
+        }
+        if chars[i] == '>' && i + 1 < len && chars[i + 1] == '=' {
+            tokens.push(Token::Op(Op::Ge));
+            i += 2;
+            continue;
+        }
+        if chars[i] == '<' && i + 1 < len && chars[i + 1] == '=' {
+            tokens.push(Token::Op(Op::Le));
+            i += 2;
+            continue;
+        }
+
+        // Single-char operators
+        if chars[i] == '=' {
+            tokens.push(Token::Op(Op::Eq));
+            i += 1;
+            continue;
+        }
+        if chars[i] == '>' {
+            tokens.push(Token::Op(Op::Gt));
+            i += 1;
+            continue;
+        }
+        if chars[i] == '<' {
+            tokens.push(Token::Op(Op::Lt));
+            i += 1;
+            continue;
+        }
+
+        // Quoted string
+        if chars[i] == '"' || chars[i] == '\'' {
+            let quote = chars[i];
+            i += 1;
+            let mut s = String::new();
+            while i < len && chars[i] != quote {
+                if chars[i] == '\\' && i + 1 < len && (chars[i + 1] == '\\' || chars[i + 1] == quote) {
+                    i += 1;
+                    s.push(chars[i]);
+                } else {
+                    s.push(chars[i]);
+                }
+                i += 1;
+            }
+            if i >= len {
+                return Err(format!("Unterminated string starting with {}", quote));
+            }
+            i += 1; // skip closing quote
+            tokens.push(Token::Str(s));
+            continue;
+        }
+
+        // Identifier / keyword
+        if chars[i].is_alphanumeric() || chars[i] == '_' || chars[i] == '.' {
+            let mut word = String::new();
+            while i < len && (chars[i].is_alphanumeric() || chars[i] == '_' || chars[i] == '.') {
+                word.push(chars[i]);
+                i += 1;
+            }
+            let token = match word.to_uppercase().as_str() {
+                "AND" => Token::And,
+                "OR" => Token::Or,
+                "NOT" => Token::Not,
+                "CONTAINS" => Token::Op(Op::Contains),
+                "STARTS_WITH" => Token::Op(Op::StartsWith),
+                "ENDS_WITH" => Token::Op(Op::EndsWith),
+                "REGEX" => Token::Op(Op::Regex),
+                _ => Token::Str(word),
+            };
+            tokens.push(token);
+            continue;
+        }
+
+        return Err(format!("Unexpected character '{}' at position {}", chars[i], i));
+    }
+
+    Ok(tokens)
+}
+
+/// Recursive descent parser.
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, pos: 0 }
+    }
+
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.pos)
+    }
+
+    fn next(&mut self) -> Option<Token> {
+        if self.pos < self.tokens.len() {
+            let t = self.tokens[self.pos].clone();
+            self.pos += 1;
+            Some(t)
+        } else {
+            None
+        }
+    }
+
+    fn expect_str(&mut self) -> Result<String, String> {
+        match self.next() {
+            Some(Token::Str(s)) => Ok(s),
+            other => Err(format!("Expected identifier or string, got {:?}", other)),
+        }
+    }
+
+    /// expr = or_expr
+    fn parse_expr(&mut self) -> Result<Expr, String> {
+        self.parse_or()
+    }
+
+    /// or_expr = and_expr ("OR" and_expr)*
+    fn parse_or(&mut self) -> Result<Expr, String> {
+        let mut left = self.parse_and()?;
+        while self.peek() == Some(&Token::Or) {
+            self.next();
+            let right = self.parse_and()?;
+            left = Expr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    /// and_expr = not_expr ("AND" not_expr)*
+    fn parse_and(&mut self) -> Result<Expr, String> {
+        let mut left = self.parse_not()?;
+        while self.peek() == Some(&Token::And) {
+            self.next();
+            let right = self.parse_not()?;
+            left = Expr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    /// not_expr = "NOT" not_expr | primary
+    fn parse_not(&mut self) -> Result<Expr, String> {
+        if self.peek() == Some(&Token::Not) {
+            self.next();
+            let inner = self.parse_not()?;
+            Ok(Expr::Not(Box::new(inner)))
+        } else {
+            self.parse_primary()
+        }
+    }
+
+    /// primary = "(" expr ")" | comparison
+    fn parse_primary(&mut self) -> Result<Expr, String> {
+        if self.peek() == Some(&Token::LParen) {
+            self.next();
+            let expr = self.parse_expr()?;
+            match self.next() {
+                Some(Token::RParen) => Ok(expr),
+                other => Err(format!("Expected ')', got {:?}", other)),
+            }
+        } else {
+            self.parse_comparison()
+        }
+    }
+
+    /// comparison = field op value
+    fn parse_comparison(&mut self) -> Result<Expr, String> {
+        let field = self.expect_str()?;
+        let op = match self.next() {
+            Some(Token::Op(op)) => op,
+            other => return Err(format!("Expected operator after '{}', got {:?}", field, other)),
+        };
+        let value = self.expect_str()?;
+        Ok(Expr::Comparison { field, op, value })
+    }
+}
+
+/// Parse a filter expression string into an AST.
+pub fn parse(input: &str) -> Result<Expr, String> {
+    let tokens = tokenize(input)?;
+    if tokens.is_empty() {
+        return Err("Empty expression".to_string());
+    }
+    let mut parser = Parser::new(tokens);
+    let expr = parser.parse_expr()?;
+    if parser.pos < parser.tokens.len() {
+        return Err(format!(
+            "Unexpected token at position {}: {:?}",
+            parser.pos,
+            parser.tokens[parser.pos]
+        ));
+    }
+    Ok(expr)
+}
+
+#[cfg(test)]
+#[path = "expr_tests.rs"]
+mod expr_tests;

--- a/crates/scouty/src/filter/expr_tests.rs
+++ b/crates/scouty/src/filter/expr_tests.rs
@@ -1,0 +1,152 @@
+#[cfg(test)]
+mod tests {
+    use crate::filter::expr::{parse, Expr, Op};
+
+    #[test]
+    fn simple_comparison() {
+        let expr = parse(r#"level = "Error""#).unwrap();
+        assert_eq!(
+            expr,
+            Expr::Comparison {
+                field: "level".into(),
+                op: Op::Eq,
+                value: "Error".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn and_expression() {
+        let expr = parse(r#"level = "Error" AND component = "auth""#).unwrap();
+        match expr {
+            Expr::And(left, right) => {
+                assert_eq!(*left, Expr::Comparison { field: "level".into(), op: Op::Eq, value: "Error".into() });
+                assert_eq!(*right, Expr::Comparison { field: "component".into(), op: Op::Eq, value: "auth".into() });
+            }
+            _ => panic!("Expected And expression"),
+        }
+    }
+
+    #[test]
+    fn or_expression() {
+        let expr = parse(r#"level = "Error" OR level = "Fatal""#).unwrap();
+        match expr {
+            Expr::Or(left, right) => {
+                assert_eq!(*left, Expr::Comparison { field: "level".into(), op: Op::Eq, value: "Error".into() });
+                assert_eq!(*right, Expr::Comparison { field: "level".into(), op: Op::Eq, value: "Fatal".into() });
+            }
+            _ => panic!("Expected Or expression"),
+        }
+    }
+
+    #[test]
+    fn parenthesized_expression() {
+        let expr = parse(r#"(level = "Error" OR level = "Fatal") AND component = "auth""#).unwrap();
+        match expr {
+            Expr::And(left, right) => {
+                assert!(matches!(*left, Expr::Or(_, _)));
+                assert_eq!(*right, Expr::Comparison { field: "component".into(), op: Op::Eq, value: "auth".into() });
+            }
+            _ => panic!("Expected And with nested Or"),
+        }
+    }
+
+    #[test]
+    fn not_expression() {
+        let expr = parse(r#"NOT level = "Debug""#).unwrap();
+        match expr {
+            Expr::Not(inner) => {
+                assert_eq!(*inner, Expr::Comparison { field: "level".into(), op: Op::Eq, value: "Debug".into() });
+            }
+            _ => panic!("Expected Not expression"),
+        }
+    }
+
+    #[test]
+    fn nested_not() {
+        let expr = parse(r#"NOT NOT level = "Info""#).unwrap();
+        match expr {
+            Expr::Not(inner) => assert!(matches!(*inner, Expr::Not(_))),
+            _ => panic!("Expected nested Not"),
+        }
+    }
+
+    #[test]
+    fn all_operators() {
+        for (op_str, expected_op) in &[
+            ("=", Op::Eq), ("!=", Op::Ne),
+            (">", Op::Gt), (">=", Op::Ge),
+            ("<", Op::Lt), ("<=", Op::Le),
+            ("contains", Op::Contains),
+            ("starts_with", Op::StartsWith),
+            ("ends_with", Op::EndsWith),
+            ("regex", Op::Regex),
+        ] {
+            let input = format!(r#"field {} "val""#, op_str);
+            let expr = parse(&input).unwrap();
+            assert_eq!(
+                expr,
+                Expr::Comparison { field: "field".into(), op: expected_op.clone(), value: "val".into() }
+            );
+        }
+    }
+
+    #[test]
+    fn and_has_higher_precedence_than_or() {
+        // "a OR b AND c" should parse as "a OR (b AND c)"
+        let expr = parse(r#"level = "A" OR level = "B" AND level = "C""#).unwrap();
+        match expr {
+            Expr::Or(_, right) => assert!(matches!(*right, Expr::And(_, _))),
+            _ => panic!("Expected OR at top level"),
+        }
+    }
+
+    #[test]
+    fn unquoted_value() {
+        let expr = parse("id >= 100").unwrap();
+        assert_eq!(
+            expr,
+            Expr::Comparison { field: "id".into(), op: Op::Ge, value: "100".into() }
+        );
+    }
+
+    #[test]
+    fn metadata_dot_field() {
+        let expr = parse(r#"metadata.env = "prod""#).unwrap();
+        assert_eq!(
+            expr,
+            Expr::Comparison { field: "metadata.env".into(), op: Op::Eq, value: "prod".into() }
+        );
+    }
+
+    #[test]
+    fn complex_nested() {
+        let expr = parse(r#"(level = "Error" OR level = "Fatal") AND (component = "auth" OR component = "db") AND NOT source = "test""#).unwrap();
+        // Should parse without error
+        assert!(matches!(expr, Expr::And(_, _)));
+    }
+
+    #[test]
+    fn empty_expression_error() {
+        assert!(parse("").is_err());
+    }
+
+    #[test]
+    fn missing_value_error() {
+        assert!(parse("level =").is_err());
+    }
+
+    #[test]
+    fn unclosed_paren_error() {
+        assert!(parse(r#"(level = "Error""#).is_err());
+    }
+
+    #[test]
+    fn single_quotes() {
+        let expr = parse("level = 'Error'").unwrap();
+        assert_eq!(
+            expr,
+            Expr::Comparison { field: "level".into(), op: Op::Eq, value: "Error".into() }
+        );
+    }
+}

--- a/crates/scouty/src/filter/mod.rs
+++ b/crates/scouty/src/filter/mod.rs
@@ -1,3 +1,3 @@
 pub mod engine;
-
-// Expression parser and evaluator will be added in Phase 3.
+pub mod expr;
+pub mod eval;


### PR DESCRIPTION
## Summary

Implements filter expression parsing and evaluation for Issue #12.

Closes #12

### What's included

**`filter/expr.rs`** — Recursive descent parser
- Grammar: `<field> <op> <value> [AND|OR ...]` with parentheses
- Operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `contains`, `starts_with`, `ends_with`, `regex`
- Logical: `AND`, `OR`, `NOT` with correct precedence (NOT > AND > OR)
- Quoted strings (single/double), unquoted tokens, dotted fields (`metadata.key`)

**`filter/eval.rs`** — Expression evaluator
- Evaluates Expr AST against LogRecord
- Field extraction from all LogRecord fields + metadata
- Numeric comparison for numeric fields (id, pid, tid)
- Regex matching via `regex` crate

### Tests

33 new tests (16 parser + 17 evaluator), **77 total — all passing** ✅

### Dev plan
https://github.com/r12f/bunny-house/blob/main/dev-plans/2026-02-18-scouty-log-viewer-开发计划.md