### PR TITLE
fix: add version to scouty-tui dependency for crates.io publish

### DIFF
--- a/crates/scouty-tui/Cargo.toml
+++ b/crates/scouty-tui/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Terminal UI for scouty log viewer"
 
 [dependencies]
-scouty = { path = "../scouty" }
+scouty = { path = "../scouty", version = "0.1.2" }
 chrono = "0.4"
 ratatui = "0.29"
 crossterm = "0.28"


### PR DESCRIPTION
## Problem
Release pipeline fails at `cargo publish -p scouty-tui`:
```
dependency `scouty` does not specify a version
```

## Fix
Add `version = "0.1.2"` to the scouty dependency in `crates/scouty-tui/Cargo.toml`:
```toml
scouty = { path = "../scouty", version = "0.1.2" }
```
Local dev uses `path`, crates.io publish uses `version`.