### PR TITLE
feat: update filter interaction per spec v2

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -140,6 +140,8 @@ pub struct FieldFilterState {
     pub cursor: usize,
     /// Whether we're in Exclude (true) or Include (false) mode.
     pub exclude: bool,
+    /// Whether to combine with OR (true) or AND (false). Default: OR.
+    pub logic_or: bool,
 }
 
 /// Main application state.
@@ -378,13 +380,21 @@ impl App {
     }
 
     /// Open field filter dialog based on selected record.
-    pub fn open_field_filter(&mut self) {
+    /// `exclude` determines initial mode (Ctrl+- = true, Ctrl++ = false).
+    pub fn open_field_filter(&mut self, exclude: bool) {
         if let Some(record) = self.selected_record().cloned() {
             let mut fields = Vec::new();
 
+            // ALL fields from LogRecord
+            fields.push((
+                "timestamp".to_string(),
+                record.timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+                false,
+            ));
             if let Some(level) = record.level {
                 fields.push(("level".to_string(), format!("{}", level), false));
             }
+            fields.push(("source".to_string(), record.source.to_string(), false));
             if let Some(ref name) = record.process_name {
                 fields.push(("process_name".to_string(), name.clone(), false));
             }
@@ -397,6 +407,7 @@ impl App {
             if let Some(ref comp) = record.component_name {
                 fields.push(("component".to_string(), comp.clone(), false));
             }
+            fields.push(("message".to_string(), record.message.clone(), false));
 
             // Include metadata fields
             if let Some(ref meta) = record.metadata {
@@ -405,15 +416,11 @@ impl App {
                 }
             }
 
-            if fields.is_empty() {
-                self.status_message = Some("No filterable fields in selected record".to_string());
-                return;
-            }
-
             self.field_filter = Some(FieldFilterState {
                 fields,
                 cursor: 0,
-                exclude: true, // default to exclude
+                exclude,
+                logic_or: true, // default OR
             });
             self.input_mode = InputMode::FieldFilter;
         } else {
@@ -436,12 +443,13 @@ impl App {
                 return;
             }
 
-            // Build filter expression: field1 == "val1" AND field2 == "val2"
+            // Build filter expression with OR or AND
+            let joiner = if state.logic_or { " OR " } else { " AND " };
             let parts: Vec<String> = checked
                 .iter()
                 .map(|(name, val)| format!("{} = \"{}\"", name, val.replace('"', "\\\"")))
                 .collect();
-            let expr_str = parts.join(" AND ");
+            let expr_str = parts.join(joiner);
             let label = if state.exclude {
                 format!("exclude: {}", expr_str)
             } else {
@@ -1046,12 +1054,156 @@ mod tests {
         app.records[0].process_name = Some("myapp".to_string());
         app.records[0].pid = Some(1234);
 
-        app.open_field_filter();
+        app.open_field_filter(true);
         assert_eq!(app.input_mode, InputMode::FieldFilter);
         let ff = app.field_filter.as_ref().unwrap();
-        assert!(ff.fields.len() >= 2); // at least level + process_name
+        assert!(ff.fields.len() >= 4); // timestamp, level, source, process_name, pid, message
         assert!(ff.fields.iter().any(|(name, _, _)| name == "level"));
         assert!(ff.fields.iter().any(|(name, _, _)| name == "process_name"));
+        assert!(ff.fields.iter().any(|(name, _, _)| name == "source"));
+        assert!(ff.fields.iter().any(|(name, _, _)| name == "timestamp"));
+        assert!(ff.fields.iter().any(|(name, _, _)| name == "message"));
+        assert!(ff.fields.iter().any(|(name, _, _)| name == "pid"));
+        assert!(ff.logic_or); // default OR
+    }
+}
+
+#[cfg(test)]
+mod field_filter_v2_tests {
+    use super::*;
+    use chrono::Utc;
+    use scouty::record::{LogLevel, LogRecord};
+
+    fn make_record_full(id: u64, msg: &str, level: LogLevel) -> LogRecord {
+        LogRecord {
+            id,
+            timestamp: Utc::now(),
+            level: Some(level),
+            source: "syslog".into(),
+            pid: Some(1000 + id as u32),
+            tid: Some(2000 + id as u32),
+            component_name: Some("comp".into()),
+            process_name: Some("myapp".into()),
+            message: msg.to_string(),
+            raw: msg.to_string(),
+            metadata: None,
+            loader_id: "test".into(),
+        }
+    }
+
+    fn make_app_full(records: Vec<LogRecord>) -> App {
+        let n = records.len();
+        let filtered_indices = (0..n).collect();
+        App {
+            records,
+            total_records: n,
+            filtered_indices,
+            scroll_offset: 0,
+            selected: 0,
+            visible_rows: 10,
+            detail_open: false,
+            input_mode: InputMode::Normal,
+            filter_input: String::new(),
+            filter_error: None,
+            filters: Vec::new(),
+            quick_filter_input: String::new(),
+            field_filter: None,
+            filter_manager_cursor: 0,
+            search_input: String::new(),
+            search_matches: vec![],
+            search_match_idx: None,
+            time_input: String::new(),
+            goto_input: String::new(),
+            status_message: None,
+            col_widths: [19, 5, 11, 3, 3, 9],
+            column_config: ColumnConfig::default(),
+            follow_mode: false,
+        }
+    }
+
+    #[test]
+    fn test_field_filter_all_fields() {
+        let records = vec![make_record_full(0, "test msg", LogLevel::Error)];
+        let mut app = make_app_full(records);
+
+        app.open_field_filter(true);
+        let ff = app.field_filter.as_ref().unwrap();
+        // Should have: timestamp, level, source, process_name, pid, tid, component, message
+        assert_eq!(ff.fields.len(), 8);
+        assert!(ff.exclude);
+        assert!(ff.logic_or);
+    }
+
+    #[test]
+    fn test_field_filter_include_mode() {
+        let records = vec![make_record_full(0, "test msg", LogLevel::Info)];
+        let mut app = make_app_full(records);
+
+        app.open_field_filter(false);
+        let ff = app.field_filter.as_ref().unwrap();
+        assert!(!ff.exclude);
+    }
+
+    #[test]
+    fn test_field_filter_or_logic() {
+        let records = vec![
+            make_record_full(0, "err msg", LogLevel::Error),
+            make_record_full(1, "info msg", LogLevel::Info),
+            make_record_full(2, "warn msg", LogLevel::Warn),
+        ];
+        let mut app = make_app_full(records);
+
+        app.open_field_filter(false); // include mode
+        let ff = app.field_filter.as_mut().unwrap();
+        assert!(ff.logic_or);
+
+        // Check level field (index 1) and message field
+        let level_idx = ff.fields.iter().position(|(n, _, _)| n == "level").unwrap();
+        ff.fields[level_idx].2 = true; // check level = ERROR
+
+        // Apply — should include only record with level=ERROR
+        app.apply_field_filter();
+        assert_eq!(app.filtered_indices.len(), 1);
+    }
+
+    #[test]
+    fn test_field_filter_and_logic() {
+        let records = vec![
+            make_record_full(0, "err msg", LogLevel::Error),
+            make_record_full(1, "info msg", LogLevel::Info),
+        ];
+        let mut app = make_app_full(records);
+
+        app.open_field_filter(false); // include
+        let ff = app.field_filter.as_mut().unwrap();
+        ff.logic_or = false; // AND
+
+        // Check both level and pid
+        let level_idx = ff.fields.iter().position(|(n, _, _)| n == "level").unwrap();
+        let pid_idx = ff.fields.iter().position(|(n, _, _)| n == "pid").unwrap();
+        ff.fields[level_idx].2 = true;
+        ff.fields[pid_idx].2 = true;
+
+        app.apply_field_filter();
+        // Only record 0 has level=ERROR AND pid=1000
+        assert_eq!(app.filtered_indices.len(), 1);
+    }
+
+    #[test]
+    fn test_field_filter_metadata_fields() {
+        let mut record = make_record_full(0, "test", LogLevel::Info);
+        let mut meta = std::collections::HashMap::new();
+        meta.insert("env".to_string(), "prod".to_string());
+        meta.insert("region".to_string(), "us-west".to_string());
+        record.metadata = Some(meta);
+
+        let mut app = make_app_full(vec![record]);
+        app.open_field_filter(true);
+        let ff = app.field_filter.as_ref().unwrap();
+        // 8 standard fields + 2 metadata
+        assert_eq!(ff.fields.len(), 10);
+        assert!(ff.fields.iter().any(|(n, _, _)| n == "env"));
+        assert!(ff.fields.iter().any(|(n, _, _)| n == "region"));
     }
 }
 

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -69,6 +69,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             KeyCode::Char(']') => {
                                 app.toggle_follow();
                             }
+                            KeyCode::Char('-') => {
+                                app.open_field_filter(true); // Ctrl+- = exclude
+                            }
+                            KeyCode::Char('+') => {
+                                app.open_field_filter(false); // Ctrl++ = include
+                            }
                             _ => {}
                         }
                     } else {
@@ -105,7 +111,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 app.quick_filter_input.clear();
                             }
                             KeyCode::Char('F') => {
-                                app.open_field_filter();
+                                app.input_mode = InputMode::FilterManager;
+                                app.filter_manager_cursor = 0;
                             }
                             KeyCode::Char('n') => app.next_search_match(),
                             KeyCode::Char('N') => app.prev_search_match(),
@@ -209,12 +216,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     ff.cursor += 1;
                                 }
                             }
+                            KeyCode::PageUp => {
+                                ff.cursor = ff.cursor.saturating_sub(10);
+                            }
+                            KeyCode::PageDown => {
+                                ff.cursor = (ff.cursor + 10).min(ff.fields.len().saturating_sub(1));
+                            }
                             KeyCode::Char(' ') => {
                                 let cur = ff.cursor;
                                 ff.fields[cur].2 = !ff.fields[cur].2;
                             }
                             KeyCode::Tab => {
                                 ff.exclude = !ff.exclude;
+                            }
+                            KeyCode::Char('o') => {
+                                ff.logic_or = !ff.logic_or;
                             }
                             KeyCode::Enter => {
                                 app.apply_field_filter();
@@ -238,6 +254,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             && app.filter_manager_cursor + 1 < app.filters.len()
                         {
                             app.filter_manager_cursor += 1;
+                        }
+                    }
+                    KeyCode::PageUp => {
+                        app.filter_manager_cursor = app.filter_manager_cursor.saturating_sub(10);
+                    }
+                    KeyCode::PageDown => {
+                        if !app.filters.is_empty() {
+                            app.filter_manager_cursor = (app.filter_manager_cursor + 10)
+                                .min(app.filters.len().saturating_sub(1));
                         }
                     }
                     KeyCode::Char('d') | KeyCode::Delete => {

--- a/crates/scouty-tui/src/ui.rs
+++ b/crates/scouty-tui/src/ui.rs
@@ -422,8 +422,8 @@ fn render_field_filter_overlay(frame: &mut Frame, app: &App, area: Rect) {
         None => return,
     };
 
-    let width = 45u16.min(area.width.saturating_sub(4));
-    let height = (ff.fields.len() as u16 + 6).min(area.height.saturating_sub(4));
+    let width = 60u16.min(area.width.saturating_sub(4));
+    let height = (ff.fields.len() as u16 + 8).min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let overlay = Rect::new(x, y, width, height);
@@ -431,6 +431,7 @@ fn render_field_filter_overlay(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(Clear, overlay);
 
     let action = if ff.exclude { "Exclude" } else { "Include" };
+    let logic = if ff.logic_or { "OR" } else { "AND" };
     let mut lines = vec![
         Line::from(vec![
             Span::raw(" Action: "),
@@ -440,12 +441,30 @@ fn render_field_filter_overlay(frame: &mut Frame, app: &App, area: Rect) {
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" (Tab to toggle)", Style::default().fg(Color::DarkGray)),
+            Span::styled(" (Tab)", Style::default().fg(Color::DarkGray)),
+            Span::raw("  Logic: "),
+            Span::styled(
+                format!("[{}]", logic),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" (o)", Style::default().fg(Color::DarkGray)),
         ]),
         Line::from(""),
     ];
 
-    for (i, (name, val, checked)) in ff.fields.iter().enumerate() {
+    // Calculate visible window for scrolling
+    let max_visible = (height as usize).saturating_sub(6); // header + footer lines
+    let scroll_offset = if ff.cursor >= max_visible {
+        ff.cursor - max_visible + 1
+    } else {
+        0
+    };
+    let visible_end = (scroll_offset + max_visible).min(ff.fields.len());
+
+    for i in scroll_offset..visible_end {
+        let (name, val, checked) = &ff.fields[i];
         let checkbox = if *checked { "[x]" } else { "[ ]" };
         let is_cursor = i == ff.cursor;
         let style = if is_cursor {
@@ -453,22 +472,42 @@ fn render_field_filter_overlay(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             Style::default()
         };
+        // Truncate value to fit
+        let max_val = (width as usize).saturating_sub(22);
+        let display_val = if val.len() > max_val {
+            format!("{}…", &val[..max_val.saturating_sub(1)])
+        } else {
+            val.clone()
+        };
         lines.push(Line::styled(
-            format!(" {} {:<12} = {}", checkbox, name, val),
+            format!(" {} {:<14} = {}", checkbox, name, display_val),
             style,
+        ));
+    }
+
+    if ff.fields.len() > max_visible {
+        lines.push(Line::styled(
+            format!(" ({}/{})", ff.cursor + 1, ff.fields.len()),
+            Style::default().fg(Color::DarkGray),
         ));
     }
 
     lines.push(Line::from(""));
     lines.push(Line::styled(
-        " Enter: Apply  Esc: Cancel  Space: Toggle  Tab: Action",
+        " Enter: Apply  Esc: Cancel  Space: Toggle",
         Style::default().fg(Color::DarkGray),
     ));
+
+    let title = if ff.exclude {
+        " Exclude Fields (Ctrl+-) "
+    } else {
+        " Include Fields (Ctrl++) "
+    };
 
     let dialog = Paragraph::new(lines)
         .block(
             Block::default()
-                .title(" Quick Filter ")
+                .title(title)
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(Color::Cyan)),
         )
@@ -524,7 +563,7 @@ fn render_filter_manager_overlay(frame: &mut Frame, app: &App, area: Rect) {
     let dialog = Paragraph::new(lines)
         .block(
             Block::default()
-                .title(" Filter Manager (Ctrl+F) ")
+                .title(" Filter Manager (F) ")
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(Color::Cyan)),
         )


### PR DESCRIPTION
## Summary

Implements #74 — Filter Interaction Update per 兔总 feedback.

Closes #74

### Keybinding Changes

| Old | New | Function |
|-----|-----|----------|
| `F` | `Ctrl+-` | Exclude field dialog |
| — | `Ctrl++` | Include field dialog |
| `Ctrl+F` | `F` | Filter management panel |
| `Ctrl+F` | removed | — |

### Field Dialog (Ctrl+-/Ctrl++)

Shared dialog component, differs only in initial action:

```
┌─ Exclude Fields (Ctrl+-) ──────────────────────┐
│ Action: [Exclude] (Tab)  Logic: [OR] (o)       │
│                                                  │
│ [ ] timestamp      = 2026-02-20 15:30:00.123    │
│ [x] level          = ERROR                       │
│ [ ] source         = syslog                      │
│ [ ] process_name   = myapp                       │
│ [ ] pid            = 1234                        │
│ [x] tid            = 5678                        │
│ [ ] component      = auth                        │
│ [ ] message        = connection timeout          │
│ [ ] env            = prod           (metadata)   │
│                                                  │
│ Enter: Apply  Esc: Cancel  Space: Toggle         │
└──────────────────────────────────────────────────┘
```

- **ALL fields**: Timestamp, Level, Source, ProcessName, PID, TID, Component, Message + metadata
- **OR/AND toggle** (`o` key, default OR)
- **Tab** toggles Exclude/Include
- **PageUp/PageDown** scrolling for long field lists

### All Dialogs

Now support `j/k/↑/↓` + `PageUp/PageDown` navigation.

### Tests
233 total (5 new field filter v2 tests: all fields, include mode, OR/AND logic, metadata fields)