### PR TITLE
feat: copy format dialog j/k cursor navigation

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -235,6 +235,8 @@ pub struct App {
     pub column_config: ColumnConfig,
     /// Follow mode: auto-scroll to bottom.
     pub follow_mode: bool,
+    /// Copy format dialog cursor (0=Raw, 1=JSON, 2=YAML).
+    pub copy_format_cursor: usize,
     /// Filter version counter (incremented on filter/data change, for density cache invalidation).
     pub filter_version: u64,
     /// Cached density chart data.
@@ -313,6 +315,7 @@ impl App {
             col_widths,
             column_config: ColumnConfig::default(),
             follow_mode: false,
+            copy_format_cursor: 0,
             filter_version: 0,
             density_cache: None,
         })
@@ -1119,6 +1122,7 @@ mod tests {
             col_widths: [19, 5, 11, 3, 3, 9],
             column_config: ColumnConfig::default(),
             follow_mode: false,
+            copy_format_cursor: 0,
             filter_version: 0,
             density_cache: None,
         }
@@ -1160,6 +1164,7 @@ mod tests {
             col_widths: [19, 5, 11, 3, 3, 9],
             column_config: ColumnConfig::default(),
             follow_mode: false,
+            copy_format_cursor: 0,
             filter_version: 0,
             density_cache: None,
         }
@@ -1198,6 +1203,7 @@ mod tests {
             col_widths: [19, 5, 11, 3, 3, 9],
             column_config: ColumnConfig::default(),
             follow_mode: false,
+            copy_format_cursor: 0,
             filter_version: 0,
             density_cache: None,
         }
@@ -1632,6 +1638,7 @@ mod field_filter_v2_tests {
             col_widths: [19, 5, 11, 3, 3, 9],
             column_config: ColumnConfig::default(),
             follow_mode: false,
+            copy_format_cursor: 0,
             filter_version: 0,
             density_cache: None,
         }
@@ -1795,6 +1802,7 @@ mod column_follow_tests {
             col_widths: [19, 5, 11, 3, 3, 9],
             column_config: ColumnConfig::default(),
             follow_mode: false,
+            copy_format_cursor: 0,
             filter_version: 0,
             density_cache: None,
         }
@@ -1969,6 +1977,7 @@ mod copy_tests {
             col_widths: [19, 5, 11, 3, 3, 9],
             column_config: ColumnConfig::default(),
             follow_mode: false,
+            copy_format_cursor: 0,
             filter_version: 0,
             density_cache: None,
         }

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -228,6 +228,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 }
                                 KeyCode::Char('Y') => {
                                     app.input_mode = InputMode::CopyFormat;
+                                    app.copy_format_cursor = 0;
                                 }
                                 KeyCode::Char('c') => {
                                     app.input_mode = InputMode::ColumnSelector;
@@ -361,20 +362,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     InputMode::CopyFormat => {
                         use ui::windows::copy_format_window::CopyFormatWindow;
-                        // Determine format from key before dispatching
-                        let format = match key.code {
-                            KeyCode::Enter | KeyCode::Char('r') => Some(app::CopyFormat::Raw),
-                            KeyCode::Char('j') => Some(app::CopyFormat::Json),
-                            KeyCode::Char('y') => Some(app::CopyFormat::Yaml),
-                            _ => None,
-                        };
-                        let mut window = CopyFormatWindow;
+                        let mut window = CopyFormatWindow::from_app(&app);
                         let result = ui::dispatch_key(&mut window, key);
+                        app.copy_format_cursor = window.cursor;
                         if result == ui::ComponentResult::Close {
-                            if let Some(fmt) = format {
-                                CopyFormatWindow::select_format(&mut app, fmt);
+                            if window.confirmed {
+                                CopyFormatWindow::select_format(&mut app, window.selected_format());
                             }
                             app.input_mode = InputMode::Normal;
+                            app.copy_format_cursor = 0;
                         }
                     }
                     InputMode::Help => {

--- a/crates/scouty-tui/src/ui/windows/copy_format_window.rs
+++ b/crates/scouty-tui/src/ui/windows/copy_format_window.rs
@@ -12,10 +12,31 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use ratatui::Frame;
 
+const FORMAT_OPTIONS: [(&str, CopyFormat); 3] = [
+    ("Raw text", CopyFormat::Raw),
+    ("JSON", CopyFormat::Json),
+    ("YAML", CopyFormat::Yaml),
+];
+
 /// Popup dialog for selecting copy format (Raw/JSON/YAML).
-pub struct CopyFormatWindow;
+pub struct CopyFormatWindow {
+    pub cursor: usize,
+    pub confirmed: bool,
+}
 
 impl CopyFormatWindow {
+    pub fn from_app(app: &App) -> Self {
+        Self {
+            cursor: app.copy_format_cursor,
+            confirmed: false,
+        }
+    }
+
+    /// Get the selected format.
+    pub fn selected_format(&self) -> CopyFormat {
+        FORMAT_OPTIONS[self.cursor].1
+    }
+
     /// Handle the selected format: copy to clipboard and return Close.
     pub fn select_format(app: &mut App, format: CopyFormat) -> ComponentResult {
         if let Some(text) = app.copy_as_format(format) {
@@ -27,53 +48,41 @@ impl CopyFormatWindow {
 
 impl UiComponent for CopyFormatWindow {
     fn enable_jk_navigation(&self) -> bool {
-        false
+        true
     }
 
     fn render(&self, frame: &mut Frame, area: Rect) {
-        let width = 35u16.min(area.width.saturating_sub(4));
-        let height = 9u16.min(area.height.saturating_sub(4));
+        let width = 30u16.min(area.width.saturating_sub(4));
+        let height = 8u16.min(area.height.saturating_sub(4));
         let x = (area.width.saturating_sub(width)) / 2;
         let y = (area.height.saturating_sub(height)) / 2;
         let overlay = Rect::new(x, y, width, height);
 
         frame.render_widget(Clear, overlay);
 
-        let lines = vec![
-            Line::from(""),
-            Line::from(vec![
-                Span::styled(
-                    " [r] ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("Raw text (default)"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    " [j] ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("JSON"),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    " [y] ",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::raw("YAML"),
-            ]),
-            Line::from(""),
-            Line::styled(
-                " Enter: Raw  Esc: Cancel",
-                Style::default().fg(Color::DarkGray),
-            ),
-        ];
+        let mut lines = vec![Line::from("")];
+
+        for (i, (label, _)) in FORMAT_OPTIONS.iter().enumerate() {
+            let is_selected = i == self.cursor;
+            let marker = if is_selected { "▸ " } else { "  " };
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            lines.push(Line::from(Span::styled(
+                format!(" {}{}", marker, label),
+                style,
+            )));
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::styled(
+            " Enter: Copy  Esc: Cancel",
+            Style::default().fg(Color::DarkGray),
+        ));
 
         let dialog = Paragraph::new(lines)
             .block(
@@ -86,16 +95,27 @@ impl UiComponent for CopyFormatWindow {
         frame.render_widget(dialog, overlay);
     }
 
+    fn on_up(&mut self) -> ComponentResult {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        if self.cursor < FORMAT_OPTIONS.len() - 1 {
+            self.cursor += 1;
+        }
+        ComponentResult::Consumed
+    }
+
     fn on_confirm(&mut self) -> ComponentResult {
-        // Enter defaults to Raw — actual copy happens in the dispatch layer
-        // because we need access to App state.
+        self.confirmed = true;
         ComponentResult::Close
     }
 
-    fn on_char(&mut self, c: char) -> ComponentResult {
-        match c {
-            'r' | 'j' | 'y' => ComponentResult::Close,
-            _ => ComponentResult::Ignored,
-        }
+    fn on_cancel(&mut self) -> ComponentResult {
+        self.confirmed = false;
+        ComponentResult::Close
     }
 }

--- a/crates/scouty-tui/src/ui/windows/copy_format_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/copy_format_window_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+    use crate::app::CopyFormat;
     use crate::ui::windows::copy_format_window::CopyFormatWindow;
     use crate::ui::{dispatch_key, ComponentResult, UiComponent};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -8,54 +9,106 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::empty())
     }
 
-    #[test]
-    fn test_esc_closes() {
-        let mut w = CopyFormatWindow;
-        assert_eq!(
-            dispatch_key(&mut w, key(KeyCode::Esc)),
-            ComponentResult::Close
-        );
-    }
-
-    #[test]
-    fn test_enter_closes() {
-        let mut w = CopyFormatWindow;
-        assert_eq!(
-            dispatch_key(&mut w, key(KeyCode::Enter)),
-            ComponentResult::Close
-        );
-    }
-
-    #[test]
-    fn test_r_j_y_close() {
-        for c in ['r', 'j', 'y'] {
-            let mut w = CopyFormatWindow;
-            assert_eq!(
-                dispatch_key(&mut w, key(KeyCode::Char(c))),
-                ComponentResult::Close
-            );
+    fn sample_window() -> CopyFormatWindow {
+        CopyFormatWindow {
+            cursor: 0,
+            confirmed: false,
         }
     }
 
     #[test]
-    fn test_unknown_key_ignored() {
-        let mut w = CopyFormatWindow;
+    fn test_esc_cancels() {
+        let mut w = sample_window();
         assert_eq!(
-            dispatch_key(&mut w, key(KeyCode::Char('x'))),
-            ComponentResult::Ignored
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
         );
+        assert!(!w.confirmed);
     }
 
     #[test]
-    fn test_navigation_ignored() {
-        let mut w = CopyFormatWindow;
+    fn test_enter_confirms() {
+        let mut w = sample_window();
         assert_eq!(
-            dispatch_key(&mut w, key(KeyCode::Up)),
-            ComponentResult::Ignored
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
         );
+        assert!(w.confirmed);
+        assert_eq!(w.selected_format(), CopyFormat::Raw);
+    }
+
+    #[test]
+    fn test_jk_navigation() {
+        let mut w = sample_window();
+        assert_eq!(w.cursor, 0);
+
         assert_eq!(
             dispatch_key(&mut w, key(KeyCode::Down)),
-            ComponentResult::Ignored
+            ComponentResult::Consumed
         );
+        assert_eq!(w.cursor, 1);
+
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('j'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 2);
+
+        // Can't go past end
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Down)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 2);
+
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Up)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('k'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 0);
+
+        // Can't go past start
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Up)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 0);
+    }
+
+    #[test]
+    fn test_select_json() {
+        let mut w = sample_window();
+        dispatch_key(&mut w, key(KeyCode::Down)); // cursor=1 (JSON)
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+        assert!(w.confirmed);
+        assert_eq!(w.selected_format(), CopyFormat::Json);
+    }
+
+    #[test]
+    fn test_select_yaml() {
+        let mut w = sample_window();
+        dispatch_key(&mut w, key(KeyCode::Down));
+        dispatch_key(&mut w, key(KeyCode::Down)); // cursor=2 (YAML)
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+        assert!(w.confirmed);
+        assert_eq!(w.selected_format(), CopyFormat::Yaml);
+    }
+
+    #[test]
+    fn test_enable_jk_navigation() {
+        let w = sample_window();
+        assert!(w.enable_jk_navigation());
     }
 }

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -64,7 +64,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     if app.input_mode == InputMode::CopyFormat {
         use crate::ui::windows::copy_format_window::CopyFormatWindow;
         use crate::ui::UiComponent;
-        let window = CopyFormatWindow;
+        let window = CopyFormatWindow::from_app(app);
         window.render(frame, area);
     }
 }


### PR DESCRIPTION
Replace letter hotkeys with cursor-based navigation in the copy format dialog.

### Before
- `r` → Raw, `j` → JSON, `y` → YAML (direct hotkeys)

### After
- j/↓ k/↑ to navigate, Enter to confirm, Esc to cancel
- ▸ cursor indicator highlights current option
- Consistent with field filter, column selector, and filter manager dialogs

### Tests
7 new tests covering navigation, selection of each format, confirm/cancel.
397 total tests passing.

Closes #158