### PR TITLE
fix: wire built-in theme presets in resolve_theme

### DIFF
--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -84,6 +84,14 @@ pub fn resolve_theme(config: &Config, cli_theme: Option<&str>) -> Theme {
         return Theme::default();
     }
 
+    // Built-in theme presets
+    match theme_name {
+        "dark" => return Theme::dark(),
+        "light" => return Theme::light(),
+        "solarized" => return Theme::solarized(),
+        _ => {}
+    }
+
     // Check built-in presets first
     if let Some(theme) = Theme::builtin(theme_name) {
         return theme;


### PR DESCRIPTION
Theme::dark/light/solarized existed but resolve_theme never matched them. Now `--theme dark` and `theme: solarized` in config work.

Closes #235