### PR TITLE
feat: show time-per-column label on density chart

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -181,7 +181,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             let right_width = position.len() as u16 + 2; // " {} " padding
                                                          // Reserve space for time-per-column label (e.g. "[500ms/█]" ~10 chars)
-            let label_reserve: u16 = 12;
+            // Reserve space for time-per-column label (e.g. "[500ms/█]" ~10 chars, allow headroom)
+            let label_reserve: u16 = 15;
             let chart_width = term_width.saturating_sub(right_width + label_reserve + 2) as usize;
             if chart_width >= 4 && app.total() > 0 {
                 app.get_density_cache(chart_width);

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -41,6 +41,7 @@ impl StatusBarWidget {
             format!("[{}ms/█]", ms_per_bucket.round() as u64)
         } else if ms_per_bucket < 60_000.0 {
             let secs = ms_per_bucket / 1000.0;
+            // Show integer if close to whole number (e.g. 5.02→5, 5.97→6), else show 1 decimal (e.g. 5.5)
             if secs.fract() < 0.05 || secs.fract() > 0.95 {
                 format!("[{}s/█]", secs.round() as u64)
             } else {

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
@@ -101,4 +101,49 @@ mod tests {
         };
         assert!(StatusBarWidget::time_per_column_label(&cache).is_none());
     }
+
+    #[test]
+    fn test_time_per_column_label_decimal_seconds() {
+        let now = chrono::Utc::now();
+        let cache = crate::app::DensityCache {
+            braille_text: String::new(),
+            num_buckets: 10,
+            min_ts: now,
+            max_ts: now + chrono::Duration::milliseconds(55_000),
+            filter_version: 0,
+            chart_width: 50,
+        };
+        let label = StatusBarWidget::time_per_column_label(&cache).unwrap();
+        assert_eq!(label, "[5.5s/█]");
+    }
+
+    #[test]
+    fn test_time_per_column_label_decimal_minutes() {
+        let now = chrono::Utc::now();
+        let cache = crate::app::DensityCache {
+            braille_text: String::new(),
+            num_buckets: 10,
+            min_ts: now,
+            max_ts: now + chrono::Duration::minutes(25),
+            filter_version: 0,
+            chart_width: 50,
+        };
+        let label = StatusBarWidget::time_per_column_label(&cache).unwrap();
+        assert_eq!(label, "[2.5m/█]");
+    }
+
+    #[test]
+    fn test_time_per_column_label_decimal_hours() {
+        let now = chrono::Utc::now();
+        let cache = crate::app::DensityCache {
+            braille_text: String::new(),
+            num_buckets: 10,
+            min_ts: now,
+            max_ts: now + chrono::Duration::hours(15),
+            filter_version: 0,
+            chart_width: 50,
+        };
+        let label = StatusBarWidget::time_per_column_label(&cache).unwrap();
+        assert_eq!(label, "[1.5h/█]");
+    }
 }


### PR DESCRIPTION
## Summary

Display a `[Xs/█]` label to the left of the braille density chart in the status bar, showing how much time each column represents.

## Example
```
[5s/█]⣿⣷⣶⣤⣀⣿⣷⣶                                    42/100 (Total: 500)
```

## Changes

- Added `time_per_column_label()` to StatusBarWidget — computes and formats the label
- Auto-selects unit: ms (<1s), s (<60s), m (<60m), h (≥60m)
- Label rendered in DarkGray before the chart to visually distinguish it
- Reserved 12 chars in chart width calculation (`main.rs`) to prevent overflow
- Hidden when timestamps are identical or no data

## Testing

- 5 new tests for the label function (ms/s/m/h units + same-timestamp edge case)
- All existing tests pass
- Clippy clean

Closes #220