### PR TITLE
docs: fix spec keybindings to match current implementation

### DIFF
--- a/crates/scouty-tui/spec/copy-and-export.md
+++ b/crates/scouty-tui/spec/copy-and-export.md
@@ -24,6 +24,8 @@ Features for copying log records to clipboard and exporting filtered results to 
 - No filename: error `Usage: :w <filename>`
 - Command mode extensible for future commands
 
+> **Note:** Prior to command mode implementation, export uses `Ctrl+s` with a `[SAVE]` prompt.
+
 ## Change Log
 
 | Date | Change |

--- a/crates/scouty-tui/spec/help.md
+++ b/crates/scouty-tui/spec/help.md
@@ -14,7 +14,7 @@ A scrollable help overlay displaying all available keybindings, version informat
 ### Content
 
 - Complete keybinding reference table (all shortcuts with descriptions)
-- Grouped by category: Navigation, Search, Filter, Bookmarks, Highlight, Copy/Export, Misc
+- Grouped by category: Navigation, Search, Filter, Highlight, Copy/Export, Misc
 - Version number (from `Cargo.toml`)
 - GitHub repository URL: `https://github.com/r12f/scouty`
 

--- a/crates/scouty-tui/spec/navigation.md
+++ b/crates/scouty-tui/spec/navigation.md
@@ -7,7 +7,7 @@ Advanced navigation features beyond basic j/k scrolling: bookmarks, relative tim
 
 ## Design
 
-### Bookmarks
+### Bookmarks (Planned)
 
 - `m` — toggle bookmark on current row
 - `'` (single quote) — jump to next bookmark (cyclic)
@@ -20,8 +20,8 @@ Advanced navigation features beyond basic j/k scrolling: bookmarks, relative tim
 
 ### Relative Time Jump
 
-- `Ctrl+J` — jump forward (time increases): `[JUMP+] 5m█`
-- `Ctrl+K` — jump backward (time decreases): `[JUMP-] 5m█`
+- `]` — jump forward (time increases): `[JUMP+] 5m█`
+- `[` — jump backward (time decreases): `[JUMP-] 5m█`
 - Supported formats: `Ns` (seconds), `Nm` (minutes), `Nh` (hours), `Nd` (days)
 - Combined formats (P1): `1h30m`, `2m30s`
 - Enter confirms: binary search (O(log N)) for nearest row to target timestamp
@@ -45,4 +45,4 @@ Advanced navigation features beyond basic j/k scrolling: bookmarks, relative tim
 |------|--------|
 | 2026-02-20 | Basic navigation (j/k, g/G, Ctrl+G, follow mode) |
 | 2026-02-22 | Bookmarks with manager dialog |
-| 2026-02-22 | Relative time jump (Ctrl+J/K) |
+| 2026-02-22 | Relative time jump (`]`/`[`) |

--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -55,7 +55,6 @@ crates/scouty-tui/src/ui/
 │   ├── copy_format_window.rs
 │   ├── goto_line_window.rs
 │   ├── help_window.rs
-│   ├── bookmark_manager_window.rs
 │   ├── highlight_manager_window.rs
 │   └── stats_window.rs
 └── widgets/            # Persistent components
@@ -95,18 +94,18 @@ Components notify App via return values or callbacks. App updates shared state (
 | `n`/`N` | Next/prev search match |
 | `f` | Filter expression input |
 | `-`/`=` | Quick exclude/include text |
-| `Ctrl+-`/`Ctrl+=` | Field exclude/include dialog |
+| `Ctrl+-`/`Ctrl+=` | Field exclude/include dialog (also `_`/`+`) |
 | `F` | Filter manager |
 | `c` | Column selector |
 | `y`/`Y` | Copy raw / format selection |
 | `h`/`H` | Add highlight / highlight manager |
-| `m` | Toggle bookmark |
-| `'`/`"` | Next/prev bookmark |
-| `M` | Bookmark manager |
+| `m` | Toggle bookmark *(planned)* |
+| `'`/`"` | Next/prev bookmark *(planned)* |
+| `M` | Bookmark manager *(planned)* |
 | `S` | Stats summary |
-| `Ctrl+J`/`Ctrl+K` | Relative time jump |
+| `]`/`[` | Relative time jump (forward/backward) |
 | `Ctrl+]` | Toggle follow mode |
-| `:` | Command mode |
+| `Ctrl+s` | Save/export to file |
 | `Esc` | Close current overlay |
 | `q` | Quit |
 | `?` | Help |

--- a/crates/scouty-tui/spec/search-and-filter.md
+++ b/crates/scouty-tui/spec/search-and-filter.md
@@ -27,7 +27,7 @@ Interactive search and filtering in the TUI, providing regex search with match n
 
 - Text input; adds exclude/include filter for records containing that text
 
-### Field Filter Dialog (`Ctrl+-` / `Ctrl+=`)
+### Field Filter Dialog (`_` / `+` or `Ctrl+-` / `Ctrl+=`)
 
 Shared dialog component, differing only in initial action (exclude vs include):
 

--- a/crates/scouty/spec/filter.md
+++ b/crates/scouty/spec/filter.md
@@ -51,7 +51,7 @@ Each filter has an action that takes effect when matched:
 
 ### Time Range Filters
 
-Quick time-based filtering via `Ctrl+-` / `Ctrl+=` dialogs:
+Quick time-based filtering via `_` / `+` (or `Ctrl+-` / `Ctrl+=`) dialogs:
 - "Before this log" → `timestamp < "YYYY-MM-DDTHH:MM:SS.ffffff"`
 - "After this log" → `timestamp > "YYYY-MM-DDTHH:MM:SS.ffffff"`
 - Current row is **included** (boundary inclusive)


### PR DESCRIPTION
Fixes keybinding discrepancies between spec docs and actual code:

- **Time jump**: `Ctrl+J`/`Ctrl+K` → `]`/`[` (terminal compatibility — Ctrl+J = newline, Ctrl+K = VT)
- **Field filter dialog**: added `_`/`+` as alternative keys alongside `Ctrl+-`/`Ctrl+=`
- **Bookmarks**: marked as *(planned)* — not yet implemented on master
- **File tree**: removed `bookmark_manager_window.rs` (doesn't exist yet)
- **Export**: added note that current master uses `Ctrl+s` before command mode (`:w`) lands
- **Help spec**: removed Bookmarks from category list
- **Overview keybinding table**: updated `Ctrl+s` for save, `]`/`[` for time jump

Affected files: navigation.md, overview.md, search-and-filter.md, filter.md, copy-and-export.md, help.md