### PR TITLE
feat: auto-detect SWSS log format

### DIFF
--- a/crates/scouty/src/parser/factory.rs
+++ b/crates/scouty/src/parser/factory.rs
@@ -9,6 +9,7 @@ use std::sync::OnceLock;
 use crate::parser::extended_syslog_parser::ExtendedSyslogParser;
 use crate::parser::group::ParserGroup;
 use crate::parser::regex_parser::RegexParser;
+use crate::parser::swss_parser::SwssParser;
 use crate::parser::syslog_parser::SyslogParser;
 use crate::traits::{LoaderInfo, LoaderType};
 
@@ -33,7 +34,9 @@ impl ParserFactory {
             }
             LoaderType::TextFile | LoaderType::Archive => {
                 // Try to auto-detect from sample lines
-                if Self::looks_like_extended_syslog(&info.sample_lines) {
+                if Self::looks_like_swss(&info.sample_lines) {
+                    Self::add_swss_parsers(&mut group);
+                } else if Self::looks_like_extended_syslog(&info.sample_lines) {
                     Self::add_extended_syslog_parsers(&mut group);
                     Self::add_syslog_parsers(&mut group);
                 } else if Self::looks_like_syslog(&info.sample_lines) {
@@ -70,6 +73,14 @@ impl ParserFactory {
         Self::majority_match(sample_lines, |l| re.is_match(l))
     }
 
+    fn looks_like_swss(sample_lines: &[String]) -> bool {
+        static RE: OnceLock<regex::Regex> = OnceLock::new();
+        let re = RE.get_or_init(|| {
+            regex::Regex::new(r"^\d{4}-\d{2}-\d{2}\.\d{2}:\d{2}:\d{2}\.\d+\|").unwrap()
+        });
+        Self::majority_match(sample_lines, |l| re.is_match(l))
+    }
+
     /// Returns true if the majority of non-empty sample lines (up to 5) match the predicate.
     fn majority_match(sample_lines: &[String], pred: impl Fn(&str) -> bool) -> bool {
         let lines: Vec<&str> = sample_lines
@@ -83,6 +94,10 @@ impl ParserFactory {
         }
         let matched = lines.iter().filter(|l| pred(l)).count();
         matched * 2 > lines.len() // majority: more than half
+    }
+
+    fn add_swss_parsers(group: &mut ParserGroup) {
+        group.add_parser(Box::new(SwssParser::new()));
     }
 
     fn add_extended_syslog_parsers(group: &mut ParserGroup) {

--- a/crates/scouty/src/parser/factory_tests.rs
+++ b/crates/scouty/src/parser/factory_tests.rs
@@ -154,4 +154,63 @@ mod tests {
         assert_eq!(record.hostname.as_deref(), Some("myhost"));
         assert_eq!(record.process_name.as_deref(), Some("sshd"));
     }
+
+    #[test]
+    fn test_swss_auto_detection() {
+        let info = text_loader_info(vec![
+            "2025-11-13.22:19:03.248563|recording started".to_string(),
+            "2025-11-13.22:19:35.512358|SWITCH_TABLE:switch|SET|k:v".to_string(),
+            "2025-11-13.22:19:38.096435|FLEX_COUNTER_TABLE|PG_DROP|SET|v:1".to_string(),
+        ]);
+        let group = ParserFactory::create_parser_group(&info);
+        let record = group
+            .parse(
+                "2025-11-13.22:19:35.512358|SWITCH_TABLE:switch|SET|ecmp_hash_offset:0",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        assert_eq!(record.component_name.as_deref(), Some("SWITCH_TABLE"));
+        assert_eq!(record.context.as_deref(), Some("switch"));
+        assert_eq!(record.function.as_deref(), Some("SET"));
+    }
+
+    #[test]
+    fn test_swss_does_not_match_syslog() {
+        // Syslog lines should not trigger SWSS detection
+        let info = text_loader_info(vec![
+            "Jan 15 10:30:00 myhost sshd[1234]: Accepted publickey".to_string(),
+        ]);
+        let group = ParserFactory::create_parser_group(&info);
+        let record = group
+            .parse(
+                "Jan 15 10:30:00 myhost sshd[1234]: Accepted publickey",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        // Should parse as syslog, not SWSS
+        assert_eq!(record.hostname.as_deref(), Some("myhost"));
+        assert!(record.context.is_none());
+    }
+
+    #[test]
+    fn test_swss_does_not_match_extended_syslog() {
+        let info = text_loader_info(vec![
+            "2025 Jan 15 10:30:00.123456 BSL-0101 NOTICE restapi#root: test message".to_string(),
+        ]);
+        let group = ParserFactory::create_parser_group(&info);
+        let record = group
+            .parse(
+                "2025 Jan 15 10:30:00.123456 BSL-0101 NOTICE restapi#root: test message",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        assert_eq!(record.hostname.as_deref(), Some("BSL-0101"));
+        assert!(record.context.is_none());
+    }
 }


### PR DESCRIPTION
## Summary
Add SWSS log format auto-detection to ParserFactory, completing the SWSS parser series (#107→#108→#109).

## Changes
- `looks_like_swss()`: OnceLock regex `^\d{4}-\d{2}-\d{2}\.\d{2}:\d{2}:\d{2}\.\d+\|`
- Majority matching (>50% of non-empty sample lines, up to 5)
- Detection order: SWSS → Extended Syslog → BSD Syslog (most specific first)
- `add_swss_parsers()`: wires `SwssParser` into parser group

## Tests
352 total (238 core + 114 TUI), all passing. +3 new:
- SWSS auto-detection with structured + pure message lines
- No false positive on BSD syslog
- No false positive on extended syslog

Closes #109