### PR TITLE
fix: add section titles to detail panel

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
@@ -149,6 +149,7 @@ impl DetailPanelWidget {
             .split(area);
 
         let left_block = Block::default()
+            .title(" Log Content ")
             .borders(Borders::RIGHT)
             .border_style(theme.detail_panel.border.to_style());
         let raw_text = Paragraph::new(record.raw.clone())


### PR DESCRIPTION
Add 'Log Content' and 'Fields' titles to detail panel sub-panels per spec.

Closes #232