### PR TITLE
fix: statusbar visual improvements

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -56,13 +56,6 @@ impl StatusBarWidget {
                     spans.push(Span::styled(ch.to_string(), style));
                 }
             }
-
-            spans.push(Span::styled(
-                " │",
-                Style::default()
-                    .fg(Color::DarkGray)
-                    .bg(Color::Rgb(20, 20, 40)),
-            ));
         }
 
         spans.push(Span::styled(
@@ -124,7 +117,8 @@ impl StatusBarWidget {
             }
         }
 
-        let footer = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
+        let footer =
+            Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::Rgb(30, 30, 30)));
         frame.render_widget(footer, area);
     }
 }


### PR DESCRIPTION
- Remove `│` separator between density chart and position info (background color difference already provides clear separation)
- Line 2 uses `Rgb(30,30,30)` (darker) instead of `DarkGray` to distinguish from Line 1

401 tests passing. Closes #163