### PR TITLE
fix: remove emoji from field filter dialog

### DIFF
--- a/crates/scouty-tui/src/ui/windows/field_filter_window.rs
+++ b/crates/scouty-tui/src/ui/windows/field_filter_window.rs
@@ -102,7 +102,7 @@ impl UiComponent for FieldFilterWindow {
             let display = match &entry.kind {
                 FieldEntryKind::TimeBefore { .. } | FieldEntryKind::TimeAfter { .. } => {
                     // Time entries show just the name (e.g. "Before 2025-01-01 12:00:00.000")
-                    format!(" {} ⏱ {}", checkbox, entry.name)
+                    format!(" {} {}", checkbox, entry.name)
                 }
                 FieldEntryKind::Field => {
                     let max_val = (width as usize).saturating_sub(22);


### PR DESCRIPTION
Remove ⏱ emoji from time entries in exclude/include field filter dialog.

396 tests passing. Closes #156