### PR TITLE
fix: field filter keybindings Ctrl+-/+= → _/+

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -133,15 +133,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             KeyCode::Char(']') => {
                                 app.toggle_follow();
                             }
-                            // Ctrl+- = exclude field filter
-                            // Some terminals send Char('-'), others Char('\x1f') (ASCII 31)
-                            KeyCode::Char('-') | KeyCode::Char('\x1f') => {
-                                app.open_field_filter(true);
-                            }
-                            // Ctrl+= = include field filter
-                            KeyCode::Char('=') => {
-                                app.open_field_filter(false);
-                            }
                             _ => {}
                         }
                     } else {
@@ -176,6 +167,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             KeyCode::Char('=') => {
                                 app.input_mode = InputMode::QuickInclude;
                                 app.quick_filter_input.clear();
+                            }
+                            KeyCode::Char('_') => {
+                                app.open_field_filter(true);
+                            }
+                            KeyCode::Char('+') => {
+                                app.open_field_filter(false);
                             }
                             KeyCode::Char('F') => {
                                 app.input_mode = InputMode::FilterManager;

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -106,6 +106,8 @@ impl StatusBarWidget {
                 ("f", "Filter"),
                 ("-", "Exclude"),
                 ("=", "Include"),
+                ("_", "ExclField"),
+                ("+", "InclField"),
                 ("Enter", "Detail"),
                 ("c", "Columns"),
                 ("?", "Help"),

--- a/crates/scouty-tui/src/ui/windows/field_filter_window.rs
+++ b/crates/scouty-tui/src/ui/windows/field_filter_window.rs
@@ -1,4 +1,4 @@
-//! Field filter dialog (Ctrl+-/Ctrl+=).
+//! Field filter dialog (_/+).
 
 #[cfg(test)]
 #[path = "field_filter_window_tests.rs"]
@@ -131,9 +131,9 @@ impl UiComponent for FieldFilterWindow {
         ));
 
         let title = if self.exclude {
-            " Exclude Fields (Ctrl+-) "
+            " Exclude Fields (_) "
         } else {
-            " Include Fields (Ctrl+=) "
+            " Include Fields (+) "
         };
 
         let dialog = Paragraph::new(lines)

--- a/crates/scouty-tui/src/ui/windows/help_window.rs
+++ b/crates/scouty-tui/src/ui/windows/help_window.rs
@@ -58,7 +58,7 @@ impl UiComponent for HelpWindow {
             Line::from("  n / N            Next / prev search match"),
             Line::from("  f                Filter expression"),
             Line::from("  - / =            Quick exclude / include"),
-            Line::from("  Ctrl+- / Ctrl+=  Exclude / include field filter"),
+            Line::from("  _ / +            Exclude / include field filter"),
             Line::from("  Ctrl+F           Filter manager"),
             Line::from(""),
             section("Display"),


### PR DESCRIPTION
## Summary

Fix non-functional Ctrl+-/Ctrl+= keybindings for field filter dialogs.

### Problem
`Ctrl+-` and `Ctrl+=` don't work on most terminals — there are no standard ASCII control codes for these combinations. Most terminals simply send `-` or `=` without the Ctrl modifier.

### Solution
Changed to `_` (Shift+-) and `+` (Shift+=), which are standard printable characters reliably transmitted by all terminals.

| Action | Old (broken) | New |
|--------|-------------|-----|
| Exclude field filter | Ctrl+- | _ |
| Include field filter | Ctrl+= | + |

### Changes
- `main.rs`: Moved handlers from Ctrl block to normal key block
- `help_window.rs`: Updated keybinding display
- `status_bar_widget.rs`: Added `_: ExclField` and `+: InclField` hints
- `field_filter_window.rs`: Updated dialog titles

### Tests
All 387 tests passing.

Closes #149