### PR TITLE
feat: Parser YAML config loading

### DIFF
--- a/crates/scouty/src/parser/config.rs
+++ b/crates/scouty/src/parser/config.rs
@@ -1,2 +1,102 @@
 //! YAML config loading for parser definitions.
-//! Full implementation in Phase 2.
+//!
+//! Loads parser group definitions from YAML files. Each file can define
+//! multiple parser groups, each containing multiple regex parsers.
+//!
+//! # Example YAML
+//!
+//! ```yaml
+//! groups:
+//!   - name: syslog
+//!     parsers:
+//!       - name: bsd-syslog
+//!         pattern: '^(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?P<process>\S+)\s+(?P<component>\S+?)(?:\[(?P<pid>\d+)\])?:\s+(?P<message>.*)'
+//!         timestamp_format: "%b %d %H:%M:%S"
+//!   - name: generic
+//!     parsers:
+//!       - name: iso-level
+//!         pattern: '^(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})\s+(?P<level>\w+)\s+(?P<message>.*)'
+//! ```
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod config_tests;
+
+use crate::parser::group::ParserGroup;
+use crate::parser::regex_parser::RegexParser;
+use serde::Deserialize;
+use std::path::Path;
+
+/// Top-level config: a list of parser groups.
+#[derive(Debug, Deserialize)]
+pub struct ParserConfig {
+    pub groups: Vec<ParserGroupDef>,
+}
+
+/// Definition of a single parser group.
+#[derive(Debug, Deserialize)]
+pub struct ParserGroupDef {
+    pub name: String,
+    pub parsers: Vec<ParserDef>,
+}
+
+/// Definition of a single regex parser within a group.
+#[derive(Debug, Deserialize)]
+pub struct ParserDef {
+    pub name: String,
+    pub pattern: String,
+    #[serde(default)]
+    pub timestamp_format: Option<String>,
+}
+
+/// Load parser config from a YAML string.
+pub fn from_yaml(yaml: &str) -> Result<ParserConfig, String> {
+    serde_yaml::from_str(yaml).map_err(|e| format!("Failed to parse YAML config: {}", e))
+}
+
+/// Load parser config from a YAML file.
+pub fn from_file(path: &Path) -> Result<ParserConfig, String> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    from_yaml(&content)
+}
+
+/// Build parser groups from a config.
+pub fn build_groups(config: &ParserConfig) -> Result<Vec<ParserGroup>, String> {
+    let mut groups = Vec::new();
+
+    for group_def in &config.groups {
+        let mut group = ParserGroup::new(&group_def.name);
+
+        for parser_def in &group_def.parsers {
+            let parser = RegexParser::new(
+                &parser_def.name,
+                &parser_def.pattern,
+                parser_def.timestamp_format.clone(),
+            )
+            .map_err(|e| {
+                format!(
+                    "Invalid regex in parser '{}' of group '{}': {}",
+                    parser_def.name, group_def.name, e
+                )
+            })?;
+            group.add_parser(Box::new(parser));
+        }
+
+        groups.push(group);
+    }
+
+    Ok(groups)
+}
+
+/// Convenience: load and build parser groups from a YAML string.
+pub fn load_from_yaml(yaml: &str) -> Result<Vec<ParserGroup>, String> {
+    let config = from_yaml(yaml)?;
+    build_groups(&config)
+}
+
+/// Convenience: load and build parser groups from a YAML file.
+pub fn load_from_file(path: &Path) -> Result<Vec<ParserGroup>, String> {
+    let config = from_file(path)?;
+    build_groups(&config)
+}

--- a/crates/scouty/src/parser/config_tests.rs
+++ b/crates/scouty/src/parser/config_tests.rs
@@ -1,0 +1,121 @@
+#[cfg(test)]
+mod tests {
+    use crate::parser::config::{from_yaml, build_groups, load_from_yaml, load_from_file};
+    use crate::record::LogLevel;
+    use crate::traits::LogParser;
+
+    const SAMPLE_YAML: &str = r#"
+groups:
+  - name: syslog
+    parsers:
+      - name: bsd-syslog
+        pattern: '^(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?P<process>\S+)\s+(?P<component>\S+?)(?:\[(?P<pid>\d+)\])?:\s+(?P<message>.*)'
+        timestamp_format: "%b %d %H:%M:%S"
+  - name: generic
+    parsers:
+      - name: iso-level
+        pattern: '^(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})\s+(?P<level>\w+)\s+(?P<message>.*)'
+      - name: fallback
+        pattern: '(?P<message>.+)'
+"#;
+
+    #[test]
+    fn test_parse_yaml() {
+        let config = from_yaml(SAMPLE_YAML).unwrap();
+        assert_eq!(config.groups.len(), 2);
+        assert_eq!(config.groups[0].name, "syslog");
+        assert_eq!(config.groups[0].parsers.len(), 1);
+        assert_eq!(config.groups[1].name, "generic");
+        assert_eq!(config.groups[1].parsers.len(), 2);
+    }
+
+    #[test]
+    fn test_build_groups() {
+        let config = from_yaml(SAMPLE_YAML).unwrap();
+        let groups = build_groups(&config).unwrap();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].name, "syslog");
+        assert_eq!(groups[1].name, "generic");
+    }
+
+    #[test]
+    fn test_load_from_yaml() {
+        let groups = load_from_yaml(SAMPLE_YAML).unwrap();
+        assert_eq!(groups.len(), 2);
+
+        // Test that the generic group can parse a log line
+        let record = groups[1]
+            .parse("2024-01-15 10:30:00 ERROR something broke", "test", "loader", 0)
+            .unwrap();
+        assert_eq!(record.level, Some(LogLevel::Error));
+        assert_eq!(record.message, "something broke");
+    }
+
+    #[test]
+    fn test_invalid_yaml() {
+        let result = from_yaml("not: valid: yaml: [");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_regex() {
+        let yaml = r#"
+groups:
+  - name: bad
+    parsers:
+      - name: broken
+        pattern: '[invalid'
+"#;
+        let config = from_yaml(yaml).unwrap();
+        let result = build_groups(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid regex"));
+    }
+
+    #[test]
+    fn test_timestamp_format_optional() {
+        let yaml = r#"
+groups:
+  - name: simple
+    parsers:
+      - name: catch-all
+        pattern: '(?P<message>.+)'
+"#;
+        let groups = load_from_yaml(yaml).unwrap();
+        assert_eq!(groups.len(), 1);
+        let record = groups[0].parse("hello world", "test", "loader", 0).unwrap();
+        assert_eq!(record.message, "hello world");
+    }
+
+    #[test]
+    fn test_load_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("parsers.yaml");
+        std::fs::write(&file_path, SAMPLE_YAML).unwrap();
+
+        let groups = load_from_file(&file_path).unwrap();
+        assert_eq!(groups.len(), 2);
+    }
+
+    #[test]
+    fn test_load_from_nonexistent_file() {
+        let result = load_from_file(std::path::Path::new("/nonexistent/parsers.yaml"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_syslog_parser_from_config() {
+        let groups = load_from_yaml(SAMPLE_YAML).unwrap();
+        let record = groups[0]
+            .parse(
+                "Jan 15 10:30:00 myhost sshd[1234]: Accepted publickey",
+                "test",
+                "loader",
+                0,
+            )
+            .unwrap();
+        assert_eq!(record.component_name.as_deref(), Some("sshd"));
+        assert_eq!(record.pid, Some(1234));
+        assert_eq!(record.message, "Accepted publickey");
+    }
+}


### PR DESCRIPTION
## Summary

Implements task 2.4 — YAML configuration for parser groups.

### Changes
- **`parser/config.rs`**: Loads parser group definitions from YAML
  - `ParserConfig` / `ParserGroupDef` / `ParserDef` structs (serde-deserializable)
  - `from_yaml()` / `from_file()` for config loading
  - `build_groups()` to construct `ParserGroup` instances from config
  - `load_from_yaml()` / `load_from_file()` convenience functions
  - Optional `timestamp_format` per parser

### Tests (9 new)
- YAML parsing, group building, end-to-end loading
- Invalid YAML, invalid regex validation
- File I/O, syslog parser from config

All 86 tests pass.

Closes #7