### PR TITLE
fix: time jump keybindings ]/[ instead of Ctrl+J/K

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -216,12 +216,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 KeyCode::Down => app.page_down(),
                                 KeyCode::Up => app.page_up(),
                                 KeyCode::Char('j') => {
-                                    app.input_mode = InputMode::JumpForward;
-                                    app.time_input.clear();
+                                    app.page_down();
                                 }
                                 KeyCode::Char('k') => {
-                                    app.input_mode = InputMode::JumpBackward;
-                                    app.time_input.clear();
+                                    app.page_up();
                                 }
                                 KeyCode::Char('g') => {
                                     app.input_mode = InputMode::GotoLine;
@@ -275,6 +273,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 }
                                 KeyCode::Char('t') => {
                                     app.input_mode = InputMode::TimeJump;
+                                    app.time_input.clear();
+                                }
+                                KeyCode::Char(']') => {
+                                    app.input_mode = InputMode::JumpForward;
+                                    app.time_input.clear();
+                                }
+                                KeyCode::Char('[') => {
+                                    app.input_mode = InputMode::JumpBackward;
                                     app.time_input.clear();
                                 }
                                 KeyCode::Char('-') => {

--- a/crates/scouty-tui/src/ui/windows/help_window.rs
+++ b/crates/scouty-tui/src/ui/windows/help_window.rs
@@ -51,6 +51,7 @@ impl UiComponent for HelpWindow {
             Line::from("  G / End          Jump to last row"),
             Line::from("  Ctrl+G           Go to line number"),
             Line::from("  t                Jump to timestamp"),
+            Line::from("  ] / [            Time jump forward / back"),
             Line::from("  Ctrl+]           Toggle follow mode"),
             Line::from(""),
             section("Search & Filter"),


### PR DESCRIPTION
Ctrl+J/K are unreliable in terminals (Ctrl+J = newline, Ctrl+K = VT). Per 兔总 decision:

- `]` — time jump forward (e.g. `5m`, `30s`)
- `[` — time jump backward
- Ctrl+J/K now mapped to page down/up

416 tests passing.