### PR TITLE
fix: relax perf test threshold for CI stability

### DIFF
--- a/crates/scouty/src/store_tests.rs
+++ b/crates/scouty/src/store_tests.rs
@@ -843,8 +843,8 @@ mod tests {
 
         assert_eq!(count, 10_000);
         assert!(
-            elapsed.as_millis() < 1,
-            "Range iter 10K traversal took {:?}, expected < 1ms",
+            elapsed.as_millis() < 5,
+            "Range iter 10K traversal took {:?}, expected < 5ms",
             elapsed
         );
     }


### PR DESCRIPTION
macOS CI runners have variable performance causing `perf_range_iter_10k_traversal` to intermittently fail (3.8ms vs 1ms threshold).

Increase threshold from 1ms to 5ms — still catches real regressions while eliminating CI flakiness.

Closes #195