### PR TITLE
feat: column configuration + follow mode

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -20,7 +20,104 @@ pub enum InputMode {
     QuickInclude,
     FieldFilter,
     FilterManager,
+    ColumnSelector,
     Help,
+}
+
+/// Column identifiers for the log table.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Column {
+    Time,
+    Level,
+    ProcessName,
+    Pid,
+    Tid,
+    Component,
+    Source,
+    Log,
+}
+
+impl Column {
+    #[allow(dead_code)]
+    pub const ALL: [Column; 8] = [
+        Column::Time,
+        Column::Level,
+        Column::ProcessName,
+        Column::Pid,
+        Column::Tid,
+        Column::Component,
+        Column::Source,
+        Column::Log,
+    ];
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Column::Time => "Time",
+            Column::Level => "Level",
+            Column::ProcessName => "ProcessName",
+            Column::Pid => "Pid",
+            Column::Tid => "Tid",
+            Column::Component => "Component",
+            Column::Source => "Source",
+            Column::Log => "Log",
+        }
+    }
+}
+
+/// Column visibility configuration.
+#[derive(Debug, Clone)]
+pub struct ColumnConfig {
+    /// (Column, visible) for each column.
+    pub columns: Vec<(Column, bool)>,
+    /// Cursor in the column selector dialog.
+    pub cursor: usize,
+}
+
+impl Default for ColumnConfig {
+    fn default() -> Self {
+        Self {
+            columns: vec![
+                (Column::Time, true),
+                (Column::Level, true),
+                (Column::ProcessName, true),
+                (Column::Pid, true),
+                (Column::Tid, true),
+                (Column::Component, true),
+                (Column::Source, false), // hidden by default
+                (Column::Log, true),
+            ],
+            cursor: 0,
+        }
+    }
+}
+
+impl ColumnConfig {
+    #[allow(dead_code)]
+    pub fn is_visible(&self, col: Column) -> bool {
+        self.columns
+            .iter()
+            .find(|(c, _)| *c == col)
+            .map(|(_, v)| *v)
+            .unwrap_or(false)
+    }
+
+    pub fn visible_columns(&self) -> Vec<Column> {
+        self.columns
+            .iter()
+            .filter(|(_, v)| *v)
+            .map(|(c, _)| *c)
+            .collect()
+    }
+
+    pub fn toggle(&mut self, index: usize) {
+        if index < self.columns.len() {
+            // Don't allow hiding Log column
+            if self.columns[index].0 == Column::Log {
+                return;
+            }
+            self.columns[index].1 = !self.columns[index].1;
+        }
+    }
 }
 
 /// A single filter entry in the filter stack.
@@ -89,6 +186,10 @@ pub struct App {
     pub status_message: Option<String>,
     /// Column widths computed from data (Time, Level, ProcessName, Pid, Tid, Component).
     pub col_widths: [u16; 6],
+    /// Column visibility configuration.
+    pub column_config: ColumnConfig,
+    /// Follow mode: auto-scroll to bottom.
+    pub follow_mode: bool,
 }
 
 impl App {
@@ -132,6 +233,8 @@ impl App {
             goto_input: String::new(),
             status_message: None,
             col_widths,
+            column_config: ColumnConfig::default(),
+            follow_mode: false,
         })
     }
 
@@ -532,6 +635,9 @@ impl App {
     pub fn select_up(&mut self, n: usize) {
         self.selected = self.selected.saturating_sub(n);
         self.ensure_selected_visible();
+        if n > 0 && self.selected < self.total().saturating_sub(1) {
+            self.exit_follow();
+        }
     }
 
     pub fn page_down(&mut self) {
@@ -556,6 +662,19 @@ impl App {
 
     pub fn toggle_detail(&mut self) {
         self.detail_open = !self.detail_open;
+    }
+
+    /// Toggle follow mode.
+    pub fn toggle_follow(&mut self) {
+        self.follow_mode = !self.follow_mode;
+        if self.follow_mode {
+            self.scroll_to_bottom();
+        }
+    }
+
+    /// Exit follow mode (called on manual scroll up).
+    pub fn exit_follow(&mut self) {
+        self.follow_mode = false;
     }
 
     fn ensure_selected_visible(&mut self) {
@@ -635,6 +754,8 @@ mod tests {
             goto_input: String::new(),
             status_message: None,
             col_widths: [19, 5, 11, 3, 3, 9],
+            column_config: ColumnConfig::default(),
+            follow_mode: false,
         }
     }
 
@@ -668,6 +789,8 @@ mod tests {
             goto_input: String::new(),
             status_message: None,
             col_widths: [19, 5, 11, 3, 3, 9],
+            column_config: ColumnConfig::default(),
+            follow_mode: false,
         }
     }
 
@@ -929,5 +1052,173 @@ mod tests {
         assert!(ff.fields.len() >= 2); // at least level + process_name
         assert!(ff.fields.iter().any(|(name, _, _)| name == "level"));
         assert!(ff.fields.iter().any(|(name, _, _)| name == "process_name"));
+    }
+}
+
+#[cfg(test)]
+mod column_follow_tests {
+    use super::*;
+    use chrono::Utc;
+    use scouty::record::{LogLevel, LogRecord};
+
+    fn make_record(id: u64, message: &str) -> LogRecord {
+        LogRecord {
+            id,
+            timestamp: Utc::now(),
+            level: Some(LogLevel::Info),
+            source: "test".into(),
+            pid: Some(100),
+            tid: Some(200),
+            component_name: Some("comp".into()),
+            process_name: Some("proc".into()),
+            message: message.to_string(),
+            raw: message.to_string(),
+            metadata: None,
+            loader_id: "test".into(),
+        }
+    }
+
+    fn make_app_cf(n: usize) -> App {
+        let records: Vec<LogRecord> = (0..n)
+            .map(|i| make_record(i as u64, &format!("msg {}", i)))
+            .collect();
+        let filtered_indices = (0..n).collect();
+        App {
+            records,
+            total_records: n,
+            filtered_indices,
+            scroll_offset: 0,
+            selected: 0,
+            visible_rows: 10,
+            detail_open: false,
+            input_mode: InputMode::Normal,
+            filter_input: String::new(),
+            filter_error: None,
+            filters: Vec::new(),
+            quick_filter_input: String::new(),
+            field_filter: None,
+            filter_manager_cursor: 0,
+            search_input: String::new(),
+            search_matches: vec![],
+            search_match_idx: None,
+            time_input: String::new(),
+            goto_input: String::new(),
+            status_message: None,
+            col_widths: [19, 5, 11, 3, 3, 9],
+            column_config: ColumnConfig::default(),
+            follow_mode: false,
+        }
+    }
+
+    // ── Column config tests ──────────────────────────────────
+
+    #[test]
+    fn test_default_column_config() {
+        let config = ColumnConfig::default();
+        assert!(config.is_visible(Column::Time));
+        assert!(config.is_visible(Column::Level));
+        assert!(config.is_visible(Column::Log));
+        assert!(!config.is_visible(Column::Source)); // hidden by default
+    }
+
+    #[test]
+    fn test_toggle_column() {
+        let mut config = ColumnConfig::default();
+        // Find ProcessName index
+        let idx = config
+            .columns
+            .iter()
+            .position(|(c, _)| *c == Column::ProcessName)
+            .unwrap();
+        assert!(config.is_visible(Column::ProcessName));
+        config.toggle(idx);
+        assert!(!config.is_visible(Column::ProcessName));
+        config.toggle(idx);
+        assert!(config.is_visible(Column::ProcessName));
+    }
+
+    #[test]
+    fn test_cannot_toggle_log() {
+        let mut config = ColumnConfig::default();
+        let idx = config
+            .columns
+            .iter()
+            .position(|(c, _)| *c == Column::Log)
+            .unwrap();
+        assert!(config.is_visible(Column::Log));
+        config.toggle(idx);
+        assert!(config.is_visible(Column::Log)); // still visible
+    }
+
+    #[test]
+    fn test_visible_columns() {
+        let mut config = ColumnConfig::default();
+        let default_visible = config.visible_columns();
+        assert_eq!(default_visible.len(), 7); // all except Source
+
+        // Hide ProcessName
+        let idx = config
+            .columns
+            .iter()
+            .position(|(c, _)| *c == Column::ProcessName)
+            .unwrap();
+        config.toggle(idx);
+        let visible = config.visible_columns();
+        assert_eq!(visible.len(), 6);
+        assert!(!visible.contains(&Column::ProcessName));
+    }
+
+    #[test]
+    fn test_show_source_column() {
+        let mut config = ColumnConfig::default();
+        let idx = config
+            .columns
+            .iter()
+            .position(|(c, _)| *c == Column::Source)
+            .unwrap();
+        config.toggle(idx);
+        assert!(config.is_visible(Column::Source));
+        assert_eq!(config.visible_columns().len(), 8); // all visible
+    }
+
+    // ── Follow mode tests ────────────────────────────────────
+
+    #[test]
+    fn test_follow_mode_toggle() {
+        let mut app = make_app_cf(100);
+        assert!(!app.follow_mode);
+        app.toggle_follow();
+        assert!(app.follow_mode);
+        assert_eq!(app.selected, 99); // scrolled to bottom
+        app.toggle_follow();
+        assert!(!app.follow_mode);
+    }
+
+    #[test]
+    fn test_follow_mode_exits_on_scroll_up() {
+        let mut app = make_app_cf(100);
+        app.toggle_follow();
+        assert!(app.follow_mode);
+        app.select_up(5);
+        assert!(!app.follow_mode);
+    }
+
+    #[test]
+    fn test_follow_mode_exits_on_page_up() {
+        let mut app = make_app_cf(100);
+        app.toggle_follow();
+        assert!(app.follow_mode);
+        app.page_up();
+        assert!(!app.follow_mode);
+    }
+
+    #[test]
+    fn test_follow_mode_persists_on_down() {
+        let mut app = make_app_cf(100);
+        app.toggle_follow();
+        assert!(app.follow_mode);
+        // Already at bottom, select_down shouldn't exit follow
+        app.select_down(1);
+        assert!(app.follow_mode);
     }
 }

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -66,6 +66,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 app.input_mode = InputMode::FilterManager;
                                 app.filter_manager_cursor = 0;
                             }
+                            KeyCode::Char(']') => {
+                                app.toggle_follow();
+                            }
                             _ => {}
                         }
                     } else {
@@ -106,6 +109,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             }
                             KeyCode::Char('n') => app.next_search_match(),
                             KeyCode::Char('N') => app.prev_search_match(),
+                            KeyCode::Char('c') => {
+                                app.input_mode = InputMode::ColumnSelector;
+                                app.column_config.cursor = 0;
+                            }
                             KeyCode::Char('?') => {
                                 app.input_mode = InputMode::Help;
                             }
@@ -249,6 +256,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         app.filter_manager_cursor = 0;
                     }
                     KeyCode::Esc | KeyCode::Enter => {
+                        app.input_mode = InputMode::Normal;
+                    }
+                    _ => {}
+                },
+                InputMode::ColumnSelector => match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        app.column_config.cursor = app.column_config.cursor.saturating_sub(1);
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        if app.column_config.cursor + 1 < app.column_config.columns.len() {
+                            app.column_config.cursor += 1;
+                        }
+                    }
+                    KeyCode::Char(' ') | KeyCode::Enter => {
+                        let cur = app.column_config.cursor;
+                        app.column_config.toggle(cur);
+                    }
+                    KeyCode::Esc => {
                         app.input_mode = InputMode::Normal;
                     }
                     _ => {}

--- a/crates/scouty-tui/src/ui.rs
+++ b/crates/scouty-tui/src/ui.rs
@@ -74,33 +74,42 @@ pub fn render(frame: &mut Frame, app: &App) {
     if app.input_mode == InputMode::FilterManager {
         render_filter_manager_overlay(frame, app, area);
     }
+
+    // Column selector overlay
+    if app.input_mode == InputMode::ColumnSelector {
+        render_column_selector_overlay(frame, app, area);
+    }
 }
 
 fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {
+    use crate::app::Column;
+
     let visible = app.visible_records();
     let cw = &app.col_widths;
+    let vis_cols = app.column_config.visible_columns();
 
-    // Build column constraints: fixed widths for first 6, Fill for Log
-    let widths = [
-        Constraint::Length(cw[0]),
-        Constraint::Length(cw[1]),
-        Constraint::Length(cw[2]),
-        Constraint::Length(cw[3]),
-        Constraint::Length(cw[4]),
-        Constraint::Length(cw[5]),
-        Constraint::Fill(1), // Log column fills remaining
-    ];
+    // Build column constraints based on visible columns
+    let widths: Vec<Constraint> = vis_cols
+        .iter()
+        .map(|col| match col {
+            Column::Time => Constraint::Length(cw[0]),
+            Column::Level => Constraint::Length(cw[1]),
+            Column::ProcessName => Constraint::Length(cw[2]),
+            Column::Pid => Constraint::Length(cw[3]),
+            Column::Tid => Constraint::Length(cw[4]),
+            Column::Component => Constraint::Length(cw[5]),
+            Column::Source => Constraint::Length(15),
+            Column::Log => Constraint::Fill(1),
+        })
+        .collect();
 
-    let header = Row::new(vec![
-        Cell::from("Time").style(Style::default().add_modifier(Modifier::BOLD)),
-        Cell::from("Level").style(Style::default().add_modifier(Modifier::BOLD)),
-        Cell::from("ProcessName").style(Style::default().add_modifier(Modifier::BOLD)),
-        Cell::from("Pid").style(Style::default().add_modifier(Modifier::BOLD)),
-        Cell::from("Tid").style(Style::default().add_modifier(Modifier::BOLD)),
-        Cell::from("Component").style(Style::default().add_modifier(Modifier::BOLD)),
-        Cell::from("Log").style(Style::default().add_modifier(Modifier::BOLD)),
-    ])
-    .style(Style::default().bg(Color::DarkGray).fg(Color::White));
+    let header_cells: Vec<Cell> = vis_cols
+        .iter()
+        .map(|col| Cell::from(col.label()).style(Style::default().add_modifier(Modifier::BOLD)))
+        .collect();
+
+    let header =
+        Row::new(header_cells).style(Style::default().bg(Color::DarkGray).fg(Color::White));
 
     let rows: Vec<Row> = visible
         .iter()
@@ -112,22 +121,31 @@ fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {
 
             let row_style = level_style(record.level);
 
-            let ts = record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string();
-            let level_str = record.level.map(|l| format!("{}", l)).unwrap_or_default();
-            let proc_name = record.process_name.as_deref().unwrap_or("");
-            let pid = record.pid.map(|p| p.to_string()).unwrap_or_default();
-            let tid = record.tid.map(|t| t.to_string()).unwrap_or_default();
-            let component = record.component_name.as_deref().unwrap_or("");
-
-            let cells = vec![
-                Cell::from(ts),
-                Cell::from(level_str),
-                Cell::from(proc_name.to_string()),
-                Cell::from(pid),
-                Cell::from(tid),
-                Cell::from(component.to_string()),
-                Cell::from(record.message.clone()),
-            ];
+            let cells: Vec<Cell> = vis_cols
+                .iter()
+                .map(|col| match col {
+                    Column::Time => {
+                        Cell::from(record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string())
+                    }
+                    Column::Level => {
+                        Cell::from(record.level.map(|l| format!("{}", l)).unwrap_or_default())
+                    }
+                    Column::ProcessName => {
+                        Cell::from(record.process_name.as_deref().unwrap_or("").to_string())
+                    }
+                    Column::Pid => {
+                        Cell::from(record.pid.map(|p| p.to_string()).unwrap_or_default())
+                    }
+                    Column::Tid => {
+                        Cell::from(record.tid.map(|t| t.to_string()).unwrap_or_default())
+                    }
+                    Column::Component => {
+                        Cell::from(record.component_name.as_deref().unwrap_or("").to_string())
+                    }
+                    Column::Source => Cell::from(record.source.to_string()),
+                    Column::Log => Cell::from(record.message.clone()),
+                })
+                .collect();
 
             let mut row = Row::new(cells).style(row_style);
             if is_selected && is_match {
@@ -262,8 +280,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 }
             };
 
-            // Right side: position + optional status message
-            let mut right_text = format!(" {} ", position);
+            // Right side: position + optional follow indicator + status message
+            let follow_indicator = if app.follow_mode { " [FOLLOW]" } else { "" };
+            let mut right_text = format!(" {}{} ", position, follow_indicator);
             if let Some(ref msg) = app.status_message {
                 right_text = format!(" {} │{}", msg, right_text);
             }
@@ -316,7 +335,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 ));
             }
             spans.push(Span::styled(
-                format!(" {} ", position),
+                format!(" {}{} ", position, follow_indicator),
                 Style::default().fg(Color::White).bg(Color::DarkGray),
             ));
 
@@ -506,6 +525,60 @@ fn render_filter_manager_overlay(frame: &mut Frame, app: &App, area: Rect) {
         .block(
             Block::default()
                 .title(" Filter Manager (Ctrl+F) ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan)),
+        )
+        .style(Style::default().bg(Color::Black));
+    frame.render_widget(dialog, overlay);
+}
+
+fn render_column_selector_overlay(frame: &mut Frame, app: &App, area: Rect) {
+    let cols = &app.column_config.columns;
+    let width = 35u16.min(area.width.saturating_sub(4));
+    let height = (cols.len() as u16 + 5).min(area.height.saturating_sub(4));
+    let x = (area.width.saturating_sub(width)) / 2;
+    let y = (area.height.saturating_sub(height)) / 2;
+    let overlay = Rect::new(x, y, width, height);
+
+    frame.render_widget(Clear, overlay);
+
+    let mut lines = vec![
+        Line::styled(
+            " Toggle columns (Space/Enter)",
+            Style::default().fg(Color::DarkGray),
+        ),
+        Line::from(""),
+    ];
+
+    for (i, (col, visible)) in cols.iter().enumerate() {
+        let checkbox = if *visible { "[x]" } else { "[ ]" };
+        let is_cursor = i == app.column_config.cursor;
+        let suffix = if *col == crate::app::Column::Log {
+            " (always on)"
+        } else {
+            ""
+        };
+        let style = if is_cursor {
+            Style::default().bg(Color::DarkGray).fg(Color::White)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::styled(
+            format!(" {} {:<12}{}", checkbox, col.label(), suffix),
+            style,
+        ));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::styled(
+        " Esc: Close",
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    let dialog = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .title(" Columns (c) ")
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(Color::Cyan)),
         )


### PR DESCRIPTION
## Summary

Implements #67 — TUI Column Configuration & Follow Mode.

Closes #67

### P1-1: Column Configuration (`c`)

| Column | Default | Notes |
|--------|---------|-------|
| Time | ✅ shown | |
| Level | ✅ shown | |
| ProcessName | ✅ shown | |
| Pid | ✅ shown | |
| Tid | ✅ shown | |
| Component | ✅ shown | |
| Source | ❌ hidden | toggle to show |
| Log | ✅ shown | always on, cannot hide |

Column selector dialog:
```
┌─ Columns (c) ─────────────────┐
│ Toggle columns (Space/Enter)   │
│                                │
│ [x] Time                       │
│ [x] Level                      │
│ [x] ProcessName                │
│ [x] Pid                        │
│ [x] Tid                        │
│ [x] Component                  │
│ [ ] Source                     │
│ [x] Log          (always on)   │
│                                │
│ Esc: Close                     │
└────────────────────────────────┘
```

### P1-2: Follow Mode (`Ctrl+]`)

- Toggle: `Ctrl+]`
- Status bar: `▁▂▃█▅... │ 100/100 [FOLLOW]`
- Auto-exits on manual scroll up (k, Ctrl+k, PageUp)
- Stays active on scroll down (already at bottom)

### Tests
237 total (9 new column config + follow mode tests)