### PR TITLE
feat: migrate all TUI persistent widgets to UiComponent

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -334,6 +334,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 InputMode::Help => {
+                    use ui::windows::help_window::HelpWindow;
+                    let mut window = HelpWindow;
+                    ui::dispatch_key(&mut window, key);
                     app.input_mode = InputMode::Normal;
                 }
             }

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
@@ -1,0 +1,126 @@
+//! Detail panel widget — expanded view of the selected log record.
+
+#[cfg(test)]
+#[path = "detail_panel_widget_tests.rs"]
+mod detail_panel_widget_tests;
+
+use crate::app::App;
+use crate::ui::UiComponent;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use ratatui::Frame;
+use scouty::record::LogLevel;
+
+fn level_style(level: Option<LogLevel>) -> Style {
+    match level {
+        Some(LogLevel::Fatal) => Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        Some(LogLevel::Error) => Style::default().fg(Color::Red),
+        Some(LogLevel::Warn) => Style::default().fg(Color::Yellow),
+        Some(LogLevel::Notice) => Style::default().fg(Color::Cyan),
+        Some(LogLevel::Info) => Style::default().fg(Color::Green),
+        Some(LogLevel::Debug) => Style::default().fg(Color::Gray),
+        Some(LogLevel::Trace) => Style::default().fg(Color::DarkGray),
+        None => Style::default(),
+    }
+}
+
+pub struct DetailPanelWidget;
+
+impl DetailPanelWidget {
+    pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
+        let block = Block::default()
+            .title(" Detail ")
+            .borders(Borders::TOP)
+            .border_style(Style::default().fg(Color::DarkGray));
+
+        if let Some(record) = app.selected_record() {
+            let mut lines = vec![
+                Line::from(vec![
+                    Span::styled("Timestamp: ", Style::default().fg(Color::Cyan)),
+                    Span::raw(record.timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string()),
+                ]),
+                Line::from(vec![
+                    Span::styled("Level:     ", Style::default().fg(Color::Cyan)),
+                    Span::styled(
+                        record
+                            .level
+                            .map(|l| l.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                        level_style(record.level),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("Source:    ", Style::default().fg(Color::Cyan)),
+                    Span::raw(record.source.as_ref()),
+                ]),
+            ];
+
+            if let Some(ref host) = record.hostname {
+                lines.push(Line::from(vec![
+                    Span::styled("Hostname:  ", Style::default().fg(Color::Cyan)),
+                    Span::raw(host),
+                ]));
+            }
+            if let Some(ref ctr) = record.container {
+                lines.push(Line::from(vec![
+                    Span::styled("Container: ", Style::default().fg(Color::Cyan)),
+                    Span::raw(ctr),
+                ]));
+            }
+            if let Some(ref comp) = record.component_name {
+                lines.push(Line::from(vec![
+                    Span::styled("Component: ", Style::default().fg(Color::Cyan)),
+                    Span::raw(comp),
+                ]));
+            }
+            if let Some(ref proc_name) = record.process_name {
+                lines.push(Line::from(vec![
+                    Span::styled("Process:   ", Style::default().fg(Color::Cyan)),
+                    Span::raw(proc_name),
+                ]));
+            }
+            if let Some(pid) = record.pid {
+                lines.push(Line::from(vec![
+                    Span::styled("PID:       ", Style::default().fg(Color::Cyan)),
+                    Span::raw(pid.to_string()),
+                ]));
+            }
+            if let Some(tid) = record.tid {
+                lines.push(Line::from(vec![
+                    Span::styled("TID:       ", Style::default().fg(Color::Cyan)),
+                    Span::raw(tid.to_string()),
+                ]));
+            }
+
+            if record.metadata.as_ref().is_some_and(|m| !m.is_empty()) {
+                lines.push(Line::from(""));
+                lines.push(Line::styled("Metadata:", Style::default().fg(Color::Cyan)));
+                for (k, v) in record.metadata.as_ref().unwrap() {
+                    lines.push(Line::from(format!("  {} = {}", k, v)));
+                }
+            }
+
+            lines.push(Line::from(""));
+            lines.push(Line::styled("Message:", Style::default().fg(Color::Cyan)));
+            lines.push(Line::from(record.message.clone()));
+
+            let detail = Paragraph::new(lines)
+                .block(block)
+                .wrap(Wrap { trim: false });
+            frame.render_widget(detail, area);
+        } else {
+            let empty = Paragraph::new("No record selected").block(block);
+            frame.render_widget(empty, area);
+        }
+    }
+}
+
+impl UiComponent for DetailPanelWidget {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {}
+
+    fn enable_jk_navigation(&self) -> bool {
+        false
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::widgets::detail_panel_widget::DetailPanelWidget;
+    use crate::ui::UiComponent;
+
+    #[test]
+    fn test_enable_jk_navigation() {
+        let widget = DetailPanelWidget;
+        assert!(!widget.enable_jk_navigation());
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/filter_input_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/filter_input_widget.rs
@@ -1,0 +1,55 @@
+//! Filter input widget — f filter expression bar.
+
+#[cfg(test)]
+#[path = "filter_input_widget_tests.rs"]
+mod filter_input_widget_tests;
+
+use crate::app::App;
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+pub struct FilterInputWidget;
+
+impl FilterInputWidget {
+    pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
+        let input_line = Paragraph::new(Line::from(vec![
+            Span::styled("Filter: ", Style::default().fg(Color::Yellow)),
+            Span::raw(&app.filter_input),
+            Span::styled("█", Style::default().fg(Color::White)),
+        ]));
+        frame.render_widget(input_line, area);
+
+        if let Some(ref err) = app.filter_error {
+            if area.height > 1 {
+                let err_area = Rect::new(area.x, area.y + 1, area.width, 1);
+                let err_line =
+                    Paragraph::new(Span::styled(err.as_str(), Style::default().fg(Color::Red)));
+                frame.render_widget(err_line, err_area);
+            }
+        }
+    }
+}
+
+impl UiComponent for FilterInputWidget {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {}
+
+    fn enable_jk_navigation(&self) -> bool {
+        false
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, _c: char) -> ComponentResult {
+        ComponentResult::Consumed
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/filter_input_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/filter_input_widget_tests.rs
@@ -1,0 +1,29 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::widgets::filter_input_widget::FilterInputWidget;
+    use crate::ui::{ComponentResult, UiComponent};
+
+    #[test]
+    fn test_enable_jk_navigation_false() {
+        let widget = FilterInputWidget;
+        assert!(!widget.enable_jk_navigation());
+    }
+
+    #[test]
+    fn test_on_char_consumed() {
+        let mut widget = FilterInputWidget;
+        assert_eq!(widget.on_char('x'), ComponentResult::Consumed);
+    }
+
+    #[test]
+    fn test_on_cancel_closes() {
+        let mut widget = FilterInputWidget;
+        assert_eq!(widget.on_cancel(), ComponentResult::Close);
+    }
+
+    #[test]
+    fn test_on_confirm_closes() {
+        let mut widget = FilterInputWidget;
+        assert_eq!(widget.on_confirm(), ComponentResult::Close);
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
@@ -1,0 +1,140 @@
+//! Log table widget — main scrollable log table.
+
+#[cfg(test)]
+#[path = "log_table_widget_tests.rs"]
+mod log_table_widget_tests;
+
+use crate::app::{App, Column};
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Cell, Row, Table};
+use ratatui::Frame;
+use scouty::record::LogLevel;
+
+fn level_style(level: Option<LogLevel>) -> Style {
+    match level {
+        Some(LogLevel::Fatal) => Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        Some(LogLevel::Error) => Style::default().fg(Color::Red),
+        Some(LogLevel::Warn) => Style::default().fg(Color::Yellow),
+        Some(LogLevel::Notice) => Style::default().fg(Color::Cyan),
+        Some(LogLevel::Info) => Style::default().fg(Color::Green),
+        Some(LogLevel::Debug) => Style::default().fg(Color::Gray),
+        Some(LogLevel::Trace) => Style::default().fg(Color::DarkGray),
+        None => Style::default(),
+    }
+}
+
+pub struct LogTableWidget;
+
+impl LogTableWidget {
+    pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
+        let visible = app.visible_records();
+        let cw = &app.col_widths;
+        let vis_cols = app.column_config.visible_columns();
+
+        let widths: Vec<Constraint> = vis_cols
+            .iter()
+            .map(|col| match col {
+                Column::Time => Constraint::Length(cw[0]),
+                Column::Level => Constraint::Length(cw[1]),
+                Column::Hostname => Constraint::Length(20),
+                Column::Container => Constraint::Length(15),
+                Column::ProcessName => Constraint::Length(cw[2]),
+                Column::Pid => Constraint::Length(cw[3]),
+                Column::Tid => Constraint::Length(cw[4]),
+                Column::Component => Constraint::Length(cw[5]),
+                Column::Source => Constraint::Length(15),
+                Column::Log => Constraint::Fill(1),
+            })
+            .collect();
+
+        let header_cells: Vec<Cell> = vis_cols
+            .iter()
+            .map(|col| Cell::from(col.label()).style(Style::default().add_modifier(Modifier::BOLD)))
+            .collect();
+
+        let header =
+            Row::new(header_cells).style(Style::default().bg(Color::DarkGray).fg(Color::White));
+
+        let rows: Vec<Row> = visible
+            .iter()
+            .enumerate()
+            .map(|(i, record)| {
+                let filtered_idx = app.scroll_offset + i;
+                let is_selected = filtered_idx == app.selected;
+                let is_match = app.is_search_match(filtered_idx);
+                let row_style = level_style(record.level);
+
+                let cells: Vec<Cell> = vis_cols
+                    .iter()
+                    .map(|col| match col {
+                        Column::Time => {
+                            Cell::from(record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string())
+                        }
+                        Column::Level => {
+                            Cell::from(record.level.map(|l| format!("{}", l)).unwrap_or_default())
+                        }
+                        Column::Hostname => {
+                            Cell::from(record.hostname.as_deref().unwrap_or("").to_string())
+                        }
+                        Column::Container => {
+                            Cell::from(record.container.as_deref().unwrap_or("").to_string())
+                        }
+                        Column::ProcessName => {
+                            Cell::from(record.process_name.as_deref().unwrap_or("").to_string())
+                        }
+                        Column::Pid => {
+                            Cell::from(record.pid.map(|p| p.to_string()).unwrap_or_default())
+                        }
+                        Column::Tid => {
+                            Cell::from(record.tid.map(|t| t.to_string()).unwrap_or_default())
+                        }
+                        Column::Component => {
+                            Cell::from(record.component_name.as_deref().unwrap_or("").to_string())
+                        }
+                        Column::Source => Cell::from(record.source.to_string()),
+                        Column::Log => Cell::from(record.message.clone()),
+                    })
+                    .collect();
+
+                let mut row = Row::new(cells).style(row_style);
+                if is_selected && is_match {
+                    row = row.style(row_style.bg(Color::Rgb(120, 120, 0)));
+                } else if is_selected {
+                    row = row.style(row_style.bg(Color::Rgb(40, 40, 60)));
+                } else if is_match {
+                    row = row.style(row_style.bg(Color::Rgb(80, 80, 0)));
+                }
+                row
+            })
+            .collect();
+
+        let table = Table::new(rows, widths).header(header).column_spacing(1);
+        frame.render_widget(table, area);
+    }
+}
+
+impl UiComponent for LogTableWidget {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {}
+
+    fn enable_jk_navigation(&self) -> bool {
+        true
+    }
+
+    fn on_up(&mut self) -> ComponentResult {
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        ComponentResult::Consumed
+    }
+
+    fn on_page_up(&mut self) -> ComponentResult {
+        ComponentResult::Consumed
+    }
+
+    fn on_page_down(&mut self) -> ComponentResult {
+        ComponentResult::Consumed
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/log_table_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/log_table_widget_tests.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::widgets::log_table_widget::LogTableWidget;
+    use crate::ui::{ComponentResult, UiComponent};
+
+    #[test]
+    fn test_enable_jk_navigation_true() {
+        let widget = LogTableWidget;
+        assert!(widget.enable_jk_navigation());
+    }
+
+    #[test]
+    fn test_on_up_consumed() {
+        let mut widget = LogTableWidget;
+        assert_eq!(widget.on_up(), ComponentResult::Consumed);
+    }
+
+    #[test]
+    fn test_on_down_consumed() {
+        let mut widget = LogTableWidget;
+        assert_eq!(widget.on_down(), ComponentResult::Consumed);
+    }
+
+    #[test]
+    fn test_on_page_up_consumed() {
+        let mut widget = LogTableWidget;
+        assert_eq!(widget.on_page_up(), ComponentResult::Consumed);
+    }
+
+    #[test]
+    fn test_on_page_down_consumed() {
+        let mut widget = LogTableWidget;
+        assert_eq!(widget.on_page_down(), ComponentResult::Consumed);
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/mod.rs
+++ b/crates/scouty-tui/src/ui/widgets/mod.rs
@@ -1,1 +1,7 @@
 //! Persistent widget components (always present in the layout).
+
+pub mod detail_panel_widget;
+pub mod filter_input_widget;
+pub mod log_table_widget;
+pub mod search_input_widget;
+pub mod status_bar_widget;

--- a/crates/scouty-tui/src/ui/widgets/search_input_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/search_input_widget.rs
@@ -1,0 +1,46 @@
+//! Search input widget — / search bar.
+
+#[cfg(test)]
+#[path = "search_input_widget_tests.rs"]
+mod search_input_widget_tests;
+
+use crate::app::App;
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+pub struct SearchInputWidget;
+
+impl SearchInputWidget {
+    pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
+        let input_line = Paragraph::new(Line::from(vec![
+            Span::styled("/", Style::default().fg(Color::Yellow)),
+            Span::raw(&app.search_input),
+            Span::styled("█", Style::default().fg(Color::White)),
+        ]));
+        frame.render_widget(input_line, area);
+    }
+}
+
+impl UiComponent for SearchInputWidget {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {}
+
+    fn enable_jk_navigation(&self) -> bool {
+        false
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, _c: char) -> ComponentResult {
+        ComponentResult::Consumed
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/search_input_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/search_input_widget_tests.rs
@@ -1,0 +1,29 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::widgets::search_input_widget::SearchInputWidget;
+    use crate::ui::{ComponentResult, UiComponent};
+
+    #[test]
+    fn test_enable_jk_navigation_false() {
+        let widget = SearchInputWidget;
+        assert!(!widget.enable_jk_navigation());
+    }
+
+    #[test]
+    fn test_on_char_consumed() {
+        let mut widget = SearchInputWidget;
+        assert_eq!(widget.on_char('a'), ComponentResult::Consumed);
+    }
+
+    #[test]
+    fn test_on_cancel_closes() {
+        let mut widget = SearchInputWidget;
+        assert_eq!(widget.on_cancel(), ComponentResult::Close);
+    }
+
+    #[test]
+    fn test_on_confirm_closes() {
+        let mut widget = SearchInputWidget;
+        assert_eq!(widget.on_confirm(), ComponentResult::Close);
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -1,0 +1,100 @@
+//! Status bar widget — bottom bar with density chart and position info.
+
+#[cfg(test)]
+#[path = "status_bar_widget_tests.rs"]
+mod status_bar_widget_tests;
+
+use crate::app::App;
+use crate::ui::UiComponent;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use ratatui::Frame;
+
+/// Persistent status bar at the bottom of the screen.
+pub struct StatusBarWidget;
+
+impl StatusBarWidget {
+    /// Render the status bar with app context.
+    pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
+        let position = if app.total() == 0 {
+            format!("0/0 (Total: {})", app.total_records)
+        } else {
+            let current = app.selected + 1;
+            let filtered = app.total();
+            let total = app.total_records;
+            if filtered == total {
+                format!("{}/{}", current, total)
+            } else {
+                format!("{}/{} (Total: {})", current, filtered, total)
+            }
+        };
+
+        let follow_indicator = if app.follow_mode { " [FOLLOW]" } else { "" };
+        let mut right_text = format!(" {}{} ", position, follow_indicator);
+        if let Some(ref msg) = app.status_message {
+            right_text = format!(" {} │{}", msg, right_text);
+        }
+        let right_width = right_text.len() as u16 + 1;
+
+        let chart_width = area.width.saturating_sub(right_width + 3) as usize;
+
+        let mut spans: Vec<Span> = Vec::new();
+
+        if chart_width >= 4 && app.total() > 0 {
+            let timestamps: Vec<chrono::DateTime<chrono::Utc>> = app
+                .filtered_indices
+                .iter()
+                .map(|&i| app.records[i].timestamp)
+                .collect();
+
+            let num_buckets = (chart_width * 2).min(200);
+            let buckets = crate::density::compute_density(&timestamps, num_buckets);
+
+            let cursor_ts = app.selected_record().map(|r| r.timestamp);
+            let cursor_bucket = cursor_ts
+                .and_then(|ts| crate::density::cursor_bucket(ts, &timestamps, num_buckets));
+
+            let (braille_text, cursor_char_idx) =
+                crate::density::render_braille(&buckets, cursor_bucket);
+
+            for (i, ch) in braille_text.chars().enumerate() {
+                let style = if Some(i) == cursor_char_idx {
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .bg(Color::Rgb(40, 40, 60))
+                } else {
+                    Style::default().fg(Color::Cyan)
+                };
+                spans.push(Span::styled(ch.to_string(), style));
+            }
+
+            spans.push(Span::styled(" │", Style::default().fg(Color::DarkGray)));
+        }
+
+        if let Some(ref msg) = app.status_message {
+            spans.push(Span::styled(
+                format!(" {} │", msg),
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+        spans.push(Span::styled(
+            format!(" {}{} ", position, follow_indicator),
+            Style::default().fg(Color::White).bg(Color::DarkGray),
+        ));
+
+        let footer = Paragraph::new(Line::from(spans));
+        frame.render_widget(footer, area);
+    }
+}
+
+impl UiComponent for StatusBarWidget {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {
+        // No-op: use render_with_app() for app-aware rendering.
+    }
+
+    fn enable_jk_navigation(&self) -> bool {
+        false
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::widgets::status_bar_widget::StatusBarWidget;
+    use crate::ui::UiComponent;
+
+    #[test]
+    fn test_enable_jk_navigation() {
+        let widget = StatusBarWidget;
+        assert!(!widget.enable_jk_navigation());
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/column_selector_window.rs
+++ b/crates/scouty-tui/src/ui/windows/column_selector_window.rs
@@ -1,0 +1,128 @@
+//! Column selector dialog (c key).
+
+#[cfg(test)]
+#[path = "column_selector_window_tests.rs"]
+mod column_selector_window_tests;
+
+use crate::app::{App, Column};
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+/// Column selector overlay.
+#[allow(dead_code)]
+pub struct ColumnSelectorWindow {
+    pub cursor: usize,
+    pub columns: Vec<(Column, bool)>,
+}
+
+#[allow(dead_code)]
+impl ColumnSelectorWindow {
+    pub fn from_app(app: &App) -> Self {
+        Self {
+            cursor: app.column_config.cursor,
+            columns: app.column_config.columns.clone(),
+        }
+    }
+
+    pub fn sync_to_app(&self, app: &mut App) {
+        app.column_config.cursor = self.cursor;
+        app.column_config.columns = self.columns.clone();
+    }
+
+    fn toggle_current(&mut self) {
+        let cur = self.cursor;
+        if cur < self.columns.len() && self.columns[cur].0 != Column::Log {
+            self.columns[cur].1 = !self.columns[cur].1;
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl UiComponent for ColumnSelectorWindow {
+    fn render(&self, frame: &mut Frame, area: Rect) {
+        let width = 35u16.min(area.width.saturating_sub(4));
+        let height = (self.columns.len() as u16 + 5).min(area.height.saturating_sub(4));
+        let x = (area.width.saturating_sub(width)) / 2;
+        let y = (area.height.saturating_sub(height)) / 2;
+        let overlay = Rect::new(x, y, width, height);
+
+        frame.render_widget(Clear, overlay);
+
+        let mut lines = vec![
+            Line::styled(
+                " Toggle columns (Space/Enter)",
+                Style::default().fg(Color::DarkGray),
+            ),
+            Line::from(""),
+        ];
+
+        for (i, (col, visible)) in self.columns.iter().enumerate() {
+            let checkbox = if *visible { "[x]" } else { "[ ]" };
+            let is_cursor = i == self.cursor;
+            let suffix = if *col == Column::Log {
+                " (always on)"
+            } else {
+                ""
+            };
+            let style = if is_cursor {
+                Style::default().bg(Color::DarkGray).fg(Color::White)
+            } else {
+                Style::default()
+            };
+            lines.push(Line::styled(
+                format!(" {} {:<12}{}", checkbox, col.label(), suffix),
+                style,
+            ));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::styled(
+            " Esc: Close",
+            Style::default().fg(Color::DarkGray),
+        ));
+
+        let dialog = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .title(" Columns (c) ")
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            )
+            .style(Style::default().bg(Color::Black));
+        frame.render_widget(dialog, overlay);
+    }
+
+    fn enable_jk_navigation(&self) -> bool {
+        true
+    }
+
+    fn on_up(&mut self) -> ComponentResult {
+        self.cursor = self.cursor.saturating_sub(1);
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        if self.cursor + 1 < self.columns.len() {
+            self.cursor += 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_toggle(&mut self) -> ComponentResult {
+        self.toggle_current();
+        ComponentResult::Consumed
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        self.toggle_current();
+        ComponentResult::Consumed
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/column_selector_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/column_selector_window_tests.rs
@@ -1,0 +1,90 @@
+#[cfg(test)]
+mod tests {
+    use crate::app::Column;
+    use crate::ui::windows::column_selector_window::ColumnSelectorWindow;
+    use crate::ui::{dispatch_key, ComponentResult, UiComponent};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn sample_window() -> ColumnSelectorWindow {
+        ColumnSelectorWindow {
+            cursor: 0,
+            columns: vec![
+                (Column::Time, true),
+                (Column::Level, true),
+                (Column::Log, true),
+            ],
+        }
+    }
+
+    #[test]
+    fn test_navigation() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Down)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Up)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 0);
+    }
+
+    #[test]
+    fn test_toggle_space() {
+        let mut w = sample_window();
+        assert!(w.columns[0].1);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char(' '))),
+            ComponentResult::Consumed
+        );
+        assert!(!w.columns[0].1);
+    }
+
+    #[test]
+    fn test_toggle_enter() {
+        let mut w = sample_window();
+        assert!(w.columns[0].1);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Consumed
+        );
+        assert!(!w.columns[0].1);
+    }
+
+    #[test]
+    fn test_log_column_not_togglable() {
+        let mut w = sample_window();
+        w.cursor = 2;
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char(' '))),
+            ComponentResult::Consumed
+        );
+        assert!(w.columns[2].1);
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+    }
+
+    #[test]
+    fn test_jk_navigation() {
+        let mut w = sample_window();
+        assert!(w.enable_jk_navigation());
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('j'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/field_filter_window.rs
+++ b/crates/scouty-tui/src/ui/windows/field_filter_window.rs
@@ -1,0 +1,205 @@
+//! Field filter dialog (Ctrl+-/Ctrl++).
+
+#[cfg(test)]
+#[path = "field_filter_window_tests.rs"]
+mod field_filter_window_tests;
+
+use crate::app::App;
+use crate::ui::{ComponentResult, UiComponent};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+/// Field filter overlay — lets user select fields to include/exclude.
+#[allow(dead_code)]
+pub struct FieldFilterWindow {
+    pub fields: Vec<(String, String, bool)>,
+    pub cursor: usize,
+    pub exclude: bool,
+    pub logic_or: bool,
+    pub confirmed: bool,
+}
+
+#[allow(dead_code)]
+impl FieldFilterWindow {
+    pub fn from_app(app: &App) -> Option<Self> {
+        let ff = app.field_filter.as_ref()?;
+        Some(Self {
+            fields: ff.fields.clone(),
+            cursor: ff.cursor,
+            exclude: ff.exclude,
+            logic_or: ff.logic_or,
+            confirmed: false,
+        })
+    }
+
+    pub fn sync_to_app(&self, app: &mut App) {
+        if let Some(ref mut ff) = app.field_filter {
+            ff.fields = self.fields.clone();
+            ff.cursor = self.cursor;
+            ff.exclude = self.exclude;
+            ff.logic_or = self.logic_or;
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl UiComponent for FieldFilterWindow {
+    fn render(&self, frame: &mut Frame, area: Rect) {
+        let width = 60u16.min(area.width.saturating_sub(4));
+        let height = (self.fields.len() as u16 + 8).min(area.height.saturating_sub(4));
+        let x = (area.width.saturating_sub(width)) / 2;
+        let y = (area.height.saturating_sub(height)) / 2;
+        let overlay = Rect::new(x, y, width, height);
+
+        frame.render_widget(Clear, overlay);
+
+        let action = if self.exclude { "Exclude" } else { "Include" };
+        let logic = if self.logic_or { "OR" } else { "AND" };
+        let mut lines = vec![
+            Line::from(vec![
+                Span::raw(" Action: "),
+                Span::styled(
+                    format!("[{}]", action),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" (Tab)", Style::default().fg(Color::DarkGray)),
+                Span::raw("  Logic: "),
+                Span::styled(
+                    format!("[{}]", logic),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" (o)", Style::default().fg(Color::DarkGray)),
+            ]),
+            Line::from(""),
+        ];
+
+        let max_visible = (height as usize).saturating_sub(6);
+        let scroll_offset = if self.cursor >= max_visible {
+            self.cursor - max_visible + 1
+        } else {
+            0
+        };
+        let visible_end = (scroll_offset + max_visible).min(self.fields.len());
+
+        for i in scroll_offset..visible_end {
+            let (name, val, checked) = &self.fields[i];
+            let checkbox = if *checked { "[x]" } else { "[ ]" };
+            let is_cursor = i == self.cursor;
+            let style = if is_cursor {
+                Style::default().bg(Color::DarkGray).fg(Color::White)
+            } else {
+                Style::default()
+            };
+            let max_val = (width as usize).saturating_sub(22);
+            let display_val = if val.len() > max_val {
+                format!("{}…", &val[..max_val.saturating_sub(1)])
+            } else {
+                val.clone()
+            };
+            lines.push(Line::styled(
+                format!(" {} {:<14} = {}", checkbox, name, display_val),
+                style,
+            ));
+        }
+
+        if self.fields.len() > max_visible {
+            lines.push(Line::styled(
+                format!(" ({}/{})", self.cursor + 1, self.fields.len()),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::styled(
+            " Enter: Apply  Esc: Cancel  Space: Toggle",
+            Style::default().fg(Color::DarkGray),
+        ));
+
+        let title = if self.exclude {
+            " Exclude Fields (Ctrl+-) "
+        } else {
+            " Include Fields (Ctrl++) "
+        };
+
+        let dialog = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .title(title)
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            )
+            .style(Style::default().bg(Color::Black));
+        frame.render_widget(dialog, overlay);
+    }
+
+    fn enable_jk_navigation(&self) -> bool {
+        true
+    }
+
+    fn on_up(&mut self) -> ComponentResult {
+        self.cursor = self.cursor.saturating_sub(1);
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        if self.cursor + 1 < self.fields.len() {
+            self.cursor += 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_page_up(&mut self) -> ComponentResult {
+        self.cursor = self.cursor.saturating_sub(10);
+        ComponentResult::Consumed
+    }
+
+    fn on_page_down(&mut self) -> ComponentResult {
+        self.cursor = (self.cursor + 10).min(self.fields.len().saturating_sub(1));
+        ComponentResult::Consumed
+    }
+
+    fn on_toggle(&mut self) -> ComponentResult {
+        let cur = self.cursor;
+        if cur < self.fields.len() {
+            self.fields[cur].2 = !self.fields[cur].2;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        self.confirmed = true;
+        ComponentResult::Close
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        match c {
+            'o' => {
+                self.logic_or = !self.logic_or;
+                ComponentResult::Consumed
+            }
+            _ => ComponentResult::Ignored,
+        }
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> ComponentResult {
+        match key.code {
+            KeyCode::Tab => {
+                self.exclude = !self.exclude;
+                ComponentResult::Consumed
+            }
+            _ => ComponentResult::Ignored,
+        }
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/field_filter_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/field_filter_window_tests.rs
@@ -1,0 +1,108 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::windows::field_filter_window::FieldFilterWindow;
+    use crate::ui::{dispatch_key, ComponentResult, UiComponent};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn sample_window() -> FieldFilterWindow {
+        FieldFilterWindow {
+            fields: vec![
+                ("host".into(), "foo".into(), false),
+                ("level".into(), "error".into(), false),
+                ("pid".into(), "123".into(), false),
+            ],
+            cursor: 0,
+            exclude: true,
+            logic_or: false,
+            confirmed: false,
+        }
+    }
+
+    #[test]
+    fn test_navigation() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Down)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('j'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 2);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Down)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 2);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Up)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+    }
+
+    #[test]
+    fn test_toggle() {
+        let mut w = sample_window();
+        assert!(!w.fields[0].2);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char(' '))),
+            ComponentResult::Consumed
+        );
+        assert!(w.fields[0].2);
+    }
+
+    #[test]
+    fn test_tab_toggles_exclude() {
+        let mut w = sample_window();
+        assert!(w.exclude);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Tab)),
+            ComponentResult::Consumed
+        );
+        assert!(!w.exclude);
+    }
+
+    #[test]
+    fn test_o_toggles_logic() {
+        let mut w = sample_window();
+        assert!(!w.logic_or);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('o'))),
+            ComponentResult::Consumed
+        );
+        assert!(w.logic_or);
+    }
+
+    #[test]
+    fn test_enter_confirms() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+        assert!(w.confirmed);
+    }
+
+    #[test]
+    fn test_esc_cancels() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+        assert!(!w.confirmed);
+    }
+
+    #[test]
+    fn test_jk_navigation_enabled() {
+        let w = sample_window();
+        assert!(w.enable_jk_navigation());
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/filter_manager_window.rs
+++ b/crates/scouty-tui/src/ui/windows/filter_manager_window.rs
@@ -1,0 +1,178 @@
+//! Filter manager panel (F / Ctrl+F).
+
+#[cfg(test)]
+#[path = "filter_manager_window_tests.rs"]
+mod filter_manager_window_tests;
+
+use crate::app::App;
+use crate::ui::{ComponentResult, UiComponent};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+/// Filter manager overlay — shows active filters, allows deletion.
+#[allow(dead_code)]
+pub struct FilterManagerWindow {
+    pub cursor: usize,
+    pub filter_count: usize,
+    pub action: Option<&'static str>,
+}
+
+#[allow(dead_code)]
+impl FilterManagerWindow {
+    pub fn from_app(app: &App) -> Self {
+        Self {
+            cursor: app.filter_manager_cursor,
+            filter_count: app.filters.len(),
+            action: None,
+        }
+    }
+
+    pub fn render_with_app(&self, frame: &mut Frame, app: &App, area: Rect) {
+        let width = 55u16.min(area.width.saturating_sub(4));
+        let height = (app.filters.len() as u16 + 7)
+            .min(area.height.saturating_sub(4))
+            .max(8);
+        let x = (area.width.saturating_sub(width)) / 2;
+        let y = (area.height.saturating_sub(height)) / 2;
+        let overlay = Rect::new(x, y, width, height);
+
+        frame.render_widget(Clear, overlay);
+
+        let mut lines = vec![
+            Line::styled(
+                format!(" Active Filters ({})", app.filters.len()),
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Line::from(""),
+        ];
+
+        if app.filters.is_empty() {
+            lines.push(Line::styled(
+                " (no active filters)",
+                Style::default().fg(Color::DarkGray),
+            ));
+        } else {
+            for (i, filter) in app.filters.iter().enumerate() {
+                let is_cursor = i == self.cursor;
+                let prefix = if filter.exclude { "−" } else { "+" };
+                let style = if is_cursor {
+                    Style::default().bg(Color::DarkGray).fg(Color::White)
+                } else {
+                    Style::default()
+                };
+                lines.push(Line::styled(format!(" {} {}", prefix, filter.label), style));
+            }
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::styled(
+            " d: Delete  c: Clear all  Esc: Close",
+            Style::default().fg(Color::DarkGray),
+        ));
+
+        let dialog = Paragraph::new(lines)
+            .block(
+                Block::default()
+                    .title(" Filter Manager (F) ")
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Cyan)),
+            )
+            .style(Style::default().bg(Color::Black));
+        frame.render_widget(dialog, overlay);
+    }
+
+    pub fn apply_to_app(&self, app: &mut App) {
+        app.filter_manager_cursor = self.cursor;
+        match self.action {
+            Some("delete") => {
+                if !app.filters.is_empty() {
+                    let idx = self.cursor;
+                    app.remove_filter(idx);
+                    if app.filter_manager_cursor > 0
+                        && app.filter_manager_cursor >= app.filters.len()
+                    {
+                        app.filter_manager_cursor = app.filters.len().saturating_sub(1);
+                    }
+                }
+            }
+            Some("clear") => {
+                app.clear_filters();
+                app.filter_manager_cursor = 0;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl UiComponent for FilterManagerWindow {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {
+        // Use render_with_app instead
+    }
+
+    fn enable_jk_navigation(&self) -> bool {
+        true
+    }
+
+    fn on_up(&mut self) -> ComponentResult {
+        self.cursor = self.cursor.saturating_sub(1);
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        if self.filter_count > 0 && self.cursor + 1 < self.filter_count {
+            self.cursor += 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_page_up(&mut self) -> ComponentResult {
+        self.cursor = self.cursor.saturating_sub(10);
+        ComponentResult::Consumed
+    }
+
+    fn on_page_down(&mut self) -> ComponentResult {
+        if self.filter_count > 0 {
+            self.cursor = (self.cursor + 10).min(self.filter_count.saturating_sub(1));
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        match c {
+            'd' => {
+                self.action = Some("delete");
+                ComponentResult::Consumed
+            }
+            'c' => {
+                self.action = Some("clear");
+                ComponentResult::Consumed
+            }
+            _ => ComponentResult::Ignored,
+        }
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> ComponentResult {
+        match key.code {
+            KeyCode::Delete => {
+                self.action = Some("delete");
+                ComponentResult::Consumed
+            }
+            _ => ComponentResult::Ignored,
+        }
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/filter_manager_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/filter_manager_window_tests.rs
@@ -1,0 +1,87 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::windows::filter_manager_window::FilterManagerWindow;
+    use crate::ui::{dispatch_key, ComponentResult, UiComponent};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn sample_window() -> FilterManagerWindow {
+        FilterManagerWindow {
+            cursor: 0,
+            filter_count: 3,
+            action: None,
+        }
+    }
+
+    #[test]
+    fn test_navigation() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Down)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('j'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 2);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Down)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 2);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Up)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+    }
+
+    #[test]
+    fn test_delete() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('d'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.action, Some("delete"));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('c'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.action, Some("clear"));
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+    }
+
+    #[test]
+    fn test_enter_closes() {
+        let mut w = sample_window();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+    }
+
+    #[test]
+    fn test_jk_navigation_enabled() {
+        let w = sample_window();
+        assert!(w.enable_jk_navigation());
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/goto_line_window.rs
+++ b/crates/scouty-tui/src/ui/windows/goto_line_window.rs
@@ -1,0 +1,65 @@
+//! Go to line number dialog (Ctrl+G).
+
+#[cfg(test)]
+#[path = "goto_line_window_tests.rs"]
+mod goto_line_window_tests;
+
+use crate::ui::{ComponentResult, UiComponent};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::Rect;
+use ratatui::Frame;
+
+/// Minimal component for goto-line input mode.
+/// Actual rendering is in the footer (input bar), so render() is a no-op.
+#[allow(dead_code)]
+pub struct GotoLineWindow {
+    pub input: String,
+    pub confirmed: bool,
+}
+
+#[allow(dead_code)]
+impl GotoLineWindow {
+    pub fn new() -> Self {
+        Self {
+            input: String::new(),
+            confirmed: false,
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl UiComponent for GotoLineWindow {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {}
+
+    fn enable_jk_navigation(&self) -> bool {
+        false
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        self.confirmed = true;
+        ComponentResult::Close
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        if c.is_ascii_digit() {
+            self.input.push(c);
+            ComponentResult::Consumed
+        } else {
+            ComponentResult::Ignored
+        }
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> ComponentResult {
+        match key.code {
+            KeyCode::Backspace => {
+                self.input.pop();
+                ComponentResult::Consumed
+            }
+            _ => ComponentResult::Ignored,
+        }
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/goto_line_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/goto_line_window_tests.rs
@@ -1,0 +1,66 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::windows::goto_line_window::GotoLineWindow;
+    use crate::ui::{dispatch_key, ComponentResult};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_digit_input() {
+        let mut w = GotoLineWindow::new();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('1'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('5'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.input, "15");
+    }
+
+    #[test]
+    fn test_non_digit_ignored() {
+        let mut w = GotoLineWindow::new();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('a'))),
+            ComponentResult::Ignored
+        );
+        assert!(w.input.is_empty());
+    }
+
+    #[test]
+    fn test_enter_closes_and_confirms() {
+        let mut w = GotoLineWindow::new();
+        w.input = "42".to_string();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+        assert!(w.confirmed);
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let mut w = GotoLineWindow::new();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+        assert!(!w.confirmed);
+    }
+
+    #[test]
+    fn test_backspace() {
+        let mut w = GotoLineWindow::new();
+        w.input = "12".to_string();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Backspace)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.input, "1");
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/help_window.rs
+++ b/crates/scouty-tui/src/ui/windows/help_window.rs
@@ -1,0 +1,103 @@
+//! Help overlay window (? key).
+
+#[cfg(test)]
+#[path = "help_window_tests.rs"]
+mod help_window_tests;
+
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+/// Help overlay showing keyboard shortcuts.
+#[allow(dead_code)]
+pub struct HelpWindow;
+
+#[allow(dead_code)]
+impl UiComponent for HelpWindow {
+    fn render(&self, frame: &mut Frame, area: Rect) {
+        let width = 58u16.min(area.width.saturating_sub(4));
+        let height = 36u16.min(area.height.saturating_sub(4));
+        let x = (area.width.saturating_sub(width)) / 2;
+        let y = (area.height.saturating_sub(height)) / 2;
+        let overlay = Rect::new(x, y, width, height);
+
+        frame.render_widget(Clear, overlay);
+
+        let section = |title: &str| {
+            Line::styled(
+                format!(" {title}"),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+        };
+
+        let help_text = vec![
+            Line::styled(
+                " Keyboard Shortcuts ",
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Line::from(""),
+            section("Navigation"),
+            Line::from("  j / ↓            Move down one row"),
+            Line::from("  k / ↑            Move up one row"),
+            Line::from("  Ctrl+j/k / PgDn  Page down / up"),
+            Line::from("  g / Home         Jump to first row"),
+            Line::from("  G / End          Jump to last row"),
+            Line::from("  Ctrl+G           Go to line number"),
+            Line::from("  t                Jump to timestamp"),
+            Line::from("  Ctrl+]           Toggle follow mode"),
+            Line::from(""),
+            section("Search & Filter"),
+            Line::from("  /                Search (regex)"),
+            Line::from("  n / N            Next / prev search match"),
+            Line::from("  f                Filter expression"),
+            Line::from("  - / +            Quick exclude / include"),
+            Line::from("  Ctrl+F           Filter manager"),
+            Line::from(""),
+            section("Display"),
+            Line::from("  Enter            Toggle detail panel"),
+            Line::from("  Ctrl+C           Column selector"),
+            Line::from(""),
+            section("General"),
+            Line::from("  ?                Show this help"),
+            Line::from("  Esc              Close dialog / panel"),
+            Line::from("  q                Quit"),
+        ];
+
+        let help = Paragraph::new(help_text)
+            .block(
+                Block::default()
+                    .title(" Help ")
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Yellow)),
+            )
+            .style(Style::default().bg(Color::Black));
+        frame.render_widget(help, overlay);
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_key(&mut self, _key: crossterm::event::KeyEvent) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, _c: char) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_toggle(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/help_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/help_window_tests.rs
@@ -1,0 +1,37 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::windows::help_window::HelpWindow;
+    use crate::ui::{dispatch_key, ComponentResult};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let mut w = HelpWindow;
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+    }
+
+    #[test]
+    fn test_any_key_closes() {
+        let mut w = HelpWindow;
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('q'))),
+            ComponentResult::Close
+        );
+    }
+
+    #[test]
+    fn test_enter_closes() {
+        let mut w = HelpWindow;
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/mod.rs
+++ b/crates/scouty-tui/src/ui/windows/mod.rs
@@ -1,3 +1,8 @@
 //! Popup window components (dialogs that overlay the main view).
 
+pub mod column_selector_window;
 pub mod copy_format_window;
+pub mod field_filter_window;
+pub mod filter_manager_window;
+pub mod goto_line_window;
+pub mod help_window;

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -1,25 +1,7 @@
 //! UI rendering for the TUI.
 
 use crate::app::{App, InputMode};
-use ratatui::{
-    prelude::*,
-    widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap},
-};
-use scouty::record::LogLevel;
-
-/// Style a log line based on its level.
-fn level_style(level: Option<LogLevel>) -> Style {
-    match level {
-        Some(LogLevel::Fatal) => Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-        Some(LogLevel::Error) => Style::default().fg(Color::Red),
-        Some(LogLevel::Warn) => Style::default().fg(Color::Yellow),
-        Some(LogLevel::Notice) => Style::default().fg(Color::Cyan),
-        Some(LogLevel::Info) => Style::default().fg(Color::Green),
-        Some(LogLevel::Debug) => Style::default().fg(Color::Gray),
-        Some(LogLevel::Trace) => Style::default().fg(Color::DarkGray),
-        None => Style::default(),
-    }
-}
+use ratatui::{prelude::*, widgets::Paragraph};
 
 /// Render the full UI.
 pub fn render(frame: &mut Frame, app: &App) {
@@ -41,10 +23,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     let main_chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Min(1),                // body (table + optional detail)
-            Constraint::Length(footer_height), // footer
-        ])
+        .constraints([Constraint::Min(1), Constraint::Length(footer_height)])
         .split(area);
 
     // Body: log table + optional detail panel
@@ -63,22 +42,34 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     // Help overlay
     if app.input_mode == InputMode::Help {
-        render_help_overlay(frame, area);
+        use crate::ui::windows::help_window::HelpWindow;
+        use crate::ui::UiComponent;
+        let window = HelpWindow;
+        window.render(frame, area);
     }
 
     // Field filter overlay
     if app.input_mode == InputMode::FieldFilter {
-        render_field_filter_overlay(frame, app, area);
+        use crate::ui::windows::field_filter_window::FieldFilterWindow;
+        use crate::ui::UiComponent;
+        if let Some(window) = FieldFilterWindow::from_app(app) {
+            window.render(frame, area);
+        }
     }
 
     // Filter manager overlay
     if app.input_mode == InputMode::FilterManager {
-        render_filter_manager_overlay(frame, app, area);
+        use crate::ui::windows::filter_manager_window::FilterManagerWindow;
+        let window = FilterManagerWindow::from_app(app);
+        window.render_with_app(frame, app, area);
     }
 
     // Column selector overlay
     if app.input_mode == InputMode::ColumnSelector {
-        render_column_selector_overlay(frame, app, area);
+        use crate::ui::windows::column_selector_window::ColumnSelectorWindow;
+        use crate::ui::UiComponent;
+        let window = ColumnSelectorWindow::from_app(app);
+        window.render(frame, area);
     }
 
     if app.input_mode == InputMode::CopyFormat {
@@ -90,196 +81,28 @@ pub fn render(frame: &mut Frame, app: &App) {
 }
 
 fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {
-    use crate::app::Column;
-
-    let visible = app.visible_records();
-    let cw = &app.col_widths;
-    let vis_cols = app.column_config.visible_columns();
-
-    // Build column constraints based on visible columns
-    let widths: Vec<Constraint> = vis_cols
-        .iter()
-        .map(|col| match col {
-            Column::Time => Constraint::Length(cw[0]),
-            Column::Level => Constraint::Length(cw[1]),
-            Column::Hostname => Constraint::Length(20),
-            Column::Container => Constraint::Length(15),
-            Column::ProcessName => Constraint::Length(cw[2]),
-            Column::Pid => Constraint::Length(cw[3]),
-            Column::Tid => Constraint::Length(cw[4]),
-            Column::Component => Constraint::Length(cw[5]),
-            Column::Source => Constraint::Length(15),
-            Column::Log => Constraint::Fill(1),
-        })
-        .collect();
-
-    let header_cells: Vec<Cell> = vis_cols
-        .iter()
-        .map(|col| Cell::from(col.label()).style(Style::default().add_modifier(Modifier::BOLD)))
-        .collect();
-
-    let header =
-        Row::new(header_cells).style(Style::default().bg(Color::DarkGray).fg(Color::White));
-
-    let rows: Vec<Row> = visible
-        .iter()
-        .enumerate()
-        .map(|(i, record)| {
-            let filtered_idx = app.scroll_offset + i;
-            let is_selected = filtered_idx == app.selected;
-            let is_match = app.is_search_match(filtered_idx);
-
-            let row_style = level_style(record.level);
-
-            let cells: Vec<Cell> = vis_cols
-                .iter()
-                .map(|col| match col {
-                    Column::Time => {
-                        Cell::from(record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string())
-                    }
-                    Column::Level => {
-                        Cell::from(record.level.map(|l| format!("{}", l)).unwrap_or_default())
-                    }
-                    Column::Hostname => {
-                        Cell::from(record.hostname.as_deref().unwrap_or("").to_string())
-                    }
-                    Column::Container => {
-                        Cell::from(record.container.as_deref().unwrap_or("").to_string())
-                    }
-                    Column::ProcessName => {
-                        Cell::from(record.process_name.as_deref().unwrap_or("").to_string())
-                    }
-                    Column::Pid => {
-                        Cell::from(record.pid.map(|p| p.to_string()).unwrap_or_default())
-                    }
-                    Column::Tid => {
-                        Cell::from(record.tid.map(|t| t.to_string()).unwrap_or_default())
-                    }
-                    Column::Component => {
-                        Cell::from(record.component_name.as_deref().unwrap_or("").to_string())
-                    }
-                    Column::Source => Cell::from(record.source.to_string()),
-                    Column::Log => Cell::from(record.message.clone()),
-                })
-                .collect();
-
-            let mut row = Row::new(cells).style(row_style);
-            if is_selected && is_match {
-                row = row.style(row_style.bg(Color::Rgb(120, 120, 0)));
-            } else if is_selected {
-                row = row.style(row_style.bg(Color::Rgb(40, 40, 60)));
-            } else if is_match {
-                row = row.style(row_style.bg(Color::Rgb(80, 80, 0)));
-            }
-            row
-        })
-        .collect();
-
-    let table = Table::new(rows, widths).header(header).column_spacing(1);
-
-    frame.render_widget(table, area);
+    use crate::ui::widgets::log_table_widget::LogTableWidget;
+    let widget = LogTableWidget;
+    widget.render_with_app(frame, area, app);
 }
 
 fn render_detail_panel(frame: &mut Frame, app: &App, area: Rect) {
-    let block = Block::default()
-        .title(" Detail ")
-        .borders(Borders::TOP)
-        .border_style(Style::default().fg(Color::DarkGray));
-
-    if let Some(record) = app.selected_record() {
-        let mut lines = vec![
-            Line::from(vec![
-                Span::styled("Timestamp: ", Style::default().fg(Color::Cyan)),
-                Span::raw(record.timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string()),
-            ]),
-            Line::from(vec![
-                Span::styled("Level:     ", Style::default().fg(Color::Cyan)),
-                Span::styled(
-                    record
-                        .level
-                        .map(|l| l.to_string())
-                        .unwrap_or_else(|| "-".to_string()),
-                    level_style(record.level),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("Source:    ", Style::default().fg(Color::Cyan)),
-                Span::raw(record.source.as_ref()),
-            ]),
-        ];
-
-        if let Some(ref host) = record.hostname {
-            lines.push(Line::from(vec![
-                Span::styled("Hostname:  ", Style::default().fg(Color::Cyan)),
-                Span::raw(host),
-            ]));
-        }
-        if let Some(ref ctr) = record.container {
-            lines.push(Line::from(vec![
-                Span::styled("Container: ", Style::default().fg(Color::Cyan)),
-                Span::raw(ctr),
-            ]));
-        }
-        if let Some(ref comp) = record.component_name {
-            lines.push(Line::from(vec![
-                Span::styled("Component: ", Style::default().fg(Color::Cyan)),
-                Span::raw(comp),
-            ]));
-        }
-        if let Some(ref proc) = record.process_name {
-            lines.push(Line::from(vec![
-                Span::styled("Process:   ", Style::default().fg(Color::Cyan)),
-                Span::raw(proc),
-            ]));
-        }
-        if let Some(pid) = record.pid {
-            lines.push(Line::from(vec![
-                Span::styled("PID:       ", Style::default().fg(Color::Cyan)),
-                Span::raw(pid.to_string()),
-            ]));
-        }
-        if let Some(tid) = record.tid {
-            lines.push(Line::from(vec![
-                Span::styled("TID:       ", Style::default().fg(Color::Cyan)),
-                Span::raw(tid.to_string()),
-            ]));
-        }
-
-        if record.metadata.as_ref().is_some_and(|m| !m.is_empty()) {
-            lines.push(Line::from(""));
-            lines.push(Line::styled("Metadata:", Style::default().fg(Color::Cyan)));
-            for (k, v) in record.metadata.as_ref().unwrap() {
-                lines.push(Line::from(format!("  {} = {}", k, v)));
-            }
-        }
-
-        lines.push(Line::from(""));
-        lines.push(Line::styled("Message:", Style::default().fg(Color::Cyan)));
-        lines.push(Line::from(record.message.clone()));
-
-        let detail = Paragraph::new(lines)
-            .block(block)
-            .wrap(Wrap { trim: false });
-        frame.render_widget(detail, area);
-    } else {
-        let empty = Paragraph::new("No record selected").block(block);
-        frame.render_widget(empty, area);
-    }
+    use crate::ui::widgets::detail_panel_widget::DetailPanelWidget;
+    let widget = DetailPanelWidget;
+    widget.render_with_app(frame, area, app);
 }
 
 fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
     match app.input_mode {
         InputMode::Filter => {
-            render_input_footer(
-                frame,
-                area,
-                "Filter: ",
-                &app.filter_input,
-                app.filter_error.as_deref(),
-            );
+            use crate::ui::widgets::filter_input_widget::FilterInputWidget;
+            let widget = FilterInputWidget;
+            widget.render_with_app(frame, area, app);
         }
         InputMode::Search => {
-            render_input_footer(frame, area, "/", &app.search_input, None);
+            use crate::ui::widgets::search_input_widget::SearchInputWidget;
+            let widget = SearchInputWidget;
+            widget.render_with_app(frame, area, app);
         }
         InputMode::TimeJump => {
             render_input_footer(frame, area, "Jump to time: ", &app.time_input, None);
@@ -294,81 +117,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             render_input_footer(frame, area, "Include text: ", &app.quick_filter_input, None);
         }
         _ => {
-            // Status bar: density chart │ position info
-            let position = if app.total() == 0 {
-                format!("0/0 (Total: {})", app.total_records)
-            } else {
-                let current = app.selected + 1;
-                let filtered = app.total();
-                let total = app.total_records;
-                if filtered == total {
-                    format!("{}/{}", current, total)
-                } else {
-                    format!("{}/{} (Total: {})", current, filtered, total)
-                }
-            };
-
-            // Right side: position + optional follow indicator + status message
-            let follow_indicator = if app.follow_mode { " [FOLLOW]" } else { "" };
-            let mut right_text = format!(" {}{} ", position, follow_indicator);
-            if let Some(ref msg) = app.status_message {
-                right_text = format!(" {} │{}", msg, right_text);
-            }
-            let right_width = right_text.len() as u16 + 1; // +1 for separator
-
-            // Left side: density chart (adaptive width)
-            let chart_width = area.width.saturating_sub(right_width + 3) as usize; // 3 for " │ "
-
-            let mut spans: Vec<Span> = Vec::new();
-
-            if chart_width >= 4 && app.total() > 0 {
-                // Collect filtered timestamps
-                let timestamps: Vec<chrono::DateTime<chrono::Utc>> = app
-                    .filtered_indices
-                    .iter()
-                    .map(|&i| app.records[i].timestamp)
-                    .collect();
-
-                // 2 data points per braille char
-                let num_buckets = (chart_width * 2).min(200);
-                let buckets = crate::density::compute_density(&timestamps, num_buckets);
-
-                let cursor_ts = app.selected_record().map(|r| r.timestamp);
-                let cursor_bucket = cursor_ts
-                    .and_then(|ts| crate::density::cursor_bucket(ts, &timestamps, num_buckets));
-
-                let (braille_text, cursor_char_idx) =
-                    crate::density::render_braille(&buckets, cursor_bucket);
-
-                // Render braille with cursor highlight
-                for (i, ch) in braille_text.chars().enumerate() {
-                    let style = if Some(i) == cursor_char_idx {
-                        Style::default()
-                            .fg(Color::Yellow)
-                            .bg(Color::Rgb(40, 40, 60))
-                    } else {
-                        Style::default().fg(Color::Cyan)
-                    };
-                    spans.push(Span::styled(ch.to_string(), style));
-                }
-
-                spans.push(Span::styled(" │", Style::default().fg(Color::DarkGray)));
-            }
-
-            // Right side
-            if let Some(ref msg) = app.status_message {
-                spans.push(Span::styled(
-                    format!(" {} │", msg),
-                    Style::default().fg(Color::Yellow),
-                ));
-            }
-            spans.push(Span::styled(
-                format!(" {}{} ", position, follow_indicator),
-                Style::default().fg(Color::White).bg(Color::DarkGray),
-            ));
-
-            let footer = Paragraph::new(Line::from(spans));
-            frame.render_widget(footer, area);
+            use crate::ui::widgets::status_bar_widget::StatusBarWidget;
+            let widget = StatusBarWidget;
+            widget.render_with_app(frame, area, app);
         }
     }
 }
@@ -394,277 +145,4 @@ fn render_input_footer(
             frame.render_widget(err_line, err_area);
         }
     }
-}
-
-fn render_help_overlay(frame: &mut Frame, area: Rect) {
-    let width = 58u16.min(area.width.saturating_sub(4));
-    let height = 36u16.min(area.height.saturating_sub(4));
-    let x = (area.width.saturating_sub(width)) / 2;
-    let y = (area.height.saturating_sub(height)) / 2;
-    let overlay = Rect::new(x, y, width, height);
-
-    frame.render_widget(Clear, overlay);
-
-    let section = |title: &str| {
-        Line::styled(
-            format!(" {title}"),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )
-    };
-
-    let help_text = vec![
-        Line::styled(
-            " Keyboard Shortcuts ",
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Line::from(""),
-        section("Navigation"),
-        Line::from("  j / ↓            Move down one row"),
-        Line::from("  k / ↑            Move up one row"),
-        Line::from("  Ctrl+j/k / PgDn  Page down / up"),
-        Line::from("  g / Home         Jump to first row"),
-        Line::from("  G / End          Jump to last row"),
-        Line::from("  Ctrl+G           Go to line number"),
-        Line::from("  t                Jump to timestamp"),
-        Line::from("  Ctrl+]           Toggle follow mode"),
-        Line::from(""),
-        section("Search & Filter"),
-        Line::from("  /                Search (regex)"),
-        Line::from("  n / N            Next / prev search match"),
-        Line::from("  f                Filter expression"),
-        Line::from("  - / +            Quick exclude / include"),
-        Line::from("  Ctrl+F           Filter manager"),
-        Line::from(""),
-        section("Display"),
-        Line::from("  Enter            Toggle detail panel"),
-        Line::from("  Ctrl+C           Column selector"),
-        Line::from(""),
-        section("General"),
-        Line::from("  ?                Show this help"),
-        Line::from("  Esc              Close dialog / panel"),
-        Line::from("  q                Quit"),
-    ];
-
-    let help = Paragraph::new(help_text)
-        .block(
-            Block::default()
-                .title(" Help ")
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow)),
-        )
-        .style(Style::default().bg(Color::Black));
-    frame.render_widget(help, overlay);
-}
-
-fn render_field_filter_overlay(frame: &mut Frame, app: &App, area: Rect) {
-    let ff = match &app.field_filter {
-        Some(ff) => ff,
-        None => return,
-    };
-
-    let width = 60u16.min(area.width.saturating_sub(4));
-    let height = (ff.fields.len() as u16 + 8).min(area.height.saturating_sub(4));
-    let x = (area.width.saturating_sub(width)) / 2;
-    let y = (area.height.saturating_sub(height)) / 2;
-    let overlay = Rect::new(x, y, width, height);
-
-    frame.render_widget(Clear, overlay);
-
-    let action = if ff.exclude { "Exclude" } else { "Include" };
-    let logic = if ff.logic_or { "OR" } else { "AND" };
-    let mut lines = vec![
-        Line::from(vec![
-            Span::raw(" Action: "),
-            Span::styled(
-                format!("[{}]", action),
-                Style::default()
-                    .fg(Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" (Tab)", Style::default().fg(Color::DarkGray)),
-            Span::raw("  Logic: "),
-            Span::styled(
-                format!("[{}]", logic),
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" (o)", Style::default().fg(Color::DarkGray)),
-        ]),
-        Line::from(""),
-    ];
-
-    // Calculate visible window for scrolling
-    let max_visible = (height as usize).saturating_sub(6); // header + footer lines
-    let scroll_offset = if ff.cursor >= max_visible {
-        ff.cursor - max_visible + 1
-    } else {
-        0
-    };
-    let visible_end = (scroll_offset + max_visible).min(ff.fields.len());
-
-    for i in scroll_offset..visible_end {
-        let (name, val, checked) = &ff.fields[i];
-        let checkbox = if *checked { "[x]" } else { "[ ]" };
-        let is_cursor = i == ff.cursor;
-        let style = if is_cursor {
-            Style::default().bg(Color::DarkGray).fg(Color::White)
-        } else {
-            Style::default()
-        };
-        // Truncate value to fit
-        let max_val = (width as usize).saturating_sub(22);
-        let display_val = if val.len() > max_val {
-            format!("{}…", &val[..max_val.saturating_sub(1)])
-        } else {
-            val.clone()
-        };
-        lines.push(Line::styled(
-            format!(" {} {:<14} = {}", checkbox, name, display_val),
-            style,
-        ));
-    }
-
-    if ff.fields.len() > max_visible {
-        lines.push(Line::styled(
-            format!(" ({}/{})", ff.cursor + 1, ff.fields.len()),
-            Style::default().fg(Color::DarkGray),
-        ));
-    }
-
-    lines.push(Line::from(""));
-    lines.push(Line::styled(
-        " Enter: Apply  Esc: Cancel  Space: Toggle",
-        Style::default().fg(Color::DarkGray),
-    ));
-
-    let title = if ff.exclude {
-        " Exclude Fields (Ctrl+-) "
-    } else {
-        " Include Fields (Ctrl++) "
-    };
-
-    let dialog = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .title(title)
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Cyan)),
-        )
-        .style(Style::default().bg(Color::Black));
-    frame.render_widget(dialog, overlay);
-}
-
-fn render_filter_manager_overlay(frame: &mut Frame, app: &App, area: Rect) {
-    let width = 55u16.min(area.width.saturating_sub(4));
-    let height = (app.filters.len() as u16 + 7)
-        .min(area.height.saturating_sub(4))
-        .max(8);
-    let x = (area.width.saturating_sub(width)) / 2;
-    let y = (area.height.saturating_sub(height)) / 2;
-    let overlay = Rect::new(x, y, width, height);
-
-    frame.render_widget(Clear, overlay);
-
-    let mut lines = vec![
-        Line::styled(
-            format!(" Active Filters ({})", app.filters.len()),
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Line::from(""),
-    ];
-
-    if app.filters.is_empty() {
-        lines.push(Line::styled(
-            " (no active filters)",
-            Style::default().fg(Color::DarkGray),
-        ));
-    } else {
-        for (i, filter) in app.filters.iter().enumerate() {
-            let is_cursor = i == app.filter_manager_cursor;
-            let prefix = if filter.exclude { "−" } else { "+" };
-            let style = if is_cursor {
-                Style::default().bg(Color::DarkGray).fg(Color::White)
-            } else {
-                Style::default()
-            };
-            lines.push(Line::styled(format!(" {} {}", prefix, filter.label), style));
-        }
-    }
-
-    lines.push(Line::from(""));
-    lines.push(Line::styled(
-        " d: Delete  c: Clear all  Esc: Close",
-        Style::default().fg(Color::DarkGray),
-    ));
-
-    let dialog = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .title(" Filter Manager (F) ")
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Cyan)),
-        )
-        .style(Style::default().bg(Color::Black));
-    frame.render_widget(dialog, overlay);
-}
-
-fn render_column_selector_overlay(frame: &mut Frame, app: &App, area: Rect) {
-    let cols = &app.column_config.columns;
-    let width = 35u16.min(area.width.saturating_sub(4));
-    let height = (cols.len() as u16 + 5).min(area.height.saturating_sub(4));
-    let x = (area.width.saturating_sub(width)) / 2;
-    let y = (area.height.saturating_sub(height)) / 2;
-    let overlay = Rect::new(x, y, width, height);
-
-    frame.render_widget(Clear, overlay);
-
-    let mut lines = vec![
-        Line::styled(
-            " Toggle columns (Space/Enter)",
-            Style::default().fg(Color::DarkGray),
-        ),
-        Line::from(""),
-    ];
-
-    for (i, (col, visible)) in cols.iter().enumerate() {
-        let checkbox = if *visible { "[x]" } else { "[ ]" };
-        let is_cursor = i == app.column_config.cursor;
-        let suffix = if *col == crate::app::Column::Log {
-            " (always on)"
-        } else {
-            ""
-        };
-        let style = if is_cursor {
-            Style::default().bg(Color::DarkGray).fg(Color::White)
-        } else {
-            Style::default()
-        };
-        lines.push(Line::styled(
-            format!(" {} {:<12}{}", checkbox, col.label(), suffix),
-            style,
-        ));
-    }
-
-    lines.push(Line::from(""));
-    lines.push(Line::styled(
-        " Esc: Close",
-        Style::default().fg(Color::DarkGray),
-    ));
-
-    let dialog = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .title(" Columns (c) ")
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Cyan)),
-        )
-        .style(Style::default().bg(Color::Black));
-    frame.render_widget(dialog, overlay);
 }


### PR DESCRIPTION
Migrate 5 persistent widgets to UiComponent trait pattern:

- LogTableWidget, DetailPanelWidget, SearchInputWidget, FilterInputWidget, StatusBarWidget

Each widget has render_with_app() for app-context-aware rendering. ui_legacy.rs now delegates to widget instances. All 274 tests pass, clippy clean.

Closes #100