### PR TITLE
feat: regex search and detail panel for TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "ratatui",
+ "regex",
  "scouty",
 ]
 

--- a/crates/scouty-tui/Cargo.toml
+++ b/crates/scouty-tui/Cargo.toml
@@ -11,3 +11,4 @@ scouty = { path = "../scouty" }
 chrono = "0.4"
 ratatui = "0.29"
 crossterm = "0.28"
+regex = "1"

--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -205,20 +205,33 @@ impl App {
         self.clear_search();
     }
 
-    /// Execute text search across filtered records.
+    /// Execute regex search across filtered records.
     pub fn execute_search(&mut self) {
         if self.search_input.is_empty() {
             self.clear_search();
             return;
         }
-        let query = self.search_input.to_lowercase();
+        // Build case-insensitive regex
+        let pattern = match regex::RegexBuilder::new(&self.search_input)
+            .case_insensitive(true)
+            .build()
+        {
+            Ok(re) => re,
+            Err(e) => {
+                self.search_matches.clear();
+                self.search_match_idx = None;
+                self.status_message = Some(format!("Invalid regex: {}", e));
+                return;
+            }
+        };
+
         self.search_matches = self
             .filtered_indices
             .iter()
             .enumerate()
             .filter(|(_, &ri)| {
-                self.records[ri].message.to_lowercase().contains(&query)
-                    || self.records[ri].raw.to_lowercase().contains(&query)
+                pattern.is_match(&self.records[ri].message)
+                    || pattern.is_match(&self.records[ri].raw)
             })
             .map(|(i, _)| i)
             .collect();
@@ -545,6 +558,35 @@ mod tests {
         app.execute_search();
         assert!(app.search_matches.is_empty());
         assert!(app.status_message.is_some());
+    }
+
+    #[test]
+    fn test_search_regex() {
+        let mut app = make_app(20);
+        app.records[3].message = "ERROR: connection timeout".to_string();
+        app.records[7].message = "error: disk full".to_string();
+        app.records[12].message = "Warning: low memory".to_string();
+
+        // Regex search: case-insensitive by default
+        app.search_input = "error".to_string();
+        app.execute_search();
+        assert_eq!(app.search_matches.len(), 2);
+        assert_eq!(app.search_matches, vec![3, 7]);
+
+        // Regex pattern
+        app.search_input = r"error.*(?:timeout|full)".to_string();
+        app.execute_search();
+        assert_eq!(app.search_matches.len(), 2);
+
+        // Invalid regex
+        app.search_input = "[invalid".to_string();
+        app.execute_search();
+        assert!(app.search_matches.is_empty());
+        assert!(app
+            .status_message
+            .as_ref()
+            .unwrap()
+            .contains("Invalid regex"));
     }
 
     #[test]

--- a/crates/scouty-tui/src/ui.rs
+++ b/crates/scouty-tui/src/ui.rs
@@ -116,11 +116,11 @@ fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {
 
             let mut row = Row::new(cells).style(row_style);
             if is_selected && is_match {
-                row = row.style(row_style.bg(Color::Rgb(80, 80, 0)));
+                row = row.style(row_style.bg(Color::Rgb(120, 120, 0)));
             } else if is_selected {
                 row = row.style(row_style.bg(Color::Rgb(40, 40, 60)));
             } else if is_match {
-                row = row.style(row_style.bg(Color::Rgb(60, 60, 0)));
+                row = row.style(row_style.bg(Color::Rgb(80, 80, 0)));
             }
             row
         })


### PR DESCRIPTION
## Summary

Implements #64 — TUI Detail Panel & Search.

Closes #64

### Search (upgraded to regex)
- `/` opens search input, supports full regex patterns (case-insensitive)
- Invalid regex shows error message instead of crashing
- Searches within current filtered results only
- `n`/`N` navigate between matches
- `Esc` closes search input, highlights preserved
- Match highlight: yellow background; selected+match: brighter yellow

### Detail Panel
Already implemented in #63, verified matches spec:
- Enter toggles open/close, persistent below table, follows cursor
- Shows: Timestamp, Level (`-` if empty), Source (always), Component, Process, PID, TID, Metadata, Message
- No Raw Message display

### Tests
211 total (13 TUI tests, new regex search test with pattern matching + invalid regex handling)