### PR TITLE
feat: TUI table layout, navigation & status bar

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -15,6 +15,7 @@ pub enum InputMode {
     Filter,
     Search,
     TimeJump,
+    GotoLine,
     Help,
 }
 
@@ -22,6 +23,8 @@ pub enum InputMode {
 pub struct App {
     /// All log records loaded from the file.
     pub records: Vec<LogRecord>,
+    /// Total records before filtering.
+    pub total_records: usize,
     /// Filtered indices into records.
     pub filtered_indices: Vec<usize>,
     /// Current scroll offset (index into filtered list).
@@ -48,8 +51,12 @@ pub struct App {
     pub search_match_idx: Option<usize>,
     /// Time jump input buffer.
     pub time_input: String,
+    /// Goto line input buffer.
+    pub goto_input: String,
     /// Status message shown temporarily.
     pub status_message: Option<String>,
+    /// Column widths computed from data (Time, Level, ProcessName, Pid, Tid, Component).
+    pub col_widths: [u16; 6],
 }
 
 impl App {
@@ -66,10 +73,14 @@ impl App {
         let _filtered = session.run()?;
 
         let records: Vec<LogRecord> = session.store().iter().cloned().collect();
+        let total_records = records.len();
         let filtered_indices: Vec<usize> = (0..records.len()).collect();
+
+        let col_widths = Self::compute_col_widths(&records, &filtered_indices);
 
         Ok(Self {
             records,
+            total_records,
             filtered_indices,
             scroll_offset: 0,
             selected: 0,
@@ -83,8 +94,79 @@ impl App {
             search_matches: vec![],
             search_match_idx: None,
             time_input: String::new(),
+            goto_input: String::new(),
             status_message: None,
+            col_widths,
         })
+    }
+
+    /// Compute auto-fit column widths by sampling records.
+    /// Returns [Time, Level, ProcessName, Pid, Tid, Component] widths.
+    /// The Log column will fill remaining space.
+    fn compute_col_widths(records: &[LogRecord], indices: &[usize]) -> [u16; 6] {
+        // Minimum widths from headers
+        let mut widths: [u16; 6] = [
+            4,  // "Time"
+            5,  // "Level"
+            11, // "ProcessName"
+            3,  // "Pid"
+            3,  // "Tid"
+            9,  // "Component"
+        ];
+
+        // Maximum widths to prevent any single column from being too wide
+        let max_widths: [u16; 6] = [23, 5, 20, 8, 8, 20];
+
+        // Sample up to 1000 records evenly distributed
+        let sample_size = 1000.min(indices.len());
+        let step = if sample_size == 0 {
+            1
+        } else {
+            indices.len().max(1) / sample_size.max(1)
+        }
+        .max(1);
+
+        for i in (0..indices.len()).step_by(step) {
+            let r = &records[indices[i]];
+
+            // Time: fixed format "YYYY-MM-DD HH:MM:SS"
+            widths[0] = widths[0].max(19);
+
+            // Level
+            if let Some(level) = r.level {
+                let len = format!("{}", level).len() as u16;
+                widths[1] = widths[1].max(len);
+            }
+
+            // ProcessName
+            if let Some(ref name) = r.process_name {
+                widths[2] = widths[2].max((name.len() as u16).min(max_widths[2]));
+            }
+
+            // Pid
+            if let Some(pid) = r.pid {
+                let len = format!("{}", pid).len() as u16;
+                widths[3] = widths[3].max(len.min(max_widths[3]));
+            }
+
+            // Tid
+            if let Some(tid) = r.tid {
+                let len = format!("{}", tid).len() as u16;
+                widths[4] = widths[4].max(len.min(max_widths[4]));
+            }
+
+            // Component
+            if let Some(ref comp) = r.component_name {
+                widths[5] = widths[5].max((comp.len() as u16).min(max_widths[5]));
+            }
+        }
+
+        // Clamp all to max
+        for i in 0..6 {
+            widths[i] = widths[i].min(max_widths[i]);
+        }
+
+        widths
     }
 
     /// Total filtered record count.
@@ -113,12 +195,11 @@ impl App {
                 }
                 Err(e) => {
                     self.filter_error = Some(e);
-                    // Keep current filter active
                     return;
                 }
             }
         }
-        // Reset selection
+        self.col_widths = Self::compute_col_widths(&self.records, &self.filtered_indices);
         self.scroll_offset = 0;
         self.selected = 0;
         self.clear_search();
@@ -146,7 +227,6 @@ impl App {
             self.search_match_idx = None;
             self.status_message = Some("No matches found".to_string());
         } else {
-            // Jump to first match at or after current selected
             let idx = self
                 .search_matches
                 .iter()
@@ -209,9 +289,7 @@ impl App {
             return;
         }
 
-        // Try parsing as HH:MM:SS
         if let Ok(time) = NaiveTime::parse_from_str(input, "%H:%M:%S") {
-            // Find first filtered record with time >= input
             for (fi, &ri) in self.filtered_indices.iter().enumerate() {
                 let record_time = self.records[ri].timestamp.time();
                 if record_time >= time {
@@ -225,7 +303,6 @@ impl App {
             return;
         }
 
-        // Try parsing as full datetime
         if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(input, "%Y-%m-%d %H:%M:%S") {
             let dt_utc = dt.and_utc();
             for (fi, &ri) in self.filtered_indices.iter().enumerate() {
@@ -244,6 +321,28 @@ impl App {
             Some("Invalid time format (use HH:MM:SS or YYYY-MM-DD HH:MM:SS)".to_string());
     }
 
+    /// Jump to a specific line number (1-indexed).
+    pub fn goto_line(&mut self) {
+        let input = self.goto_input.trim();
+        if input.is_empty() {
+            return;
+        }
+        match input.parse::<usize>() {
+            Ok(line) if line >= 1 && line <= self.total() => {
+                self.selected = line - 1;
+                self.ensure_selected_visible();
+                self.status_message = Some(format!("Line {}", line));
+            }
+            Ok(line) if line > self.total() => {
+                self.scroll_to_bottom();
+                self.status_message = Some(format!("Line {} (clamped to {})", line, self.total()));
+            }
+            _ => {
+                self.status_message = Some("Invalid line number".to_string());
+            }
+        }
+    }
+
     pub fn select_down(&mut self, n: usize) {
         let max = self.total().saturating_sub(1);
         self.selected = (self.selected + n).min(max);
@@ -255,23 +354,14 @@ impl App {
         self.ensure_selected_visible();
     }
 
-    #[allow(dead_code)]
-    pub fn scroll_down(&mut self, n: usize) {
-        let max = self.total().saturating_sub(self.visible_rows);
-        self.scroll_offset = (self.scroll_offset + n).min(max);
-    }
-
-    #[allow(dead_code)]
-    pub fn scroll_up(&mut self, n: usize) {
-        self.scroll_offset = self.scroll_offset.saturating_sub(n);
-    }
-
     pub fn page_down(&mut self) {
-        self.select_down(self.visible_rows);
+        let half = self.visible_rows / 2;
+        self.select_down(half.max(1));
     }
 
     pub fn page_up(&mut self) {
-        self.select_up(self.visible_rows);
+        let half = self.visible_rows / 2;
+        self.select_up(half.max(1));
     }
 
     pub fn scroll_to_top(&mut self) {
@@ -325,7 +415,6 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use scouty::record::{LogLevel, LogRecord};
-    use std::collections::HashMap;
 
     fn make_record(id: u64, level: Option<LogLevel>, message: &str) -> LogRecord {
         LogRecord {
@@ -351,6 +440,7 @@ mod tests {
         let filtered_indices = (0..n).collect();
         App {
             records,
+            total_records: n,
             filtered_indices,
             scroll_offset: 0,
             selected: 0,
@@ -364,7 +454,9 @@ mod tests {
             search_matches: vec![],
             search_match_idx: None,
             time_input: String::new(),
+            goto_input: String::new(),
             status_message: None,
+            col_widths: [19, 5, 11, 3, 3, 9],
         }
     }
 
@@ -389,8 +481,8 @@ mod tests {
     #[test]
     fn test_page_down_up() {
         let mut app = make_app(100);
-        app.page_down();
-        assert_eq!(app.selected, 10);
+        app.page_down(); // half screen = 5
+        assert_eq!(app.selected, 5);
         app.page_up();
         assert_eq!(app.selected, 0);
     }
@@ -439,10 +531,10 @@ mod tests {
         app.next_search_match();
         assert_eq!(app.selected, 15);
 
-        app.next_search_match(); // wrap
+        app.next_search_match();
         assert_eq!(app.selected, 5);
 
-        app.prev_search_match(); // wrap back
+        app.prev_search_match();
         assert_eq!(app.selected, 15);
     }
 
@@ -469,5 +561,30 @@ mod tests {
     fn test_input_modes() {
         let app = make_app(10);
         assert_eq!(app.input_mode, InputMode::Normal);
+    }
+
+    #[test]
+    fn test_goto_line() {
+        let mut app = make_app(100);
+        app.goto_input = "50".to_string();
+        app.goto_line();
+        assert_eq!(app.selected, 49); // 1-indexed
+
+        app.goto_input = "999".to_string();
+        app.goto_line();
+        assert_eq!(app.selected, 99); // clamped
+
+        app.goto_input = "abc".to_string();
+        app.goto_line();
+        assert!(app.status_message.as_ref().unwrap().contains("Invalid"));
+    }
+
+    #[test]
+    fn test_col_widths() {
+        let app = make_app(10);
+        // Time should be at least 19 (YYYY-MM-DD HH:MM:SS)
+        assert!(app.col_widths[0] >= 19);
+        // Level should be at least 5
+        assert!(app.col_widths[1] >= 5);
     }
 }

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -5,7 +5,7 @@ mod ui;
 
 use app::{App, InputMode};
 use crossterm::{
-    event::{self, Event, KeyCode, KeyEventKind},
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
@@ -30,18 +30,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Main loop
     loop {
         terminal.draw(|frame| {
-            let log_area_height = if app.detail_open {
-                // 60% of body area (body = total - header - footer)
-                let body = frame.area().height.saturating_sub(3);
-                (body * 60 / 100) as usize
+            let body_area = frame.area();
+            // Compute visible rows: total height - header row (1) - footer (1) - border overhead
+            let table_height = if app.detail_open {
+                let body = body_area.height.saturating_sub(1); // footer
+                (body * 60 / 100).saturating_sub(1) as usize // 60% minus header row
             } else {
-                frame.area().height.saturating_sub(2) as usize
+                body_area.height.saturating_sub(2) as usize // minus header row and footer
             };
-            app.visible_rows = log_area_height;
+            app.visible_rows = table_height.max(1);
             ui::render(frame, &app);
         })?;
 
-        // Poll with timeout for potential live refresh support
         if !event::poll(Duration::from_millis(250))? {
             continue;
         }
@@ -54,33 +54,55 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Clear status message on any key
             app.status_message = None;
 
+            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
             match app.input_mode {
-                InputMode::Normal => match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => break,
-                    KeyCode::Down | KeyCode::Char('j') => app.select_down(1),
-                    KeyCode::Up | KeyCode::Char('k') => app.select_up(1),
-                    KeyCode::PageDown => app.page_down(),
-                    KeyCode::PageUp => app.page_up(),
-                    KeyCode::Home | KeyCode::Char('g') => app.scroll_to_top(),
-                    KeyCode::End | KeyCode::Char('G') => app.scroll_to_bottom(),
-                    KeyCode::Enter => app.toggle_detail(),
-                    KeyCode::Char('f') => {
-                        app.input_mode = InputMode::Filter;
+                InputMode::Normal => {
+                    if ctrl {
+                        match key.code {
+                            KeyCode::Char('j') | KeyCode::Down => app.page_down(),
+                            KeyCode::Char('k') | KeyCode::Up => app.page_up(),
+                            KeyCode::Char('g') => {
+                                app.input_mode = InputMode::GotoLine;
+                                app.goto_input.clear();
+                            }
+                            _ => {}
+                        }
+                    } else {
+                        match key.code {
+                            KeyCode::Char('q') => break,
+                            KeyCode::Esc => {
+                                // Close detail panel if open, otherwise do nothing
+                                if app.detail_open {
+                                    app.detail_open = false;
+                                }
+                            }
+                            KeyCode::Down | KeyCode::Char('j') => app.select_down(1),
+                            KeyCode::Up | KeyCode::Char('k') => app.select_up(1),
+                            KeyCode::PageDown => app.page_down(),
+                            KeyCode::PageUp => app.page_up(),
+                            KeyCode::Home | KeyCode::Char('g') => app.scroll_to_top(),
+                            KeyCode::End | KeyCode::Char('G') => app.scroll_to_bottom(),
+                            KeyCode::Enter => app.toggle_detail(),
+                            KeyCode::Char('f') => {
+                                app.input_mode = InputMode::Filter;
+                            }
+                            KeyCode::Char('/') => {
+                                app.input_mode = InputMode::Search;
+                            }
+                            KeyCode::Char('t') => {
+                                app.input_mode = InputMode::TimeJump;
+                                app.time_input.clear();
+                            }
+                            KeyCode::Char('n') => app.next_search_match(),
+                            KeyCode::Char('N') => app.prev_search_match(),
+                            KeyCode::Char('?') => {
+                                app.input_mode = InputMode::Help;
+                            }
+                            _ => {}
+                        }
                     }
-                    KeyCode::Char('/') => {
-                        app.input_mode = InputMode::Search;
-                    }
-                    KeyCode::Char('t') => {
-                        app.input_mode = InputMode::TimeJump;
-                        app.time_input.clear();
-                    }
-                    KeyCode::Char('n') => app.next_search_match(),
-                    KeyCode::Char('N') => app.prev_search_match(),
-                    KeyCode::Char('?') | KeyCode::Char('h') => {
-                        app.input_mode = InputMode::Help;
-                    }
-                    _ => {}
-                },
+                }
                 InputMode::Filter => match key.code {
                     KeyCode::Enter => {
                         app.apply_filter();
@@ -133,8 +155,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     _ => {}
                 },
+                InputMode::GotoLine => match key.code {
+                    KeyCode::Enter => {
+                        app.goto_line();
+                        app.input_mode = InputMode::Normal;
+                    }
+                    KeyCode::Esc => {
+                        app.input_mode = InputMode::Normal;
+                    }
+                    KeyCode::Backspace => {
+                        app.goto_input.pop();
+                    }
+                    KeyCode::Char(c) if c.is_ascii_digit() => {
+                        app.goto_input.push(c);
+                    }
+                    _ => {}
+                },
                 InputMode::Help => {
-                    // Any key closes help
                     app.input_mode = InputMode::Normal;
                 }
             }

--- a/crates/scouty-tui/src/ui.rs
+++ b/crates/scouty-tui/src/ui.rs
@@ -3,7 +3,7 @@
 use crate::app::{App, InputMode};
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
 };
 use scouty::record::LogLevel;
 
@@ -14,30 +14,19 @@ fn level_style(level: Option<LogLevel>) -> Style {
         Some(LogLevel::Error) => Style::default().fg(Color::Red),
         Some(LogLevel::Warn) => Style::default().fg(Color::Yellow),
         Some(LogLevel::Info) => Style::default().fg(Color::Green),
-        Some(LogLevel::Debug) => Style::default().fg(Color::Cyan),
+        Some(LogLevel::Debug) => Style::default().fg(Color::Gray),
         Some(LogLevel::Trace) => Style::default().fg(Color::DarkGray),
         None => Style::default(),
     }
-}
-
-/// Format a single log record as a line.
-fn format_record(record: &scouty::record::LogRecord) -> String {
-    let ts = record.timestamp.format("%Y-%m-%d %H:%M:%S");
-    let level = record
-        .level
-        .map(|l| format!("{:5}", l))
-        .unwrap_or_else(|| "     ".to_string());
-    format!("{} {} {}", ts, level, record.message)
 }
 
 /// Render the full UI.
 pub fn render(frame: &mut Frame, app: &App) {
     let area = frame.area();
 
-    // Main layout: header + body + input/footer
     let footer_height = if matches!(
         app.input_mode,
-        InputMode::Filter | InputMode::Search | InputMode::TimeJump
+        InputMode::Filter | InputMode::Search | InputMode::TimeJump | InputMode::GotoLine
     ) {
         2
     } else {
@@ -47,27 +36,24 @@ pub fn render(frame: &mut Frame, app: &App) {
     let main_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),
-            Constraint::Min(1),
-            Constraint::Length(footer_height),
+            Constraint::Min(1),                // body (table + optional detail)
+            Constraint::Length(footer_height), // footer
         ])
         .split(area);
 
-    render_header(frame, app, main_chunks[0]);
-
-    // Body: log list + optional detail panel
+    // Body: log table + optional detail panel
     if app.detail_open {
         let body_chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
-            .split(main_chunks[1]);
-        render_log_list(frame, app, body_chunks[0]);
+            .split(main_chunks[0]);
+        render_log_table(frame, app, body_chunks[0]);
         render_detail_panel(frame, app, body_chunks[1]);
     } else {
-        render_log_list(frame, app, main_chunks[1]);
+        render_log_table(frame, app, main_chunks[0]);
     }
 
-    render_footer(frame, app, main_chunks[2]);
+    render_footer(frame, app, main_chunks[1]);
 
     // Help overlay
     if app.input_mode == InputMode::Help {
@@ -75,59 +61,74 @@ pub fn render(frame: &mut Frame, app: &App) {
     }
 }
 
-fn render_header(frame: &mut Frame, app: &App, area: Rect) {
-    let mut spans = vec![
-        Span::styled(
-            " scouty ",
-            Style::default().fg(Color::White).bg(Color::Blue),
-        ),
-        Span::raw(format!(" {} records", app.total())),
+fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {
+    let visible = app.visible_records();
+    let cw = &app.col_widths;
+
+    // Build column constraints: fixed widths for first 6, Fill for Log
+    let widths = [
+        Constraint::Length(cw[0]),
+        Constraint::Length(cw[1]),
+        Constraint::Length(cw[2]),
+        Constraint::Length(cw[3]),
+        Constraint::Length(cw[4]),
+        Constraint::Length(cw[5]),
+        Constraint::Fill(1), // Log column fills remaining
     ];
 
-    if app.records.len() != app.total() {
-        spans.push(Span::styled(
-            format!(" (filtered from {})", app.records.len()),
-            Style::default().fg(Color::DarkGray),
-        ));
-    }
+    let header = Row::new(vec![
+        Cell::from("Time").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("Level").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("ProcessName").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("Pid").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("Tid").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("Component").style(Style::default().add_modifier(Modifier::BOLD)),
+        Cell::from("Log").style(Style::default().add_modifier(Modifier::BOLD)),
+    ])
+    .style(Style::default().bg(Color::DarkGray).fg(Color::White));
 
-    if let Some(ref msg) = app.status_message {
-        spans.push(Span::raw(" | "));
-        spans.push(Span::styled(msg, Style::default().fg(Color::Yellow)));
-    }
-
-    let header = Paragraph::new(Line::from(spans));
-    frame.render_widget(header, area);
-}
-
-fn render_log_list(frame: &mut Frame, app: &App, area: Rect) {
-    let visible = app.visible_records();
-    let lines: Vec<Line> = visible
+    let rows: Vec<Row> = visible
         .iter()
         .enumerate()
         .map(|(i, record)| {
             let filtered_idx = app.scroll_offset + i;
             let is_selected = filtered_idx == app.selected;
             let is_match = app.is_search_match(filtered_idx);
-            let text = format_record(record);
 
-            let mut style = level_style(record.level);
-            if is_selected {
-                style = style.bg(Color::DarkGray);
-            }
-            if is_match {
-                style = style.bg(Color::Rgb(60, 60, 0));
-            }
+            let row_style = level_style(record.level);
+
+            let ts = record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string();
+            let level_str = record.level.map(|l| format!("{}", l)).unwrap_or_default();
+            let proc_name = record.process_name.as_deref().unwrap_or("");
+            let pid = record.pid.map(|p| p.to_string()).unwrap_or_default();
+            let tid = record.tid.map(|t| t.to_string()).unwrap_or_default();
+            let component = record.component_name.as_deref().unwrap_or("");
+
+            let cells = vec![
+                Cell::from(ts),
+                Cell::from(level_str),
+                Cell::from(proc_name.to_string()),
+                Cell::from(pid),
+                Cell::from(tid),
+                Cell::from(component.to_string()),
+                Cell::from(record.message.clone()),
+            ];
+
+            let mut row = Row::new(cells).style(row_style);
             if is_selected && is_match {
-                style = style.bg(Color::Rgb(80, 80, 0));
+                row = row.style(row_style.bg(Color::Rgb(80, 80, 0)));
+            } else if is_selected {
+                row = row.style(row_style.bg(Color::Rgb(40, 40, 60)));
+            } else if is_match {
+                row = row.style(row_style.bg(Color::Rgb(60, 60, 0)));
             }
-
-            Line::styled(text, style)
+            row
         })
         .collect();
 
-    let log_block = Paragraph::new(lines).block(Block::default().borders(Borders::NONE));
-    frame.render_widget(log_block, area);
+    let table = Table::new(rows, widths).header(header).column_spacing(1);
+
+    frame.render_widget(table, area);
 }
 
 fn render_detail_panel(frame: &mut Frame, app: &App, area: Rect) {
@@ -195,12 +196,6 @@ fn render_detail_panel(frame: &mut Frame, app: &App, area: Rect) {
         lines.push(Line::styled("Message:", Style::default().fg(Color::Cyan)));
         lines.push(Line::from(record.message.clone()));
 
-        if record.raw != record.message {
-            lines.push(Line::from(""));
-            lines.push(Line::styled("Raw:", Style::default().fg(Color::Cyan)));
-            lines.push(Line::from(record.raw.clone()));
-        }
-
         let detail = Paragraph::new(lines)
             .block(block)
             .wrap(Wrap { trim: false });
@@ -214,64 +209,82 @@ fn render_detail_panel(frame: &mut Frame, app: &App, area: Rect) {
 fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
     match app.input_mode {
         InputMode::Filter => {
-            let input = Paragraph::new(Line::from(vec![
-                Span::styled("Filter: ", Style::default().fg(Color::Yellow)),
-                Span::raw(&app.filter_input),
-                Span::styled("█", Style::default().fg(Color::White)),
-            ]));
-            frame.render_widget(input, area);
-            if let Some(ref err) = app.filter_error {
-                if area.height > 1 {
-                    let err_area = Rect::new(area.x, area.y + 1, area.width, 1);
-                    let err_line =
-                        Paragraph::new(Span::styled(err.as_str(), Style::default().fg(Color::Red)));
-                    frame.render_widget(err_line, err_area);
-                }
-            }
+            render_input_footer(
+                frame,
+                area,
+                "Filter: ",
+                &app.filter_input,
+                app.filter_error.as_deref(),
+            );
         }
         InputMode::Search => {
-            let input = Paragraph::new(Line::from(vec![
-                Span::styled("/", Style::default().fg(Color::Yellow)),
-                Span::raw(&app.search_input),
-                Span::styled("█", Style::default().fg(Color::White)),
-            ]));
-            frame.render_widget(input, area);
+            render_input_footer(frame, area, "/", &app.search_input, None);
         }
         InputMode::TimeJump => {
-            let input = Paragraph::new(Line::from(vec![
-                Span::styled("Jump to time: ", Style::default().fg(Color::Yellow)),
-                Span::raw(&app.time_input),
-                Span::styled("█", Style::default().fg(Color::White)),
-            ]));
-            frame.render_widget(input, area);
+            render_input_footer(frame, area, "Jump to time: ", &app.time_input, None);
+        }
+        InputMode::GotoLine => {
+            render_input_footer(frame, area, "Go to line: ", &app.goto_input, None);
         }
         _ => {
+            // Status bar: position info
             let position = if app.total() == 0 {
-                "Empty".to_string()
+                format!("0/0 (Total: {})", app.total_records)
             } else {
-                format!("Line {} of {}", app.selected + 1, app.total())
+                let current = app.selected + 1;
+                let filtered = app.total();
+                let total = app.total_records;
+                if filtered == total {
+                    format!("{}/{}", current, total)
+                } else {
+                    format!("{}/{} (Total: {})", current, filtered, total)
+                }
             };
 
-            let footer = Paragraph::new(Line::from(vec![
-                Span::styled(
-                    " ?:help q:quit j/k:↑↓ Enter:detail /:search f:filter t:time ",
-                    Style::default().fg(Color::DarkGray),
-                ),
-                Span::styled(
-                    format!(" {} ", position),
-                    Style::default().fg(Color::White).bg(Color::DarkGray),
-                ),
-            ]))
-            .alignment(Alignment::Right);
+            let mut right_spans = vec![Span::styled(
+                format!(" {} ", position),
+                Style::default().fg(Color::White).bg(Color::DarkGray),
+            )];
+
+            if let Some(ref msg) = app.status_message {
+                right_spans.insert(
+                    0,
+                    Span::styled(format!(" {} │", msg), Style::default().fg(Color::Yellow)),
+                );
+            }
+
+            let footer = Paragraph::new(Line::from(right_spans)).alignment(Alignment::Right);
             frame.render_widget(footer, area);
         }
     }
 }
 
+fn render_input_footer(
+    frame: &mut Frame,
+    area: Rect,
+    prompt: &str,
+    input: &str,
+    error: Option<&str>,
+) {
+    let input_line = Paragraph::new(Line::from(vec![
+        Span::styled(prompt, Style::default().fg(Color::Yellow)),
+        Span::raw(input),
+        Span::styled("█", Style::default().fg(Color::White)),
+    ]));
+    frame.render_widget(input_line, area);
+
+    if let Some(err) = error {
+        if area.height > 1 {
+            let err_area = Rect::new(area.x, area.y + 1, area.width, 1);
+            let err_line = Paragraph::new(Span::styled(err, Style::default().fg(Color::Red)));
+            frame.render_widget(err_line, err_area);
+        }
+    }
+}
+
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
-    // Center overlay
-    let width = 50u16.min(area.width.saturating_sub(4));
-    let height = 20u16.min(area.height.saturating_sub(4));
+    let width = 55u16.min(area.width.saturating_sub(4));
+    let height = 22u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let overlay = Rect::new(x, y, width, height);
@@ -287,21 +300,23 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
         ),
         Line::from(""),
         Line::from(" Navigation"),
-        Line::from("  j / ↓        Scroll down"),
-        Line::from("  k / ↑        Scroll up"),
-        Line::from("  PgDn         Page down"),
-        Line::from("  PgUp         Page up"),
-        Line::from("  g / Home     Go to top"),
-        Line::from("  G / End      Go to bottom"),
+        Line::from("  j / k            Move up/down one row"),
+        Line::from("  Ctrl+j/k/↑/↓    Page jump (half screen)"),
+        Line::from("  g                Jump to first row"),
+        Line::from("  G                Jump to last row"),
+        Line::from("  Ctrl+G           Go to line number"),
         Line::from(""),
         Line::from(" Actions"),
-        Line::from("  Enter        Toggle detail panel"),
-        Line::from("  f            Filter records"),
-        Line::from("  /            Search text"),
-        Line::from("  n / N        Next / prev search match"),
-        Line::from("  t            Jump to time"),
-        Line::from("  ? / h        Show this help"),
-        Line::from("  q / Esc      Quit (or close panel)"),
+        Line::from("  Enter            Toggle detail panel"),
+        Line::from("  f                Filter expression"),
+        Line::from("  /                Search (regex)"),
+        Line::from("  n / N            Next / prev match"),
+        Line::from("  t                Jump to time"),
+        Line::from("  ?                Show this help"),
+        Line::from(""),
+        Line::from(" General"),
+        Line::from("  Esc              Close dialog/panel"),
+        Line::from("  q                Quit"),
     ];
 
     let help = Paragraph::new(help_text)


### PR DESCRIPTION
## Summary

Implements #63 — TUI Log Viewer P0-Part1: table layout with auto-fit columns, vim-style navigation, and status bar.

Closes #63

### Table Layout
- Proper `ratatui::Table` widget with 7 columns: Time / Level / ProcessName / Pid / Tid / Component / Log
- Auto-fit column widths by sampling up to 1000 records (min from headers, max capped)
- Log column fills remaining width via `Constraint::Fill(1)`
- Level color coding: FATAL red+bold / ERROR red / WARN yellow / INFO green / DEBUG gray / TRACE dark gray
- Selected row: highlighted background; search matches: yellow-ish background
- Empty fields display blank

### Navigation
| Key | Action |
|-----|--------|
| j/k | Move up/down one row |
| Ctrl+j/k/↑/↓ | Half-screen page jump |
| g | First row |
| G | Last row |
| Ctrl+G | Goto line number (popup input) |
| q | Quit |
| Esc | Close detail panel / dialog (does NOT quit) |
| ? | Help overlay |

### Status Bar
- Format: `3/7688 (Total: 120000)` when filtered
- Format: `3/7688` when unfiltered
- `0/0 (Total: N)` when empty after filter

### Tests
210 total (12 TUI tests including new goto_line + col_widths tests)