### PR TITLE
feat: add built-in theme presets (dark, light, solarized)

### DIFF
--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -84,6 +84,11 @@ pub fn resolve_theme(config: &Config, cli_theme: Option<&str>) -> Theme {
         return Theme::default();
     }
 
+    // Check built-in presets first
+    if let Some(theme) = Theme::builtin(theme_name) {
+        return theme;
+    }
+
     // Try loading from ~/.scouty/themes/<name>.yaml
     if let Some(dir) = config_dir() {
         let theme_path = dir.join("themes").join(format!("{theme_name}.yaml"));

--- a/crates/scouty-tui/src/config/theme.rs
+++ b/crates/scouty-tui/src/config/theme.rs
@@ -314,6 +314,209 @@ impl Theme {
     pub fn from_yaml(yaml: &str) -> Result<Self, String> {
         serde_yaml::from_str(yaml).map_err(|e| format!("invalid theme YAML: {e}"))
     }
+
+    /// Built-in preset: look up by name. Returns None for unknown names.
+    pub fn builtin(name: &str) -> Option<Self> {
+        match name {
+            "default" => Some(Self::default()),
+            "dark" => Some(Self::dark()),
+            "light" => Some(Self::light()),
+            "solarized" => Some(Self::solarized()),
+            _ => None,
+        }
+    }
+
+    /// Muted dark theme — lower contrast, softer colors.
+    pub fn dark() -> Self {
+        use Color::*;
+        Self {
+            log_levels: LogLevelTheme {
+                fatal: StyleEntry::fg_bold(Red),
+                error: StyleEntry::fg(Rgb(205, 92, 92)),
+                warn: StyleEntry::fg(Rgb(210, 180, 100)),
+                notice: StyleEntry::fg(Rgb(100, 160, 180)),
+                info: StyleEntry::fg(Rgb(120, 180, 120)),
+                debug: StyleEntry::fg(Rgb(140, 140, 140)),
+                trace: StyleEntry::fg(DarkGray),
+            },
+            table: TableTheme {
+                header: StyleEntry::fg_bg(Rgb(180, 180, 180), Rgb(30, 30, 40)),
+                selected: StyleEntry::bg(Rgb(40, 40, 55)),
+                ..TableTheme::default()
+            },
+            status_bar: StatusBarTheme {
+                line1_bg: StyleEntry::bg(Rgb(30, 30, 40)),
+                line2_bg: StyleEntry::bg(Rgb(35, 35, 50)),
+                mode_label: StyleEntry::fg_bg(Black, Rgb(100, 160, 180)),
+                mode_view: StyleEntry::fg_bg(Black, Rgb(140, 140, 140)),
+                mode_follow: StyleEntry::fg_bg(Black, Rgb(120, 180, 120)),
+                density_normal: StyleEntry::fg(Rgb(100, 160, 180)),
+                density_hot: StyleEntry::fg(Rgb(210, 180, 100)),
+                ..StatusBarTheme::default()
+            },
+            search: SearchTheme {
+                match_highlight: StyleEntry::fg_bg(Black, Rgb(210, 180, 100)),
+                current_match: StyleEntry::fg_bg(Black, Rgb(200, 120, 50)),
+            },
+            dialog: DialogTheme {
+                border: StyleEntry::fg(Rgb(100, 160, 180)),
+                title: StyleEntry::fg_bold(Rgb(180, 180, 180)),
+                selected: StyleEntry::fg_bg(White, Rgb(40, 40, 55)),
+                text: StyleEntry::fg(Rgb(180, 180, 180)),
+                muted: StyleEntry::fg(DarkGray),
+                ..DialogTheme::default()
+            },
+            detail_panel: DetailPanelTheme {
+                border: StyleEntry::fg(Rgb(60, 60, 80)),
+                field_name: StyleEntry::fg(Rgb(100, 160, 180)),
+                field_value: StyleEntry::fg(Rgb(180, 180, 180)),
+                section_header: StyleEntry::fg_bold(Rgb(180, 180, 180)),
+            },
+            input: InputTheme {
+                prompt: StyleEntry::fg(Rgb(210, 180, 100)),
+                error: StyleEntry::fg(Rgb(205, 92, 92)),
+                ..InputTheme::default()
+            },
+            general: GeneralTheme {
+                accent: StyleEntry::fg(Rgb(100, 160, 180)),
+                muted: StyleEntry::fg(DarkGray),
+                border: StyleEntry::fg(Rgb(60, 60, 80)),
+            },
+            ..Self::default()
+        }
+    }
+
+    /// Light theme — light background, dark text.
+    pub fn light() -> Self {
+        use Color::*;
+        Self {
+            log_levels: LogLevelTheme {
+                fatal: StyleEntry::fg_bold(Rgb(180, 0, 0)),
+                error: StyleEntry::fg(Rgb(180, 0, 0)),
+                warn: StyleEntry::fg(Rgb(180, 120, 0)),
+                notice: StyleEntry::fg(Rgb(0, 120, 150)),
+                info: StyleEntry::fg(Rgb(0, 130, 60)),
+                debug: StyleEntry::fg(Rgb(100, 100, 100)),
+                trace: StyleEntry::fg(Rgb(150, 150, 150)),
+            },
+            table: TableTheme {
+                header: StyleEntry::fg_bg(Rgb(30, 30, 40), Rgb(220, 220, 230)),
+                selected: StyleEntry::fg_bg(Black, Rgb(200, 210, 230)),
+                ..TableTheme::default()
+            },
+            status_bar: StatusBarTheme {
+                line1_bg: StyleEntry::bg(Rgb(220, 220, 230)),
+                line2_bg: StyleEntry::bg(Rgb(210, 210, 220)),
+                mode_label: StyleEntry::fg_bg(White, Rgb(0, 120, 150)),
+                mode_view: StyleEntry::fg_bg(White, Rgb(100, 100, 100)),
+                mode_follow: StyleEntry::fg_bg(White, Rgb(0, 130, 60)),
+                density_normal: StyleEntry::fg(Rgb(0, 120, 150)),
+                density_hot: StyleEntry::fg(Rgb(180, 120, 0)),
+                ..StatusBarTheme::default()
+            },
+            search: SearchTheme {
+                match_highlight: StyleEntry::fg_bg(Black, Rgb(255, 230, 100)),
+                current_match: StyleEntry::fg_bg(Black, Rgb(255, 180, 50)),
+            },
+            dialog: DialogTheme {
+                border: StyleEntry::fg(Rgb(0, 120, 150)),
+                title: StyleEntry::fg_bold(Rgb(30, 30, 40)),
+                selected: StyleEntry::fg_bg(Black, Rgb(200, 210, 230)),
+                text: StyleEntry::fg(Rgb(30, 30, 40)),
+                muted: StyleEntry::fg(Rgb(150, 150, 150)),
+                ..DialogTheme::default()
+            },
+            detail_panel: DetailPanelTheme {
+                border: StyleEntry::fg(Rgb(180, 180, 190)),
+                field_name: StyleEntry::fg(Rgb(0, 120, 150)),
+                field_value: StyleEntry::fg(Rgb(30, 30, 40)),
+                section_header: StyleEntry::fg_bold(Rgb(30, 30, 40)),
+            },
+            input: InputTheme {
+                prompt: StyleEntry::fg(Rgb(180, 120, 0)),
+                error: StyleEntry::fg(Rgb(180, 0, 0)),
+                ..InputTheme::default()
+            },
+            general: GeneralTheme {
+                accent: StyleEntry::fg(Rgb(0, 120, 150)),
+                muted: StyleEntry::fg(Rgb(150, 150, 150)),
+                border: StyleEntry::fg(Rgb(180, 180, 190)),
+            },
+            ..Self::default()
+        }
+    }
+
+    /// Solarized theme — based on Ethan Schoonover's solarized palette.
+    pub fn solarized() -> Self {
+        use Color::*;
+        let base03 = Rgb(0, 43, 54);
+        let base02 = Rgb(7, 54, 66);
+        let base01 = Rgb(88, 110, 117);
+        let base0 = Rgb(131, 148, 150);
+        let base1 = Rgb(147, 161, 161);
+        let yellow = Rgb(181, 137, 0);
+        let orange = Rgb(203, 75, 22);
+        let red = Rgb(220, 50, 47);
+        let blue = Rgb(38, 139, 210);
+        let cyan = Rgb(42, 161, 152);
+        let green = Rgb(133, 153, 0);
+
+        Self {
+            log_levels: LogLevelTheme {
+                fatal: StyleEntry::fg_bold(red),
+                error: StyleEntry::fg(red),
+                warn: StyleEntry::fg(yellow),
+                notice: StyleEntry::fg(cyan),
+                info: StyleEntry::fg(green),
+                debug: StyleEntry::fg(base01),
+                trace: StyleEntry::fg(base01),
+            },
+            table: TableTheme {
+                header: StyleEntry::fg_bg(base1, base02),
+                selected: StyleEntry::fg_bg(base1, base02),
+                ..TableTheme::default()
+            },
+            status_bar: StatusBarTheme {
+                line1_bg: StyleEntry::bg(base02),
+                line2_bg: StyleEntry::bg(base02),
+                mode_label: StyleEntry::fg_bg(base03, cyan),
+                mode_view: StyleEntry::fg_bg(base03, base01),
+                mode_follow: StyleEntry::fg_bg(base03, green),
+                density_normal: StyleEntry::fg(blue),
+                density_hot: StyleEntry::fg(orange),
+                ..StatusBarTheme::default()
+            },
+            search: SearchTheme {
+                match_highlight: StyleEntry::fg_bg(base03, yellow),
+                current_match: StyleEntry::fg_bg(base03, orange),
+            },
+            dialog: DialogTheme {
+                border: StyleEntry::fg(blue),
+                title: StyleEntry::fg_bold(base1),
+                selected: StyleEntry::fg_bg(base1, base02),
+                text: StyleEntry::fg(base0),
+                muted: StyleEntry::fg(base01),
+                ..DialogTheme::default()
+            },
+            detail_panel: DetailPanelTheme {
+                border: StyleEntry::fg(base01),
+                field_name: StyleEntry::fg(cyan),
+                field_value: StyleEntry::fg(base0),
+                section_header: StyleEntry::fg_bold(base1),
+            },
+            input: InputTheme {
+                prompt: StyleEntry::fg(yellow),
+                error: StyleEntry::fg(red),
+                ..InputTheme::default()
+            },
+            general: GeneralTheme {
+                accent: StyleEntry::fg(blue),
+                muted: StyleEntry::fg(base01),
+                border: StyleEntry::fg(base01),
+            },
+            ..Self::default()
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add 3 built-in theme presets per theme.md spec:

- **dark**: muted dark — lower contrast, softer colors
- **light**: light background, dark text for daytime use
- **solarized**: Ethan Schoonover's solarized color palette

`resolve_theme()` now checks built-in presets before loading from `~/.scouty/themes/`.

Usage: `theme: "dark"` in config.yaml or `--theme dark` CLI flag.

Closes #235