### PR TITLE
fix: remove Ctrl+-/Ctrl+= keybindings

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -232,15 +232,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 KeyCode::Char(']') => {
                                     app.toggle_follow();
                                 }
-                                // Ctrl+- = exclude field filter
-                                // Some terminals send Char('-'), others Char('\x1f') (ASCII 31)
-                                KeyCode::Char('-') | KeyCode::Char('\x1f') => {
-                                    app.open_field_filter(true);
-                                }
-                                // Ctrl+= = include field filter
-                                KeyCode::Char('=') => {
-                                    app.open_field_filter(false);
-                                }
                                 _ => {}
                             }
                         } else {


### PR DESCRIPTION
Remove `Ctrl+-` and `Ctrl+=` handlers — unreliable across terminals. `_` and `+` already provide the same field filter functionality.

428 tests passing. Closes #204