### PR TITLE
feat: complete help overlay with all keybindings

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -1053,6 +1053,16 @@ mod tests {
         assert!(ff.fields.iter().any(|(name, _, _)| name == "level"));
         assert!(ff.fields.iter().any(|(name, _, _)| name == "process_name"));
     }
+
+    #[test]
+    fn test_help_mode_toggle() {
+        let mut app = make_app(3);
+        assert_eq!(app.input_mode, InputMode::Normal);
+        app.input_mode = InputMode::Help;
+        assert_eq!(app.input_mode, InputMode::Help);
+        app.input_mode = InputMode::Normal;
+        assert_eq!(app.input_mode, InputMode::Normal);
+    }
 }
 
 #[cfg(test)]

--- a/crates/scouty-tui/src/ui.rs
+++ b/crates/scouty-tui/src/ui.rs
@@ -369,13 +369,22 @@ fn render_input_footer(
 }
 
 fn render_help_overlay(frame: &mut Frame, area: Rect) {
-    let width = 55u16.min(area.width.saturating_sub(4));
-    let height = 22u16.min(area.height.saturating_sub(4));
+    let width = 58u16.min(area.width.saturating_sub(4));
+    let height = 36u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(width)) / 2;
     let y = (area.height.saturating_sub(height)) / 2;
     let overlay = Rect::new(x, y, width, height);
 
     frame.render_widget(Clear, overlay);
+
+    let section = |title: &str| {
+        Line::styled(
+            format!(" {title}"),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+    };
 
     let help_text = vec![
         Line::styled(
@@ -385,23 +394,30 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
                 .add_modifier(Modifier::BOLD),
         ),
         Line::from(""),
-        Line::from(" Navigation"),
-        Line::from("  j / k            Move up/down one row"),
-        Line::from("  Ctrl+j/k/↑/↓    Page jump (half screen)"),
-        Line::from("  g                Jump to first row"),
-        Line::from("  G                Jump to last row"),
+        section("Navigation"),
+        Line::from("  j / ↓            Move down one row"),
+        Line::from("  k / ↑            Move up one row"),
+        Line::from("  Ctrl+j/k / PgDn  Page down / up"),
+        Line::from("  g / Home         Jump to first row"),
+        Line::from("  G / End          Jump to last row"),
         Line::from("  Ctrl+G           Go to line number"),
+        Line::from("  t                Jump to timestamp"),
+        Line::from("  Ctrl+]           Toggle follow mode"),
         Line::from(""),
-        Line::from(" Actions"),
-        Line::from("  Enter            Toggle detail panel"),
-        Line::from("  f                Filter expression"),
+        section("Search & Filter"),
         Line::from("  /                Search (regex)"),
-        Line::from("  n / N            Next / prev match"),
-        Line::from("  t                Jump to time"),
-        Line::from("  ?                Show this help"),
+        Line::from("  n / N            Next / prev search match"),
+        Line::from("  f                Filter expression"),
+        Line::from("  - / +            Quick exclude / include"),
+        Line::from("  Ctrl+F           Filter manager"),
         Line::from(""),
-        Line::from(" General"),
-        Line::from("  Esc              Close dialog/panel"),
+        section("Display"),
+        Line::from("  Enter            Toggle detail panel"),
+        Line::from("  Ctrl+C           Column selector"),
+        Line::from(""),
+        section("General"),
+        Line::from("  ?                Show this help"),
+        Line::from("  Esc              Close dialog / panel"),
         Line::from("  q                Quit"),
     ];
 


### PR DESCRIPTION
## Summary

Updated the `?` help overlay to show all current keybindings, organized by category:

- **Navigation**: j/k, Ctrl+j/k, g/G, Ctrl+G, t, Ctrl+]
- **Search & Filter**: /, n/N, f, -/+, Ctrl+F
- **Display**: Enter, Ctrl+C
- **General**: ?, Esc, q

Added color-styled section headers for better readability.

### Tests
36 tests passing ✅ (1 new test added)

Closes #68