### PR TITLE
docs: remove Ctrl+-/Ctrl+= from specs, use _/+ only

### DIFF
--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -94,7 +94,7 @@ Components notify App via return values or callbacks. App updates shared state (
 | `n`/`N` | Next/prev search match |
 | `f` | Filter expression input |
 | `-`/`=` | Quick exclude/include text |
-| `Ctrl+-`/`Ctrl+=` | Field exclude/include dialog (also `_`/`+`) |
+| `_`/`+` | Field exclude/include dialog |
 | `F` | Filter manager |
 | `c` | Column selector |
 | `y`/`Y` | Copy raw / format selection |

--- a/crates/scouty-tui/spec/search-and-filter.md
+++ b/crates/scouty-tui/spec/search-and-filter.md
@@ -27,7 +27,7 @@ Interactive search and filtering in the TUI, providing regex search with match n
 
 - Text input; adds exclude/include filter for records containing that text
 
-### Field Filter Dialog (`_` / `+` or `Ctrl+-` / `Ctrl+=`)
+### Field Filter Dialog (`_` / `+`)
 
 Shared dialog component, differing only in initial action (exclude vs include):
 

--- a/crates/scouty/spec/filter.md
+++ b/crates/scouty/spec/filter.md
@@ -51,7 +51,7 @@ Each filter has an action that takes effect when matched:
 
 ### Time Range Filters
 
-Quick time-based filtering via `_` / `+` (or `Ctrl+-` / `Ctrl+=`) dialogs:
+Quick time-based filtering via `_` / `+` dialogs:
 - "Before this log" → `timestamp < "YYYY-MM-DDTHH:MM:SS.ffffff"`
 - "After this log" → `timestamp > "YYYY-MM-DDTHH:MM:SS.ffffff"`
 - Current row is **included** (boundary inclusive)


### PR DESCRIPTION
Remove all `Ctrl+-`/`Ctrl+=` references from spec docs. These Ctrl+Shift combos are unreliable across terminals. Only `_`/`+` keybindings are documented going forward.

Affected files: overview.md, search-and-filter.md, filter.md