### PR TITLE
fix: improve Ctrl+-/+ key detection across terminals

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -69,11 +69,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             KeyCode::Char(']') => {
                                 app.toggle_follow();
                             }
-                            KeyCode::Char('-') => {
-                                app.open_field_filter(true); // Ctrl+- = exclude
+                            // Ctrl+- = exclude field filter
+                            // Some terminals send Char('-'), others Char('\x1f') (ASCII 31)
+                            KeyCode::Char('-') | KeyCode::Char('\x1f') => {
+                                app.open_field_filter(true);
                             }
-                            KeyCode::Char('+') => {
-                                app.open_field_filter(false); // Ctrl++ = include
+                            // Ctrl++ = include field filter
+                            // '+' requires Shift on most keyboards, so also accept Ctrl+=
+                            KeyCode::Char('+') | KeyCode::Char('=') => {
+                                app.open_field_filter(false);
                             }
                             _ => {}
                         }


### PR DESCRIPTION
Closes #79

## Problem
`Ctrl+-` and `Ctrl++` field filter shortcuts do not work in some terminal emulators.

## Root Cause
Terminal emulators send different key codes for `Ctrl+-` and `Ctrl++`:
- **Ctrl+-**: Some terminals send `Char('-')` with CONTROL modifier, others send `Char('\x1f')` (ASCII 31 = Unit Separator)
- **Ctrl++**: The `+` key requires Shift on most keyboards, so users actually press `Ctrl+Shift+=`. Some terminals deliver this as `Char('+')`, others as `Char('=')` with modifiers

## Fix
- `Ctrl+-` (exclude): match both `Char('-')` and `Char('\x1f')`
- `Ctrl++` (include): match both `Char('+')` and `Char('=')`

246 tests, all pass.