### PR TITLE
docs: modular PM specs in crate directories

### DIFF
--- a/crates/scouty-tui/spec/copy-and-export.md
+++ b/crates/scouty-tui/spec/copy-and-export.md
@@ -4,9 +4,6 @@
 
 Features for copying log records to clipboard and exporting filtered results to files.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/detail-panel.md
+++ b/crates/scouty-tui/spec/detail-panel.md
@@ -4,9 +4,6 @@
 
 The detail panel displays the full content of the currently selected log record in a left-right split layout: log content on the left, structured fields on the right.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/help.md
+++ b/crates/scouty-tui/spec/help.md
@@ -4,9 +4,6 @@
 
 A scrollable help overlay displaying all available keybindings, version information, and project links.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/highlight.md
+++ b/crates/scouty-tui/spec/highlight.md
@@ -4,9 +4,6 @@
 
 Custom highlight rules allow users to visually mark multiple patterns simultaneously with different colors, independent of search and filtering.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/log-table.md
+++ b/crates/scouty-tui/spec/log-table.md
@@ -4,9 +4,6 @@
 
 The main log table widget displays parsed log records in a scrollable, column-based view with level coloring and selection tracking.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/navigation.md
+++ b/crates/scouty-tui/spec/navigation.md
@@ -4,9 +4,6 @@
 
 Advanced navigation features beyond basic j/k scrolling: bookmarks, relative time jumps, and go-to-line.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -4,9 +4,6 @@
 
 `scouty-tui` is an interactive terminal log viewer built on the `scouty` core library. It provides table-based log browsing, filtering, searching, and analysis through a component-based architecture using `ratatui` + `crossterm`.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/perf.md
+++ b/crates/scouty-tui/spec/perf.md
@@ -4,9 +4,6 @@
 
 End-to-end performance optimization covering the full loading pipeline (file I/O → parsing → LogStore insertion → TUI first render) and TUI navigation responsiveness.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/search-and-filter.md
+++ b/crates/scouty-tui/spec/search-and-filter.md
@@ -4,9 +4,6 @@
 
 Interactive search and filtering in the TUI, providing regex search with match navigation and multiple filter interaction modes.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/stats.md
+++ b/crates/scouty-tui/spec/stats.md
@@ -4,9 +4,6 @@
 
 A statistics overlay providing a quick overview of log data distribution: level breakdown, top components, time range, and record counts.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty-tui/spec/status-bar.md
+++ b/crates/scouty-tui/spec/status-bar.md
@@ -4,9 +4,6 @@
 
 The status bar occupies the bottom 2 lines, providing data overview (density chart + position) on line 1 and interactive state (mode/input/messages) on line 2.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty/spec/filter.md
+++ b/crates/scouty/spec/filter.md
@@ -4,9 +4,6 @@
 
 The filter engine evaluates expressions against LogRecord fields to include or exclude records. It supports a rich expression language with field comparisons, logical operators, and string matching.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty/spec/loaders.md
+++ b/crates/scouty/spec/loaders.md
@@ -4,9 +4,6 @@
 
 Loaders are responsible for reading raw log data from various sources and feeding lines into their associated Parser Groups. Each source/file gets an independent Loader instance; a session can have multiple Loaders.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty/spec/log-record.md
+++ b/crates/scouty/spec/log-record.md
@@ -4,9 +4,6 @@
 
 `LogRecord` is the core data structure representing a single parsed log entry. It is the universal exchange format between all Scouty components — parsers produce it, the store holds it, filters evaluate it, and the TUI renders it.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty/spec/log-store-view.md
+++ b/crates/scouty/spec/log-store-view.md
@@ -4,9 +4,6 @@
 
 `LogStoreView` encapsulates a `FilterEngine` and its cached filter results, enabling a **double-buffering** mechanism: the active view serves the TUI while a pending view filters in the background, then atomically replaces the active view.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty/spec/log-store.md
+++ b/crates/scouty/spec/log-store.md
@@ -4,9 +4,6 @@
 
 LogStore is the central storage for all parsed `LogRecord`s, maintaining timestamp-sorted order and supporting both batch and live insertion. It uses a **Segmented Sorted Array** architecture for high performance.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/crates/scouty/spec/parsers.md
+++ b/crates/scouty/spec/parsers.md
@@ -4,9 +4,6 @@
 
 Scouty parsers transform raw log lines into `LogRecord` structs. The system supports multiple parser types: a unified hand-written syslog parser (zero-regex), SONiC SWSS parser, sairedis parser, and user-defined regex parsers.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/spec/ci-and-release.md
+++ b/spec/ci-and-release.md
@@ -4,9 +4,6 @@
 
 GitHub Actions pipelines for continuous integration (build + test on every push/PR) and manual release workflow (version bump, multi-platform build, GitHub Release, crates.io publish).
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 

--- a/spec/cli.md
+++ b/spec/cli.md
@@ -4,9 +4,6 @@
 
 Command-line interface for `scouty-tui`, handling file arguments, default syslog paths, and stdin pipe detection.
 
-## Current Status
-
-✅ Implemented
 
 ## Design
 


### PR DESCRIPTION
Reorganize PM specs from external bunny-house repo into modular spec/ directories within each crate for easier co-located maintenance.

**Structure:**
- `crates/scouty/spec/` — Core library specs (log-record, log-store, log-store-view, parsers, loaders, filter)
- `crates/scouty-tui/spec/` — TUI app specs (overview, log-table, detail-panel, status-bar, search-and-filter, navigation, highlight, copy-and-export, stats, help, perf)
- `spec/` — Project-level specs (ci-and-release, cli)

**Format:** Each spec contains Overview, Design decisions, Performance metrics (where applicable), and Change Log.

Going forward, feature specs will be updated in-place within these files instead of submitting new files to bunny-house.