### PR TITLE
feat: LogStoreView + dual-buffer mechanism

### DIFF
--- a/crates/scouty/src/integration_tests.rs
+++ b/crates/scouty/src/integration_tests.rs
@@ -197,6 +197,7 @@ random garbage
             .filter_engine_mut()
             .add_expr_filter(FilterAction::Include, "level = ERROR")
             .unwrap();
+        session.refresh_active_view();
         let view = session.filtered_view();
         assert_eq!(view.len(), 1);
     }
@@ -357,6 +358,7 @@ random garbage
             .add_expr_filter(FilterAction::Include, "level = ERROR")
             .unwrap();
 
+        session.refresh_active_view();
         let start = std::time::Instant::now();
         let view = session.filtered_view();
         let elapsed = start.elapsed();

--- a/crates/scouty/src/lib.rs
+++ b/crates/scouty/src/lib.rs
@@ -6,6 +6,7 @@ pub mod record;
 pub mod session;
 pub mod store;
 pub mod traits;
+pub mod view;
 
 #[cfg(test)]
 #[path = "integration_tests.rs"]

--- a/crates/scouty/src/session.rs
+++ b/crates/scouty/src/session.rs
@@ -5,6 +5,7 @@ use crate::parser::group::ParserGroup;
 use crate::record::LogRecord;
 use crate::store::LogStore;
 use crate::traits::{LogLoader, LogProcessor, Result};
+use crate::view::LogStoreView;
 use rayon::prelude::*;
 
 /// Represents a registered loader paired with its parser group.
@@ -19,7 +20,10 @@ pub struct LogSession {
     loader_slots: Vec<LoaderSlot>,
     store: LogStore,
     processors: Vec<Box<dyn LogProcessor>>,
-    filter_engine: FilterEngine,
+    /// Currently active view — serves TUI, always has valid results.
+    active_view: LogStoreView,
+    /// Pending view — created when filter changes, not yet applied.
+    pending_view: Option<LogStoreView>,
     /// Records that failed parsing by all parsers in their group.
     pub failing_parsing_logs: Vec<FailedLog>,
     /// Auto-incrementing record ID counter.
@@ -41,7 +45,8 @@ impl LogSession {
             loader_slots: Vec::new(),
             store: LogStore::new(),
             processors: Vec::new(),
-            filter_engine: FilterEngine::new(),
+            active_view: LogStoreView::new(FilterEngine::new()),
+            pending_view: None,
             failing_parsing_logs: Vec::new(),
             next_id: 0,
         }
@@ -60,14 +65,52 @@ impl LogSession {
         self.processors.push(processor);
     }
 
-    /// Access the filter engine for adding/removing filters.
+    /// Access the filter engine of the active view for adding/removing filters.
+    ///
+    /// Note: after modifying filters, call `apply_pending()` or use `update_filter()`
+    /// for the dual-buffer workflow.
     pub fn filter_engine_mut(&mut self) -> &mut FilterEngine {
-        &mut self.filter_engine
+        self.active_view.filter_engine_mut()
     }
 
     /// Access the store.
     pub fn store(&self) -> &LogStore {
         &self.store
+    }
+
+    /// Get the currently active view.
+    pub fn active_view(&self) -> &LogStoreView {
+        &self.active_view
+    }
+
+    /// Whether a pending view exists (filter update in progress).
+    pub fn has_pending_view(&self) -> bool {
+        self.pending_view.is_some()
+    }
+
+    /// Start a filter update using the dual-buffer mechanism.
+    ///
+    /// Creates a new pending view with the given filter engine.
+    /// If a pending view already exists, it is discarded and replaced.
+    pub fn update_filter(&mut self, filter_engine: FilterEngine) {
+        self.pending_view = Some(LogStoreView::new(filter_engine));
+    }
+
+    /// Apply the pending view's filter against the store, then replace active view.
+    ///
+    /// If no pending view exists, this is a no-op.
+    pub fn apply_pending(&mut self) {
+        if let Some(mut pending) = self.pending_view.take() {
+            pending.apply(&self.store);
+            self.active_view = pending;
+        }
+    }
+
+    /// Re-apply the active view's filter against the store.
+    ///
+    /// Use after modifying filters via `filter_engine_mut()`.
+    pub fn refresh_active_view(&mut self) {
+        self.active_view.apply(&self.store);
     }
 
     /// Execute the full pipeline: Load → Parse → Store → Process → Filter.
@@ -106,20 +149,17 @@ impl LogSession {
             }
         }
 
-        // 3. Filter → Filtered View
-        let filtered = self.filter_engine.apply_iter(self.store.iter());
-        Ok(filtered)
+        // 3. Apply active view filter
+        self.active_view.apply(&self.store);
+        Ok(self.active_view.indices().to_vec())
     }
 
-    /// Get the filtered view based on current filters (without re-running load/parse).
+    /// Get the filtered view based on current active view's cache.
     pub fn filtered_view(&self) -> Vec<usize> {
-        self.filter_engine.apply_iter(self.store.iter())
+        self.active_view.indices().to_vec()
     }
 
     /// Execute the pipeline with parallel loading and parsing across loader slots.
-    ///
-    /// Each loader slot is processed in its own rayon task. Results are merged
-    /// into the store after all slots complete.
     pub fn run_parallel(&mut self) -> Result<Vec<usize>> {
         // 1. Load + Parse in parallel
         let results: Vec<Result<(Vec<LogRecord>, Vec<FailedLog>)>> = self
@@ -134,7 +174,6 @@ impl LogSession {
                 let mut failures = Vec::new();
 
                 for (i, line) in lines.iter().enumerate() {
-                    // Use a placeholder ID; will be reassigned after merge
                     match slot.parser_group.parse(line, source, &info.id, i as u64) {
                         Some(record) => records.push(record),
                         None => failures.push(FailedLog {
@@ -168,9 +207,9 @@ impl LogSession {
             }
         }
 
-        // 4. Filter → Filtered View
-        let filtered = self.filter_engine.apply_iter(self.store.iter());
-        Ok(filtered)
+        // 4. Apply active view filter
+        self.active_view.apply(&self.store);
+        Ok(self.active_view.indices().to_vec())
     }
 }
 

--- a/crates/scouty/src/session_tests.rs
+++ b/crates/scouty/src/session_tests.rs
@@ -230,4 +230,135 @@ mod tests {
         assert_eq!(seq.store().len(), par.store().len());
         assert_eq!(seq_filtered.len(), par_filtered.len());
     }
+
+    fn make_mock_loader(id: &str, lines: Vec<String>) -> MockLoader {
+        MockLoader {
+            info: LoaderInfo {
+                id: id.into(),
+                loader_type: LoaderType::TextFile,
+                multiline_enabled: false,
+                sample_lines: vec![],
+            },
+            lines,
+        }
+    }
+
+    /// Helper: AlwaysSucceed parser that puts raw as message
+    #[derive(Debug)]
+    struct AllParser;
+    impl LogParser for AllParser {
+        fn parse(&self, raw: &str, _source: &str, _loader_id: &str, id: u64) -> Option<LogRecord> {
+            Some(make_record(id, raw))
+        }
+        fn name(&self) -> &str {
+            "all"
+        }
+    }
+
+    #[test]
+    fn test_dual_view_active_not_affected_by_pending() {
+        use crate::filter::engine::{FilterAction, FilterEngine};
+
+        let mut session = LogSession::new();
+        let mut group = ParserGroup::new("test");
+        group.add_parser(Box::new(AllParser));
+
+        session.add_loader(
+            Box::new(make_mock_loader(
+                "l1",
+                vec!["msg1".into(), "msg2".into(), "msg3".into()],
+            )),
+            group,
+        );
+        session.run().unwrap();
+
+        // Active view has all 3 records
+        assert_eq!(session.active_view().len(), 3);
+
+        // Create pending view with a filter
+        let mut new_engine = FilterEngine::new();
+        new_engine
+            .add_expr_filter(FilterAction::Include, r#"message contains "msg1""#)
+            .unwrap();
+        session.update_filter(new_engine);
+
+        // Active view still has 3 records (not affected by pending)
+        assert_eq!(session.active_view().len(), 3);
+        assert!(session.has_pending_view());
+
+        // Apply pending → active now has 1 record
+        session.apply_pending();
+        assert_eq!(session.active_view().len(), 1);
+        assert!(!session.has_pending_view());
+    }
+
+    #[test]
+    fn test_dual_view_pending_replaced_on_new_filter() {
+        use crate::filter::engine::{FilterAction, FilterEngine};
+
+        let mut session = LogSession::new();
+        let mut group = ParserGroup::new("test");
+        group.add_parser(Box::new(AllParser));
+
+        session.add_loader(
+            Box::new(make_mock_loader("l1", vec!["msg1".into(), "msg2".into()])),
+            group,
+        );
+        session.run().unwrap();
+
+        // Create first pending
+        let mut engine1 = FilterEngine::new();
+        engine1
+            .add_expr_filter(FilterAction::Include, r#"message contains "msg1""#)
+            .unwrap();
+        session.update_filter(engine1);
+
+        // Create second pending — should discard first
+        let mut engine2 = FilterEngine::new();
+        engine2
+            .add_expr_filter(FilterAction::Include, r#"message contains "msg2""#)
+            .unwrap();
+        session.update_filter(engine2);
+
+        // Apply — should apply engine2 (msg2 only)
+        session.apply_pending();
+        assert_eq!(session.active_view().len(), 1);
+        let record = session
+            .active_view()
+            .get_record(0, session.store())
+            .unwrap();
+        assert_eq!(record.message, "msg2");
+    }
+
+    #[test]
+    fn test_refresh_active_view() {
+        use crate::filter::engine::FilterAction;
+
+        let mut session = LogSession::new();
+        let mut group = ParserGroup::new("test");
+        group.add_parser(Box::new(AllParser));
+
+        session.add_loader(
+            Box::new(make_mock_loader(
+                "l1",
+                vec!["msg1".into(), "msg2".into(), "msg3".into()],
+            )),
+            group,
+        );
+        session.run().unwrap();
+        assert_eq!(session.filtered_view().len(), 3);
+
+        // Modify active filter directly
+        session
+            .filter_engine_mut()
+            .add_expr_filter(FilterAction::Include, r#"message contains "msg1""#)
+            .unwrap();
+
+        // filtered_view() still returns cached (3 records)
+        assert_eq!(session.filtered_view().len(), 3);
+
+        // After refresh, it's updated
+        session.refresh_active_view();
+        assert_eq!(session.filtered_view().len(), 1);
+    }
 }

--- a/crates/scouty/src/view.rs
+++ b/crates/scouty/src/view.rs
@@ -1,0 +1,86 @@
+//! LogStoreView — encapsulates a FilterEngine + cached filtered indices.
+//!
+//! Provides a snapshot of filter results that can be queried without re-filtering.
+//! Used by LogSession's dual-buffer mechanism for non-blocking filter updates.
+
+#[cfg(test)]
+#[path = "view_tests.rs"]
+mod view_tests;
+
+use crate::filter::engine::FilterEngine;
+use crate::record::LogRecord;
+use crate::store::LogStore;
+
+/// Status of a LogStoreView's filter results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewStatus {
+    /// Filter has been applied, results are ready.
+    Ready,
+    /// Filter is being applied (results may be stale or empty).
+    Filtering,
+}
+
+/// Encapsulates a FilterEngine and its cached filter results (indices into LogStore).
+///
+/// Does not own the LogStore — borrows it during `apply()`.
+#[derive(Debug)]
+pub struct LogStoreView {
+    filter_engine: FilterEngine,
+    filtered_indices: Vec<usize>,
+    status: ViewStatus,
+}
+
+impl LogStoreView {
+    /// Create a new view with the given filter engine. Status starts as Filtering
+    /// (no results until `apply()` is called).
+    pub fn new(filter_engine: FilterEngine) -> Self {
+        Self {
+            filter_engine,
+            filtered_indices: Vec::new(),
+            status: ViewStatus::Filtering,
+        }
+    }
+
+    /// Apply the filter engine against the store, updating cached indices.
+    pub fn apply(&mut self, store: &LogStore) {
+        self.status = ViewStatus::Filtering;
+        self.filtered_indices = self.filter_engine.apply_iter(store.iter());
+        self.status = ViewStatus::Ready;
+    }
+
+    /// Get the cached filtered indices.
+    pub fn indices(&self) -> &[usize] {
+        &self.filtered_indices
+    }
+
+    /// Access the filter engine (read-only).
+    pub fn filter_engine(&self) -> &FilterEngine {
+        &self.filter_engine
+    }
+
+    /// Access the filter engine (mutable).
+    pub fn filter_engine_mut(&mut self) -> &mut FilterEngine {
+        &mut self.filter_engine
+    }
+
+    /// Number of records in the filtered view.
+    pub fn len(&self) -> usize {
+        self.filtered_indices.len()
+    }
+
+    /// Whether the filtered view is empty.
+    pub fn is_empty(&self) -> bool {
+        self.filtered_indices.is_empty()
+    }
+
+    /// Get a record by filtered index (0-based index into the filtered view).
+    pub fn get_record<'a>(&self, index: usize, store: &'a LogStore) -> Option<&'a LogRecord> {
+        let store_index = *self.filtered_indices.get(index)?;
+        store.get(store_index)
+    }
+
+    /// Current status of the view.
+    pub fn status(&self) -> ViewStatus {
+        self.status
+    }
+}

--- a/crates/scouty/src/view_tests.rs
+++ b/crates/scouty/src/view_tests.rs
@@ -1,0 +1,150 @@
+#[cfg(test)]
+mod tests {
+    use crate::filter::engine::{FilterAction, FilterEngine};
+    use crate::record::{LogLevel, LogRecord};
+    use crate::store::LogStore;
+    use crate::view::{LogStoreView, ViewStatus};
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use std::sync::Arc;
+
+    fn make_record(id: u64, level: LogLevel, message: &str) -> LogRecord {
+        let ts = NaiveDateTime::new(
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            NaiveTime::from_hms_opt(0, 0, id as u32 % 60).unwrap(),
+        )
+        .and_utc();
+        LogRecord {
+            id,
+            timestamp: ts,
+            level: Some(level),
+            source: "test".into(),
+            pid: None,
+            tid: None,
+            component_name: None,
+            process_name: None,
+            message: message.to_string(),
+            raw: message.to_string(),
+            metadata: None,
+            loader_id: "loader".into(),
+        }
+    }
+
+    fn make_store_with_records() -> LogStore {
+        let mut store = LogStore::new();
+        store.insert(make_record(0, LogLevel::Info, "hello world"));
+        store.insert(make_record(1, LogLevel::Error, "something failed"));
+        store.insert(make_record(2, LogLevel::Warn, "watch out"));
+        store.insert(make_record(3, LogLevel::Info, "all good"));
+        store.insert(make_record(4, LogLevel::Debug, "debug trace"));
+        store
+    }
+
+    #[test]
+    fn test_empty_filter_returns_all() {
+        let store = make_store_with_records();
+        let mut view = LogStoreView::new(FilterEngine::new());
+        assert_eq!(view.status(), ViewStatus::Filtering);
+
+        view.apply(&store);
+
+        assert_eq!(view.status(), ViewStatus::Ready);
+        assert_eq!(view.len(), 5);
+        assert_eq!(view.indices(), &[0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_exclude_filter() {
+        let store = make_store_with_records();
+        let mut engine = FilterEngine::new();
+        engine
+            .add_expr_filter(FilterAction::Exclude, r#"level = "ERROR""#)
+            .unwrap();
+
+        let mut view = LogStoreView::new(engine);
+        view.apply(&store);
+
+        assert_eq!(view.len(), 4);
+        // Record at index 1 (Error) should be excluded
+        assert!(!view.indices().contains(&1));
+    }
+
+    #[test]
+    fn test_include_filter() {
+        let store = make_store_with_records();
+        let mut engine = FilterEngine::new();
+        engine
+            .add_expr_filter(FilterAction::Include, r#"level = "INFO""#)
+            .unwrap();
+
+        let mut view = LogStoreView::new(engine);
+        view.apply(&store);
+
+        assert_eq!(view.len(), 2);
+        assert_eq!(view.indices(), &[0, 3]);
+    }
+
+    #[test]
+    fn test_mixed_filters() {
+        let store = make_store_with_records();
+        let mut engine = FilterEngine::new();
+        // Include INFO and WARN
+        engine
+            .add_expr_filter(FilterAction::Include, r#"level = "INFO""#)
+            .unwrap();
+        engine
+            .add_expr_filter(FilterAction::Include, r#"level = "WARN""#)
+            .unwrap();
+        // Exclude "all good"
+        engine
+            .add_expr_filter(FilterAction::Exclude, "message contains \"all good\"")
+            .unwrap();
+
+        let mut view = LogStoreView::new(engine);
+        view.apply(&store);
+
+        // INFO records: 0 ("hello world"), 3 ("all good" - excluded)
+        // WARN records: 2 ("watch out")
+        assert_eq!(view.len(), 2);
+        assert_eq!(view.indices(), &[0, 2]);
+    }
+
+    #[test]
+    fn test_get_record() {
+        let store = make_store_with_records();
+        let mut view = LogStoreView::new(FilterEngine::new());
+        view.apply(&store);
+
+        let r = view.get_record(1, &store).unwrap();
+        assert_eq!(r.message, "something failed");
+
+        assert!(view.get_record(100, &store).is_none());
+    }
+
+    #[test]
+    fn test_reapply_after_store_change() {
+        let mut store = make_store_with_records();
+        let mut view = LogStoreView::new(FilterEngine::new());
+        view.apply(&store);
+        assert_eq!(view.len(), 5);
+
+        // Add more records
+        store.insert(make_record(5, LogLevel::Info, "new record"));
+        view.apply(&store);
+        assert_eq!(view.len(), 6);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let store = make_store_with_records();
+        let mut engine = FilterEngine::new();
+        engine
+            .add_expr_filter(FilterAction::Include, r#"level = "FATAL""#)
+            .unwrap();
+
+        let mut view = LogStoreView::new(engine);
+        view.apply(&store);
+
+        assert!(view.is_empty());
+        assert_eq!(view.len(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `LogStoreView` abstraction with dual-buffer mechanism for non-blocking filter updates in TUI.

Closes #57

### P0-1: LogStoreView struct
- Encapsulates `FilterEngine` + `Vec<usize>` filtered indices cache
- `ViewStatus`: `Ready` / `Filtering` state tracking
- Methods: `new()`, `apply()`, `indices()`, `filter_engine()/mut()`, `len()`, `is_empty()`, `get_record()`
- Does not own LogStore — borrows reference during apply

### P0-2: LogSession dual-view mechanism
- `active_view: LogStoreView` — current view, always serves TUI
- `pending_view: Option<LogStoreView>` — created on filter change, not yet applied
- **Workflow**: filter change → `update_filter()` creates pending → `apply_pending()` filters & replaces active
- If filter changes again during pending, old pending discarded, new one created
- `refresh_active_view()` — convenience method for direct `filter_engine_mut()` changes

### P0-3: API migration
- `filtered_view()` → returns cached active_view indices (no re-computation)
- `filter_engine_mut()` → modifies active view; requires explicit `refresh_active_view()` 
- `run()` / `run_parallel()` → auto-apply active_view after load/parse/process
- All existing tests adapted to new explicit-apply semantics

### Tests
201 total — 10 new tests:
- 7 LogStoreView unit tests (empty filter, exclude, include, mixed, get_record, reapply, is_empty)
- 3 dual-buffer session tests (active not affected by pending, pending replacement, refresh)

All passing ✅