### PR TITLE
fix: load keybindings from config.yaml

### DIFF
--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -17,12 +17,16 @@ use std::path::PathBuf;
 pub struct Config {
     /// Theme name: "default" or a custom theme file name (without .yaml).
     pub theme: String,
+    /// Keybinding overrides.
+    #[serde(default)]
+    pub keybindings: crate::keybinding::KeybindingConfig,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             theme: "default".to_string(),
+            keybindings: crate::keybinding::KeybindingConfig::default(),
         }
     }
 }

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -99,8 +99,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let files: Vec<&str> = files.iter().map(|s| s.as_str()).collect();
 
-    // Build keymap before entering TUI mode so any warnings are visible on stderr
-    let keymap = keybinding::Keymap::default_keymap();
+    // Load config before entering TUI mode so warnings are visible on stderr
+    let cfg = config::load_config();
+    let keymap = keybinding::Keymap::from_config(&cfg.keybindings);
 
     // Enter TUI mode first so the user sees a loading screen immediately
     enable_raw_mode()?;
@@ -160,9 +161,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    // Load config and resolve theme
+    // Apply theme from config
     {
-        let cfg = config::load_config();
         app.theme = config::resolve_theme(&cfg, None);
     }
 


### PR DESCRIPTION
## Problem

Keybindings from `~/.scouty/config.yaml` were never loaded. `Keymap::default_keymap()` was always used, ignoring user config.

## Fix

- Added `keybindings: KeybindingConfig` field to `Config` struct with `#[serde(default)]`
- Moved config loading before TUI mode so warnings print to stderr
- Pass `cfg.keybindings` to `Keymap::from_config()` instead of using defaults

## Testing

- All 204 tests pass
- Clippy clean
- Minimal change: 2 files, +8/-4 lines

Closes #228