### PR TITLE
feat: SyslogLoader — UDP syslog receiver

### DIFF
--- a/crates/scouty/src/loader/mod.rs
+++ b/crates/scouty/src/loader/mod.rs
@@ -1,4 +1,5 @@
 pub mod archive;
 pub mod file;
+pub mod syslog;
 
-// Other loaders (syslog, otlp) will be added in later phases.
+// Other loaders (otlp) will be added in later phases.

--- a/crates/scouty/src/loader/syslog.rs
+++ b/crates/scouty/src/loader/syslog.rs
@@ -1,0 +1,124 @@
+//! Syslog loader — receives syslog messages via UDP.
+//!
+//! Listens on a UDP socket and collects syslog messages. Since the
+//! `LogLoader` trait is synchronous, the loader collects messages for
+//! a configurable timeout or until max_messages is reached.
+
+#[cfg(test)]
+#[path = "syslog_tests.rs"]
+mod syslog_tests;
+
+use crate::traits::{LoaderInfo, LoaderType, LogLoader, Result, ScoutyError};
+use std::net::UdpSocket;
+use std::time::{Duration, Instant};
+
+/// Configuration for the syslog loader.
+#[derive(Debug, Clone)]
+pub struct SyslogConfig {
+    /// Address to bind to (e.g., "0.0.0.0:514" or "127.0.0.1:1514").
+    pub bind_addr: String,
+    /// Maximum time to collect messages per `load()` call.
+    pub timeout: Duration,
+    /// Maximum number of messages to collect per `load()` call.
+    /// 0 means unlimited (bounded only by timeout).
+    pub max_messages: usize,
+}
+
+impl Default for SyslogConfig {
+    fn default() -> Self {
+        Self {
+            bind_addr: "127.0.0.1:1514".to_string(),
+            timeout: Duration::from_secs(5),
+            max_messages: 10000,
+        }
+    }
+}
+
+/// Loads syslog messages from a UDP socket.
+#[derive(Debug)]
+pub struct SyslogLoader {
+    config: SyslogConfig,
+    info: LoaderInfo,
+    socket: Option<UdpSocket>,
+}
+
+impl SyslogLoader {
+    /// Create a new SyslogLoader. Does not bind the socket until `load()` is called.
+    pub fn new(config: SyslogConfig) -> Self {
+        let id = format!("syslog:{}", config.bind_addr);
+        Self {
+            info: LoaderInfo {
+                id,
+                loader_type: LoaderType::Syslog,
+                multiline_enabled: false,
+                sample_lines: Vec::new(),
+            },
+            config,
+            socket: None,
+        }
+    }
+
+    fn ensure_socket(&mut self) -> Result<&UdpSocket> {
+        if self.socket.is_none() {
+            let sock = UdpSocket::bind(&self.config.bind_addr).map_err(|e| {
+                ScoutyError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("Failed to bind syslog socket to {}: {}", self.config.bind_addr, e),
+                ))
+            })?;
+            sock.set_nonblocking(true).map_err(ScoutyError::Io)?;
+            self.socket = Some(sock);
+        }
+        Ok(self.socket.as_ref().unwrap())
+    }
+}
+
+impl LogLoader for SyslogLoader {
+    fn info(&self) -> &LoaderInfo {
+        &self.info
+    }
+
+    fn load(&mut self) -> Result<Vec<String>> {
+        self.ensure_socket()?;
+        let socket = self.socket.as_ref().unwrap();
+        let timeout = self.config.timeout;
+        let max_messages = self.config.max_messages;
+        let mut messages = Vec::new();
+        let mut buf = [0u8; 8192];
+        let start = Instant::now();
+
+        loop {
+            if start.elapsed() >= timeout {
+                break;
+            }
+
+            if max_messages > 0 && messages.len() >= max_messages {
+                break;
+            }
+
+            match socket.recv_from(&mut buf) {
+                Ok((len, _addr)) => {
+                    if let Ok(msg) = std::str::from_utf8(&buf[..len]) {
+                        let trimmed = msg.trim_end_matches(|c| c == '\n' || c == '\r');
+                        if !trimmed.is_empty() {
+                            messages.push(trimmed.to_string());
+                        }
+                    }
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // No data available, sleep briefly then retry
+                    if messages.is_empty() {
+                        std::thread::sleep(Duration::from_millis(10));
+                    } else {
+                        // We have some messages and no more coming, return what we have
+                        break;
+                    }
+                }
+                Err(e) => return Err(ScoutyError::Io(e)),
+            }
+        }
+
+        self.info.sample_lines = messages.iter().take(10).cloned().collect();
+        Ok(messages)
+    }
+}

--- a/crates/scouty/src/loader/syslog_tests.rs
+++ b/crates/scouty/src/loader/syslog_tests.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+mod tests {
+    use crate::loader::syslog::{SyslogConfig, SyslogLoader};
+    use crate::traits::LogLoader;
+    use std::net::UdpSocket;
+    use std::time::Duration;
+
+    fn find_free_port() -> u16 {
+        let sock = UdpSocket::bind("127.0.0.1:0").unwrap();
+        sock.local_addr().unwrap().port()
+    }
+
+    #[test]
+    fn test_loader_info() {
+        let loader = SyslogLoader::new(SyslogConfig {
+            bind_addr: "127.0.0.1:0".to_string(),
+            ..Default::default()
+        });
+        let info = loader.info();
+        assert_eq!(info.loader_type, crate::traits::LoaderType::Syslog);
+        assert!(info.id.starts_with("syslog:"));
+    }
+
+    #[test]
+    fn test_load_no_messages_timeout() {
+        let port = find_free_port();
+        let mut loader = SyslogLoader::new(SyslogConfig {
+            bind_addr: format!("127.0.0.1:{}", port),
+            timeout: Duration::from_millis(100),
+            max_messages: 100,
+        });
+        let messages = loader.load().unwrap();
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_load_receives_messages() {
+        let port = find_free_port();
+        let addr = format!("127.0.0.1:{}", port);
+
+        let mut loader = SyslogLoader::new(SyslogConfig {
+            bind_addr: addr.clone(),
+            timeout: Duration::from_secs(2),
+            max_messages: 10,
+        });
+
+        // Send some messages from a separate thread
+        let send_addr = addr.clone();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+            for i in 0..3 {
+                let msg = format!("<14>Jan 15 10:00:00 host test: message {}", i);
+                sender.send_to(msg.as_bytes(), &send_addr).unwrap();
+            }
+        });
+
+        let messages = loader.load().unwrap();
+        handle.join().unwrap();
+
+        assert_eq!(messages.len(), 3);
+        assert!(messages[0].contains("message 0"));
+        assert!(messages[2].contains("message 2"));
+    }
+
+    #[test]
+    fn test_max_messages_limit() {
+        let port = find_free_port();
+        let addr = format!("127.0.0.1:{}", port);
+
+        let mut loader = SyslogLoader::new(SyslogConfig {
+            bind_addr: addr.clone(),
+            timeout: Duration::from_secs(5),
+            max_messages: 2,
+        });
+
+        let send_addr = addr.clone();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+            for i in 0..5 {
+                let msg = format!("<14>test message {}", i);
+                sender.send_to(msg.as_bytes(), &send_addr).unwrap();
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        });
+
+        let messages = loader.load().unwrap();
+        handle.join().unwrap();
+
+        assert!(messages.len() <= 2);
+    }
+
+    #[test]
+    fn test_sample_lines_populated() {
+        let port = find_free_port();
+        let addr = format!("127.0.0.1:{}", port);
+
+        let mut loader = SyslogLoader::new(SyslogConfig {
+            bind_addr: addr.clone(),
+            timeout: Duration::from_secs(2),
+            max_messages: 100,
+        });
+
+        let send_addr = addr.clone();
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+            for i in 0..15 {
+                let msg = format!("<14>line {}", i);
+                sender.send_to(msg.as_bytes(), &send_addr).unwrap();
+            }
+        });
+
+        loader.load().unwrap();
+        handle.join().unwrap();
+
+        assert!(loader.info().sample_lines.len() <= 10);
+    }
+}


### PR DESCRIPTION
## Summary

Implements task 4.1 — Syslog Loader for live log ingestion.

### Changes
- **`loader/syslog.rs`**: `SyslogLoader` that receives syslog messages via UDP
  - Configurable bind address, timeout, and max message limit
  - Non-blocking socket with efficient polling
  - Compatible with sync `LogLoader` trait
- **`SyslogConfig`**: Configuration struct with sensible defaults (127.0.0.1:1514, 5s timeout, 10k max)

### Tests (5 new)
- Loader info, empty timeout, message receive via UDP, max messages limit, sample lines

All 108 tests pass.

Closes #14