### PR TITLE
[PM Spec] Density chart time-per-column label

### DIFF
--- a/crates/scouty-tui/spec/status-bar.md
+++ b/crates/scouty-tui/spec/status-bar.md
@@ -14,6 +14,31 @@ The status bar occupies the bottom 2 lines, providing data overview (density cha
 - Density chart shows filtered log time distribution; each braille char = 2×4 dot matrix
 - Current cursor position highlighted in the density chart (yellow)
 
+### Density Chart Time-Per-Column Label
+
+Display a time-per-column label to the left of the density chart on line 1, showing the time span each braille column represents.
+
+**Format:** `[Xs/█]` where X is dynamically computed as `(max_ts - min_ts) / num_buckets`.
+
+**Unit auto-selection:**
+- < 1s → ms (e.g., `[500ms/█]`)
+- 1s to < 60s → s (e.g., `[5s/█]`)
+- 1m to < 60m → m (e.g., `[2m/█]`)
+- ≥ 60m → h (e.g., `[1h/█]`)
+
+**Layout:** `[5s/█]⣿⣷⣶⣤⣀⣿⣷⣶  42/100 (Total: 500)`
+
+**Behavior:**
+- Label width is deducted from density chart available width
+- Hidden when no data or only one timestamp exists
+- Visually distinguishable from chart (e.g., dimmer color)
+
+**Acceptance criteria:**
+- [ ] Label displayed left of density chart in `[time/█]` format
+- [ ] Time unit dynamically computed and auto-selected (ms/s/m/h)
+- [ ] Label width deducted from chart width, no layout overflow
+- [ ] Hidden when insufficient data
+
 ### Line 2: Interactive State (Three Mutually Exclusive Modes)
 
 **Mode A — Default (shortcut hints):**
@@ -59,3 +84,4 @@ Navigation (j/k/PageUp/PageDown/g/G) does **not** trigger recomputation. Only th
 | 2026-02-20 | Initial single-line status bar with density chart |
 | 2026-02-22 | Two-line redesign with mode/input/message states |
 | 2026-02-22 | Density chart caching for navigation performance |
+| 2026-02-22 | Add time-per-column label spec for density chart |


### PR DESCRIPTION
Update status-bar.md spec to add time-per-column label requirement for density chart.

Adds section describing:
- Format: [Xs/█] with dynamic time computation
- Auto unit selection (ms/s/m/h)
- Layout integration and acceptance criteria