### PR TITLE
fix: statusbar background extends full window width

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -65,7 +65,7 @@ impl StatusBarWidget {
             Style::default().fg(Color::White).bg(Color::DarkGray),
         ));
 
-        let footer = Paragraph::new(Line::from(spans));
+        let footer = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
         frame.render_widget(footer, area);
     }
 
@@ -118,7 +118,7 @@ impl StatusBarWidget {
             }
         }
 
-        let footer = Paragraph::new(Line::from(spans));
+        let footer = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
         frame.render_widget(footer, area);
     }
 }

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -158,6 +158,6 @@ fn render_input_line2(frame: &mut Frame, area: Rect, mode: &str, input: &str, er
         ));
     }
 
-    let input_line = Paragraph::new(Line::from(spans));
+    let input_line = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
     frame.render_widget(input_line, area);
 }


### PR DESCRIPTION
## Summary

Statusbar lines 1 and 2 now fill the full terminal width with a DarkGray background, instead of only covering the content spans.

### Fix
Added `.style(Style::default().bg(Color::DarkGray))` to:
- `render_line1` (density chart + position)
- `render_line2` (mode label + shortcuts/status)
- `render_input_line2` (input mode)

All 396 tests passing.

Closes #153