### PR TITLE
fix: release pipeline — add write permission for version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
   bump-version:
     name: Bump Version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.bump.outputs.version }}
       tag: ${{ steps.bump.outputs.tag }}


### PR DESCRIPTION
## Problem
Release workflow fails at `git push origin master --tags` with 403:
```
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/r12f/scouty/': The requested URL returned error: 403
```

## Root Cause
The `bump-version` job uses the default `GITHUB_TOKEN` which has read-only `contents` permission. Pushing commits and tags requires `contents: write`.

## Fix
Add `permissions: contents: write` to the `bump-version` job. The `release` job already had this permission.