### PR TITLE
feat: LogProcessor implementations (NoOp + Counting)

### DIFF
--- a/crates/scouty/src/processor.rs
+++ b/crates/scouty/src/processor.rs
@@ -1,4 +1,69 @@
-//! Log processor placeholder.
+//! Log processor implementations.
+//!
+//! Processors run after parsing, before filtering. They can inspect or
+//! annotate records but should not modify ordering.
 
-// LogProcessor trait is defined in traits.rs.
-// Concrete processor implementations will be added in future iterations.
+#[cfg(test)]
+#[path = "processor_tests.rs"]
+mod processor_tests;
+
+use crate::record::LogRecord;
+use crate::traits::{LogProcessor, Result};
+
+/// A no-op processor that does nothing. Useful as a pipeline placeholder
+/// and for testing that the processor stage executes correctly.
+#[derive(Debug)]
+pub struct NoOpProcessor {
+    name: String,
+}
+
+impl NoOpProcessor {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+impl LogProcessor for NoOpProcessor {
+    fn process(&self, _records: &[LogRecord]) -> Result<()> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// A counting processor that counts records by level. Useful for summary stats.
+#[derive(Debug)]
+pub struct CountingProcessor {
+    name: String,
+}
+
+impl CountingProcessor {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    /// Count records, returning a map of level → count.
+    pub fn count_by_level(
+        records: &[LogRecord],
+    ) -> std::collections::HashMap<Option<crate::record::LogLevel>, usize> {
+        let mut counts = std::collections::HashMap::new();
+        for record in records {
+            *counts.entry(record.level).or_insert(0) += 1;
+        }
+        counts
+    }
+}
+
+impl LogProcessor for CountingProcessor {
+    fn process(&self, _records: &[LogRecord]) -> Result<()> {
+        // In a real implementation, this would store counts somewhere accessible.
+        // For now, the counting logic is available via count_by_level().
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}

--- a/crates/scouty/src/processor_tests.rs
+++ b/crates/scouty/src/processor_tests.rs
@@ -1,0 +1,116 @@
+#[cfg(test)]
+mod tests {
+    use crate::parser::group::ParserGroup;
+    use crate::processor::{CountingProcessor, NoOpProcessor};
+    use crate::record::{LogLevel, LogRecord};
+    use crate::session::LogSession;
+    use crate::traits::{LoaderInfo, LoaderType, LogLoader, LogParser, LogProcessor, Result};
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn make_record(id: u64, level: LogLevel, message: &str) -> LogRecord {
+        LogRecord {
+            id,
+            timestamp: Utc::now(),
+            level: Some(level),
+            source: "test".into(),
+            pid: None,
+            tid: None,
+            component_name: None,
+            process_name: None,
+            message: message.into(),
+            raw: message.into(),
+            metadata: HashMap::new(),
+            loader_id: "test-loader".into(),
+        }
+    }
+
+    #[test]
+    fn test_noop_processor() {
+        let processor = NoOpProcessor::new("noop");
+        assert_eq!(processor.name(), "noop");
+        let records = vec![make_record(0, LogLevel::Info, "test")];
+        assert!(processor.process(&records).is_ok());
+    }
+
+    #[test]
+    fn test_noop_empty_records() {
+        let processor = NoOpProcessor::new("noop");
+        assert!(processor.process(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_counting_processor() {
+        let processor = CountingProcessor::new("counter");
+        assert_eq!(processor.name(), "counter");
+        assert!(processor.process(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_count_by_level() {
+        let records = vec![
+            make_record(0, LogLevel::Info, "a"),
+            make_record(1, LogLevel::Error, "b"),
+            make_record(2, LogLevel::Info, "c"),
+            make_record(3, LogLevel::Error, "d"),
+            make_record(4, LogLevel::Error, "e"),
+        ];
+        let counts = CountingProcessor::count_by_level(&records);
+        assert_eq!(counts[&Some(LogLevel::Info)], 2);
+        assert_eq!(counts[&Some(LogLevel::Error)], 3);
+    }
+
+    #[test]
+    fn test_processor_in_session_pipeline() {
+        let mut session = LogSession::new();
+
+        #[derive(Debug)]
+        struct MockLoader {
+            info: LoaderInfo,
+        }
+        impl LogLoader for MockLoader {
+            fn info(&self) -> &LoaderInfo {
+                &self.info
+            }
+            fn load(&mut self) -> Result<Vec<String>> {
+                Ok(vec!["line1".into(), "line2".into()])
+            }
+        }
+
+        #[derive(Debug)]
+        struct EchoParser;
+        impl LogParser for EchoParser {
+            fn parse(
+                &self,
+                raw: &str,
+                _source: &str,
+                _loader_id: &str,
+                id: u64,
+            ) -> Option<LogRecord> {
+                Some(make_record(id, LogLevel::Info, raw))
+            }
+            fn name(&self) -> &str {
+                "echo"
+            }
+        }
+
+        let loader = MockLoader {
+            info: LoaderInfo {
+                id: "mock".into(),
+                loader_type: LoaderType::TextFile,
+                multiline_enabled: false,
+                sample_lines: vec![],
+            },
+        };
+
+        let mut group = ParserGroup::new("test");
+        group.add_parser(Box::new(EchoParser));
+
+        session.add_loader(Box::new(loader), group);
+        session.add_processor(Box::new(NoOpProcessor::new("pipeline-noop")));
+
+        let filtered = session.run().unwrap();
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(session.store().len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements task 3.2 — Log Processor placeholder implementations.

### Changes
- **NoOpProcessor**: Pipeline placeholder that executes correctly as a no-op
- **CountingProcessor**: Counts records by level via `count_by_level()` static method
- Both implement the `LogProcessor` trait and integrate into the session pipeline

### Tests (5 new)
- NoOp processor basic + empty records
- Counting processor basic + count_by_level verification
- Full session pipeline integration with NoOpProcessor

All 108 tests pass.

Closes #11