### PR TITLE
fix: syslog regex parser — hostname shown as process name

### DIFF
--- a/crates/scouty/src/parser/factory.rs
+++ b/crates/scouty/src/parser/factory.rs
@@ -56,7 +56,7 @@ impl ParserFactory {
         // BSD syslog format: "Jan 15 10:30:00 hostname process[pid]: message"
         if let Ok(p) = RegexParser::new(
             "syslog-bsd",
-            r"^(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?P<process>\S+)\s+(?P<component>\S+?)(?:\[(?P<pid>\d+)\])?:\s+(?P<message>.*)",
+            r"^(?P<timestamp>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+(?P<hostname>\S+)\s+(?P<process>\S+?)(?:\[(?P<pid>\d+)\])?:\s+(?P<message>.*)",
             Some("%b %d %H:%M:%S".to_string()),
         ) {
             group.add_parser(Box::new(p));

--- a/crates/scouty/src/parser/factory_tests.rs
+++ b/crates/scouty/src/parser/factory_tests.rs
@@ -74,8 +74,17 @@ mod tests {
                 3,
             )
             .unwrap();
-        assert_eq!(record.component_name.as_deref(), Some("sshd"));
+        assert_eq!(record.process_name.as_deref(), Some("sshd"));
         assert_eq!(record.pid, Some(1234));
+        // hostname should be in metadata
+        assert_eq!(
+            record
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("hostname"))
+                .map(|s| s.as_str()),
+            Some("myhost")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #81

## Bug
Process name column showed the machine hostname instead of the actual process name.

## Root Cause
The `syslog-bsd` regex pattern in `ParserFactory` had swapped named groups:

```
Before: (?P<process>\S+)\s+(?P<component>\S+?)(?:\[(?P<pid>\d+)\])?
         ^hostname^          ^process name^
```

`process` → `process_name` field, so hostname ended up as process name.

## Fix
```
After:  (?P<hostname>\S+)\s+(?P<process>\S+?)(?:\[(?P<pid>\d+)\])?
        ^hostname→metadata^  ^process→process_name^
```

- `hostname` → stored in metadata (extra group)
- `process` → correctly maps to `process_name`
- The zero-regex `SyslogParser` was already correct; only the regex fallback was affected

## Tests
Updated `test_syslog_detection` to verify correct field mapping + hostname in metadata.
246 total tests.