### PR TITLE
feat: export filtered results to file (Ctrl+S)

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -23,6 +23,7 @@ pub enum InputMode {
     ColumnSelector,
     CopyFormat,
     Help,
+    SaveFile,
 }
 
 /// Column identifiers for the log table.
@@ -237,6 +238,8 @@ pub struct App {
     pub follow_mode: bool,
     /// Copy format dialog cursor (0=Raw, 1=JSON, 2=YAML).
     pub copy_format_cursor: usize,
+    /// Save file input buffer.
+    pub save_file_input: String,
     /// Filter version counter (incremented on filter/data change, for density cache invalidation).
     pub filter_version: u64,
     /// Cached density chart data.
@@ -316,6 +319,7 @@ impl App {
             column_config: ColumnConfig::default(),
             follow_mode: false,
             copy_format_cursor: 0,
+            save_file_input: String::new(),
             filter_version: 0,
             density_cache: None,
         })
@@ -1017,6 +1021,35 @@ impl App {
             None
         }
     }
+    /// Generate default save filename based on current time.
+    pub fn default_save_filename() -> String {
+        let now = chrono::Local::now();
+        now.format("filtered_%Y%m%d_%H%M%S.log").to_string()
+    }
+
+    /// Save filtered records to a file.
+    pub fn save_filtered_to_file(&mut self) {
+        let filename = self.save_file_input.trim().to_string();
+        if filename.is_empty() {
+            self.set_status("Save cancelled: empty filename".to_string());
+            return;
+        }
+
+        let mut lines = Vec::with_capacity(self.filtered_indices.len());
+        for &idx in &self.filtered_indices {
+            lines.push(self.records[idx].raw.as_str());
+        }
+
+        match std::fs::write(&filename, lines.join("\n") + "\n") {
+            Ok(()) => {
+                let count = self.filtered_indices.len();
+                self.set_status(format!("Saved {} records to {}", count, filename));
+            }
+            Err(e) => {
+                self.set_status(format!("Save failed: {}", e));
+            }
+        }
+    }
 }
 
 /// Copy format options.
@@ -1123,6 +1156,7 @@ mod tests {
             column_config: ColumnConfig::default(),
             follow_mode: false,
             copy_format_cursor: 0,
+            save_file_input: String::new(),
             filter_version: 0,
             density_cache: None,
         }
@@ -1165,6 +1199,7 @@ mod tests {
             column_config: ColumnConfig::default(),
             follow_mode: false,
             copy_format_cursor: 0,
+            save_file_input: String::new(),
             filter_version: 0,
             density_cache: None,
         }
@@ -1204,6 +1239,7 @@ mod tests {
             column_config: ColumnConfig::default(),
             follow_mode: false,
             copy_format_cursor: 0,
+            save_file_input: String::new(),
             filter_version: 0,
             density_cache: None,
         }
@@ -1639,6 +1675,7 @@ mod field_filter_v2_tests {
             column_config: ColumnConfig::default(),
             follow_mode: false,
             copy_format_cursor: 0,
+            save_file_input: String::new(),
             filter_version: 0,
             density_cache: None,
         }
@@ -1803,6 +1840,7 @@ mod column_follow_tests {
             column_config: ColumnConfig::default(),
             follow_mode: false,
             copy_format_cursor: 0,
+            save_file_input: String::new(),
             filter_version: 0,
             density_cache: None,
         }
@@ -1978,6 +2016,7 @@ mod copy_tests {
             column_config: ColumnConfig::default(),
             follow_mode: false,
             copy_format_cursor: 0,
+            save_file_input: String::new(),
             filter_version: 0,
             density_cache: None,
         }

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -171,6 +171,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 KeyCode::Char('=') => {
                                     app.open_field_filter(false);
                                 }
+                                KeyCode::Char('s') => {
+                                    app.save_file_input = App::default_save_filename();
+                                    app.input_mode = InputMode::SaveFile;
+                                }
                                 _ => {}
                             }
                         } else {
@@ -381,6 +385,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             app.input_mode = InputMode::Normal;
                         }
                     }
+                    InputMode::SaveFile => match key.code {
+                        KeyCode::Enter => {
+                            app.save_filtered_to_file();
+                            app.input_mode = InputMode::Normal;
+                        }
+                        KeyCode::Esc => {
+                            app.input_mode = InputMode::Normal;
+                        }
+                        KeyCode::Backspace => {
+                            app.save_file_input.pop();
+                        }
+                        KeyCode::Char(c) => {
+                            app.save_file_input.push(c);
+                        }
+                        _ => {}
+                    },
                 }
             } // if let Event::Key
 

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -70,6 +70,24 @@ impl StatusBarWidget {
 
     /// Render line 2: mode label + shortcut hints or status message.
     pub fn render_line2(&self, frame: &mut Frame, area: Rect, app: &App) {
+        // SaveFile mode: show special input line
+        if app.input_mode == crate::app::InputMode::SaveFile {
+            let spans = vec![
+                Span::styled(
+                    " [SAVE] ",
+                    Style::default().fg(Color::Black).bg(Color::Yellow),
+                ),
+                Span::styled(
+                    format!(" {}█", app.save_file_input),
+                    Style::default().fg(Color::White),
+                ),
+            ];
+            let footer = Paragraph::new(Line::from(spans))
+                .style(Style::default().bg(Color::Rgb(30, 30, 30)));
+            frame.render_widget(footer, area);
+            return;
+        }
+
         let (mode_label, mode_color) = if app.follow_mode {
             ("[FOLLOW]", Color::Green)
         } else {


### PR DESCRIPTION
## Summary

Add **Ctrl+S** shortcut to export all filtered log records to a file.

### How it works
- **Ctrl+S** in Normal mode enters SaveFile input mode
- Status bar shows `[SAVE] filename█` with default filename `filtered_YYYYMMDD_HHMMSS.log`
- **Enter** confirms and writes all filtered records (raw text, one per line)
- **Esc** cancels
- Success: `Saved N records to filename`
- Error: `Save failed: reason`

### Changes
- Added `SaveFile` variant to `InputMode` enum
- Added `save_file_input` field to `App` struct
- Added `default_save_filename()` and `save_filtered_to_file()` methods
- Added Ctrl+S key binding in main event loop
- Added `[SAVE]` mode rendering in status bar widget

Closes #167