### PR TITLE
feat: Braille density chart in TUI status bar

### DIFF
--- a/crates/scouty-tui/src/density.rs
+++ b/crates/scouty-tui/src/density.rs
@@ -1,0 +1,192 @@
+//! Braille density chart for the status bar.
+//!
+//! Uses Unicode Braille characters (U+2800..U+28FF) to render a compact
+//! time-density histogram. Each Braille character encodes a 2x4 dot matrix,
+//! allowing 2 data points per character with 4 height levels each.
+//!
+//! Braille dot numbering:
+//! ```text
+//! 1 4
+//! 2 5
+//! 3 6
+//! 7 8
+//! ```
+//!
+//! We use the left column (dots 1,2,3,7) for one data point and the right
+//! column (dots 4,5,6,8) for the next. Height 0 = no dots, height 4 = all 4 dots.
+
+use chrono::{DateTime, Utc};
+
+/// Braille base character (U+2800, empty braille).
+const BRAILLE_BASE: u32 = 0x2800;
+
+/// Left column dot bits (bottom to top): dot7=0x40, dot3=0x04, dot2=0x02, dot1=0x01
+const LEFT_DOTS: [u32; 4] = [0x40, 0x04, 0x02, 0x01]; // height 1,2,3,4 from bottom
+
+/// Right column dot bits (bottom to top): dot8=0x80, dot6=0x20, dot5=0x10, dot4=0x08
+const RIGHT_DOTS: [u32; 4] = [0x80, 0x20, 0x10, 0x08];
+
+/// Build a braille character from left height (0-4) and right height (0-4).
+fn braille_char(left_height: usize, right_height: usize) -> char {
+    let mut code = BRAILLE_BASE;
+    for &dot in LEFT_DOTS.iter().take(left_height.min(4)) {
+        code |= dot;
+    }
+    for &dot in RIGHT_DOTS.iter().take(right_height.min(4)) {
+        code |= dot;
+    }
+    char::from_u32(code).unwrap_or(' ')
+}
+
+/// Compute density histogram buckets from filtered record timestamps.
+///
+/// Returns a Vec of counts, one per bucket.
+pub fn compute_density(timestamps: &[DateTime<Utc>], num_buckets: usize) -> Vec<usize> {
+    if timestamps.is_empty() || num_buckets == 0 {
+        return vec![0; num_buckets.max(1)];
+    }
+
+    let min_ts = timestamps[0];
+    let max_ts = timestamps[timestamps.len() - 1];
+
+    if min_ts == max_ts {
+        // All records at same timestamp
+        let mut buckets = vec![0; num_buckets];
+        buckets[0] = timestamps.len();
+        return buckets;
+    }
+
+    let range_ms = (max_ts - min_ts).num_milliseconds() as f64;
+    let mut buckets = vec![0usize; num_buckets];
+
+    for ts in timestamps {
+        let offset_ms = (*ts - min_ts).num_milliseconds() as f64;
+        let idx = ((offset_ms / range_ms) * (num_buckets as f64 - 1.0)) as usize;
+        buckets[idx.min(num_buckets - 1)] += 1;
+    }
+
+    buckets
+}
+
+/// Find which bucket the cursor timestamp falls into.
+pub fn cursor_bucket(
+    cursor_ts: DateTime<Utc>,
+    timestamps: &[DateTime<Utc>],
+    num_buckets: usize,
+) -> Option<usize> {
+    if timestamps.is_empty() || num_buckets == 0 {
+        return None;
+    }
+    let min_ts = timestamps[0];
+    let max_ts = timestamps[timestamps.len() - 1];
+    if min_ts == max_ts {
+        return Some(0);
+    }
+    let range_ms = (max_ts - min_ts).num_milliseconds() as f64;
+    let offset_ms = (cursor_ts - min_ts).num_milliseconds() as f64;
+    let idx = ((offset_ms / range_ms) * (num_buckets as f64 - 1.0)) as usize;
+    Some(idx.min(num_buckets - 1))
+}
+
+/// Render density buckets as a Braille string.
+///
+/// Each character encodes 2 adjacent buckets. Returns (text, cursor_char_index).
+/// `cursor_bucket_idx` is the bucket index where the cursor is.
+pub fn render_braille(
+    buckets: &[usize],
+    cursor_bucket_idx: Option<usize>,
+) -> (String, Option<usize>) {
+    if buckets.is_empty() {
+        return (String::new(), None);
+    }
+
+    let max_count = *buckets.iter().max().unwrap_or(&1).max(&1);
+    let mut result = String::new();
+    let mut cursor_char_idx = None;
+
+    let mut i = 0;
+    let mut char_idx = 0;
+    while i < buckets.len() {
+        let left = (buckets[i] as f64 / max_count as f64 * 4.0).round() as usize;
+        let right = if i + 1 < buckets.len() {
+            (buckets[i + 1] as f64 / max_count as f64 * 4.0).round() as usize
+        } else {
+            0
+        };
+
+        result.push(braille_char(left, right));
+
+        // Check if cursor is in this character's buckets
+        if let Some(cb) = cursor_bucket_idx {
+            if cb == i || (i + 1 < buckets.len() && cb == i + 1) {
+                cursor_char_idx = Some(char_idx);
+            }
+        }
+
+        i += 2;
+        char_idx += 1;
+    }
+
+    (result, cursor_char_idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn test_braille_char_empty() {
+        let c = braille_char(0, 0);
+        assert_eq!(c, '\u{2800}'); // empty braille
+    }
+
+    #[test]
+    fn test_braille_char_full() {
+        let c = braille_char(4, 4);
+        assert_eq!(c, '\u{28FF}'); // full braille
+    }
+
+    #[test]
+    fn test_braille_char_left_only() {
+        let c = braille_char(1, 0);
+        assert_eq!(c, '\u{2840}'); // only dot7
+    }
+
+    #[test]
+    fn test_compute_density_empty() {
+        let buckets = compute_density(&[], 10);
+        assert_eq!(buckets.len(), 10);
+        assert!(buckets.iter().all(|&c| c == 0));
+    }
+
+    #[test]
+    fn test_compute_density_uniform() {
+        let base = Utc::now();
+        let timestamps: Vec<DateTime<Utc>> =
+            (0..100).map(|i| base + Duration::seconds(i)).collect();
+        let buckets = compute_density(&timestamps, 10);
+        assert_eq!(buckets.len(), 10);
+        let total: usize = buckets.iter().sum();
+        assert_eq!(total, 100);
+    }
+
+    #[test]
+    fn test_render_braille_basic() {
+        let buckets = vec![10, 5, 0, 8, 10, 3];
+        let (text, _cursor) = render_braille(&buckets, None);
+        assert_eq!(text.chars().count(), 3); // 6 buckets / 2 = 3 chars
+    }
+
+    #[test]
+    fn test_cursor_bucket() {
+        let base = Utc::now();
+        let timestamps: Vec<DateTime<Utc>> =
+            (0..100).map(|i| base + Duration::seconds(i)).collect();
+        let cb = cursor_bucket(base + Duration::seconds(50), &timestamps, 10);
+        assert!(cb.is_some());
+        // Bucket should be roughly in the middle (4 or 5)
+        let idx = cb.unwrap();
+        assert!(idx >= 4 && idx <= 5, "Expected ~middle bucket, got {}", idx);
+    }
+}

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -1,6 +1,7 @@
 //! scouty-tui — Terminal UI for scouty log viewer.
 
 mod app;
+mod density;
 mod ui;
 
 use app::{App, InputMode};

--- a/crates/scouty-tui/src/ui.rs
+++ b/crates/scouty-tui/src/ui.rs
@@ -227,7 +227,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             render_input_footer(frame, area, "Go to line: ", &app.goto_input, None);
         }
         _ => {
-            // Status bar: position info
+            // Status bar: density chart │ position info
             let position = if app.total() == 0 {
                 format!("0/0 (Total: {})", app.total_records)
             } else {
@@ -241,19 +241,65 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 }
             };
 
-            let mut right_spans = vec![Span::styled(
-                format!(" {} ", position),
-                Style::default().fg(Color::White).bg(Color::DarkGray),
-            )];
-
+            // Right side: position + optional status message
+            let mut right_text = format!(" {} ", position);
             if let Some(ref msg) = app.status_message {
-                right_spans.insert(
-                    0,
-                    Span::styled(format!(" {} │", msg), Style::default().fg(Color::Yellow)),
-                );
+                right_text = format!(" {} │{}", msg, right_text);
+            }
+            let right_width = right_text.len() as u16 + 1; // +1 for separator
+
+            // Left side: density chart (adaptive width)
+            let chart_width = area.width.saturating_sub(right_width + 3) as usize; // 3 for " │ "
+
+            let mut spans: Vec<Span> = Vec::new();
+
+            if chart_width >= 4 && app.total() > 0 {
+                // Collect filtered timestamps
+                let timestamps: Vec<chrono::DateTime<chrono::Utc>> = app
+                    .filtered_indices
+                    .iter()
+                    .map(|&i| app.records[i].timestamp)
+                    .collect();
+
+                // 2 data points per braille char
+                let num_buckets = (chart_width * 2).min(200);
+                let buckets = crate::density::compute_density(&timestamps, num_buckets);
+
+                let cursor_ts = app.selected_record().map(|r| r.timestamp);
+                let cursor_bucket = cursor_ts
+                    .and_then(|ts| crate::density::cursor_bucket(ts, &timestamps, num_buckets));
+
+                let (braille_text, cursor_char_idx) =
+                    crate::density::render_braille(&buckets, cursor_bucket);
+
+                // Render braille with cursor highlight
+                for (i, ch) in braille_text.chars().enumerate() {
+                    let style = if Some(i) == cursor_char_idx {
+                        Style::default()
+                            .fg(Color::Yellow)
+                            .bg(Color::Rgb(40, 40, 60))
+                    } else {
+                        Style::default().fg(Color::Cyan)
+                    };
+                    spans.push(Span::styled(ch.to_string(), style));
+                }
+
+                spans.push(Span::styled(" │", Style::default().fg(Color::DarkGray)));
             }
 
-            let footer = Paragraph::new(Line::from(right_spans)).alignment(Alignment::Right);
+            // Right side
+            if let Some(ref msg) = app.status_message {
+                spans.push(Span::styled(
+                    format!(" {} │", msg),
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
+            spans.push(Span::styled(
+                format!(" {} ", position),
+                Style::default().fg(Color::White).bg(Color::DarkGray),
+            ));
+
+            let footer = Paragraph::new(Line::from(spans));
             frame.render_widget(footer, area);
         }
     }


### PR DESCRIPTION
## Summary

Implements #66 — Status bar density chart using Unicode Braille characters.

Closes #66

### Braille Density Chart
- Each Braille character (U+2800..U+28FF) encodes **2 data points** using 2x4 dot matrix
- Left column dots = data point A (0-4 height), right column dots = data point B (0-4 height)
- **Adaptive width**: chart fills available status bar space (terminal width minus position text)
- Shows **filtered** log density — updates when filter changes
- **Cursor position** highlighted in yellow on the chart
- Graceful degradation: hidden when terminal < ~10 chars wide

### Status Bar Format
```
⡀⣤⣶⣿⣷⣤⡀ │ 3/7688 (Total: 120000)
```

### Implementation
- `density.rs` module with pure functions:
  - `compute_density(timestamps, num_buckets)` → bucket counts
  - `cursor_bucket(cursor_ts, timestamps, num_buckets)` → bucket index
  - `render_braille(buckets, cursor_idx)` → (braille_string, cursor_char_idx)

### Tests
218 total (7 new density tests: braille encoding, empty/uniform density, render, cursor bucket)