### PR TITLE
feat: Multi-line log merging

### DIFF
--- a/crates/scouty/src/parser/multiline.rs
+++ b/crates/scouty/src/parser/multiline.rs
@@ -1,2 +1,73 @@
 //! Multi-line log merging.
-//! Full implementation in Phase 2.
+//!
+//! Merges continuation lines into the preceding log entry based on a
+//! "start pattern" regex. Lines that match the start pattern begin a new
+//! record; lines that don't are appended to the current record.
+
+#[cfg(test)]
+#[path = "multiline_tests.rs"]
+mod multiline_tests;
+
+use regex::Regex;
+
+/// Merges raw log lines into multi-line blocks.
+///
+/// The `start_pattern` regex identifies lines that begin a new log entry.
+/// All subsequent lines that do *not* match are appended to the current block.
+#[derive(Debug)]
+pub struct MultilineMerger {
+    start_pattern: Regex,
+    separator: String,
+}
+
+impl MultilineMerger {
+    /// Create a new merger.
+    ///
+    /// `start_pattern` — regex that matches the first line of a new log entry.
+    /// `separator` — string inserted between merged lines (typically `"\n"`).
+    pub fn new(start_pattern: &str, separator: impl Into<String>) -> Result<Self, String> {
+        let re = Regex::new(start_pattern)
+            .map_err(|e| format!("Invalid start pattern '{}': {}", start_pattern, e))?;
+        Ok(Self {
+            start_pattern: re,
+            separator: separator.into(),
+        })
+    }
+
+    /// Merge a sequence of raw lines into multi-line blocks.
+    ///
+    /// Returns a vec of merged strings, each representing one logical log entry.
+    pub fn merge(&self, lines: &[String]) -> Vec<String> {
+        let mut blocks: Vec<String> = Vec::new();
+        let mut current: Option<String> = None;
+
+        for line in lines {
+            if self.start_pattern.is_match(line) {
+                // This line starts a new block
+                if let Some(block) = current.take() {
+                    blocks.push(block);
+                }
+                current = Some(line.clone());
+            } else {
+                // Continuation line
+                match &mut current {
+                    Some(block) => {
+                        block.push_str(&self.separator);
+                        block.push_str(line);
+                    }
+                    None => {
+                        // Orphan continuation line — treat as its own block
+                        current = Some(line.clone());
+                    }
+                }
+            }
+        }
+
+        // Flush last block
+        if let Some(block) = current {
+            blocks.push(block);
+        }
+
+        blocks
+    }
+}

--- a/crates/scouty/src/parser/multiline_tests.rs
+++ b/crates/scouty/src/parser/multiline_tests.rs
@@ -1,0 +1,99 @@
+#[cfg(test)]
+mod tests {
+    use crate::parser::multiline::MultilineMerger;
+
+    fn lines(input: &[&str]) -> Vec<String> {
+        input.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_no_multiline() {
+        let merger = MultilineMerger::new(r"^\d{4}-\d{2}-\d{2}", "\n").unwrap();
+        let input = lines(&[
+            "2024-01-15 10:00:00 INFO first",
+            "2024-01-15 10:00:01 INFO second",
+        ]);
+        let blocks = merger.merge(&input);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0], "2024-01-15 10:00:00 INFO first");
+        assert_eq!(blocks[1], "2024-01-15 10:00:01 INFO second");
+    }
+
+    #[test]
+    fn test_java_stack_trace() {
+        let merger = MultilineMerger::new(r"^\d{4}-\d{2}-\d{2}", "\n").unwrap();
+        let input = lines(&[
+            "2024-01-15 10:00:00 ERROR NullPointerException",
+            "    at com.example.Foo.bar(Foo.java:42)",
+            "    at com.example.Main.main(Main.java:10)",
+            "2024-01-15 10:00:01 INFO Recovery complete",
+        ]);
+        let blocks = merger.merge(&input);
+        assert_eq!(blocks.len(), 2);
+        assert!(blocks[0].contains("NullPointerException"));
+        assert!(blocks[0].contains("Foo.java:42"));
+        assert!(blocks[0].contains("Main.java:10"));
+        assert_eq!(blocks[1], "2024-01-15 10:00:01 INFO Recovery complete");
+    }
+
+    #[test]
+    fn test_trailing_multiline() {
+        let merger = MultilineMerger::new(r"^\d{4}-\d{2}-\d{2}", "\n").unwrap();
+        let input = lines(&[
+            "2024-01-15 10:00:00 ERROR crash",
+            "  detail line 1",
+            "  detail line 2",
+        ]);
+        let blocks = merger.merge(&input);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            blocks[0],
+            "2024-01-15 10:00:00 ERROR crash\n  detail line 1\n  detail line 2"
+        );
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let merger = MultilineMerger::new(r"^\d{4}", "\n").unwrap();
+        let blocks = merger.merge(&[]);
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn test_orphan_continuation_lines() {
+        let merger = MultilineMerger::new(r"^\d{4}-\d{2}-\d{2}", "\n").unwrap();
+        let input = lines(&[
+            "  orphan line 1",
+            "  orphan line 2",
+            "2024-01-15 10:00:00 INFO normal",
+        ]);
+        let blocks = merger.merge(&input);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0], "  orphan line 1\n  orphan line 2");
+        assert_eq!(blocks[1], "2024-01-15 10:00:00 INFO normal");
+    }
+
+    #[test]
+    fn test_custom_separator() {
+        let merger = MultilineMerger::new(r"^>>", " | ").unwrap();
+        let input = lines(&[">> start", "cont1", "cont2"]);
+        let blocks = merger.merge(&input);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0], ">> start | cont1 | cont2");
+    }
+
+    #[test]
+    fn test_invalid_pattern() {
+        let result = MultilineMerger::new("[invalid", "\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_single_line() {
+        let merger = MultilineMerger::new(r"^.", "\n").unwrap();
+        let input = lines(&["just one line"]);
+        let blocks = merger.merge(&input);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0], "just one line");
+    }
+}


### PR DESCRIPTION
## Summary

Implements task 2.5 — Multi-line log merging via regex start pattern.

### Changes
- **`parser/multiline.rs`**: `MultilineMerger` that groups raw lines into logical blocks
  - Uses a start pattern regex to detect new log entries
  - Continuation lines (not matching start pattern) are appended to current block
  - Handles orphan continuation lines, custom separators
  - Works for Java stack traces, Python tracebacks, etc.

### Tests (8 new)
- Normal (no multiline), Java stack trace, trailing multiline
- Empty input, orphan lines, custom separator
- Invalid pattern, single line

All 85 tests pass.

Closes #8