### PR TITLE
fix: default visible columns match spec

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -2170,6 +2170,9 @@ mod column_follow_tests {
         assert!(config.is_visible(Column::Time));
         assert!(config.is_visible(Column::Level));
         assert!(config.is_visible(Column::ProcessName));
+        assert!(config.is_visible(Column::Pid));
+        assert!(config.is_visible(Column::Tid));
+        assert!(config.is_visible(Column::Component));
         assert!(config.is_visible(Column::Log));
         assert!(!config.is_visible(Column::Source)); // hidden by default
     }


### PR DESCRIPTION
Default columns now show Time, Level, ProcessName, Pid, Tid, Component, and Log per log-table.md spec. Previously only Time and Log were visible.

Closes #231