### PR TITLE
feat: default visible columns to Time + Log only

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -102,13 +102,13 @@ impl Default for ColumnConfig {
         Self {
             columns: vec![
                 (Column::Time, true),
-                (Column::Level, true),
+                (Column::Level, false),
                 (Column::Hostname, false),
                 (Column::Container, false),
-                (Column::ProcessName, true),
-                (Column::Pid, true),
-                (Column::Tid, true),
-                (Column::Component, true),
+                (Column::ProcessName, false),
+                (Column::Pid, false),
+                (Column::Tid, false),
+                (Column::Component, false),
                 (Column::Function, false),
                 (Column::Context, false),
                 (Column::Source, false),
@@ -2200,11 +2200,11 @@ mod column_follow_tests {
     fn test_default_column_config() {
         let config = ColumnConfig::default();
         assert!(config.is_visible(Column::Time));
-        assert!(config.is_visible(Column::Level));
-        assert!(config.is_visible(Column::ProcessName));
-        assert!(config.is_visible(Column::Pid));
-        assert!(config.is_visible(Column::Tid));
-        assert!(config.is_visible(Column::Component));
+        assert!(!config.is_visible(Column::Level)); // hidden by default
+        assert!(!config.is_visible(Column::ProcessName)); // hidden by default
+        assert!(!config.is_visible(Column::Pid)); // hidden by default
+        assert!(!config.is_visible(Column::Tid)); // hidden by default
+        assert!(!config.is_visible(Column::Component)); // hidden by default
         assert!(config.is_visible(Column::Log));
         assert!(!config.is_visible(Column::Source)); // hidden by default
     }
@@ -2242,7 +2242,7 @@ mod column_follow_tests {
     fn test_visible_columns() {
         let mut config = ColumnConfig::default();
         let default_visible = config.visible_columns();
-        assert_eq!(default_visible.len(), 7); // Time+Level+ProcessName+Pid+Tid+Component+Log
+        assert_eq!(default_visible.len(), 2); // Time+Log
 
         // Show Hostname (hidden by default)
         let idx = config
@@ -2252,7 +2252,7 @@ mod column_follow_tests {
             .unwrap();
         config.toggle(idx);
         let visible = config.visible_columns();
-        assert_eq!(visible.len(), 8);
+        assert_eq!(visible.len(), 3);
         assert!(visible.contains(&Column::Hostname));
     }
 
@@ -2266,7 +2266,7 @@ mod column_follow_tests {
             .unwrap();
         config.toggle(idx);
         assert!(config.is_visible(Column::Source));
-        assert_eq!(config.visible_columns().len(), 8); // 7 defaults + Source
+        assert_eq!(config.visible_columns().len(), 3); // 2 defaults + Source
     }
 
     // ── Follow mode tests ────────────────────────────────────
@@ -2451,7 +2451,7 @@ mod copy_tests {
         config.toggle(ctr_idx);
         assert!(config.is_visible(Column::Hostname));
         assert!(config.is_visible(Column::Container));
-        assert_eq!(config.visible_columns().len(), 9); // 7 defaults + Hostname + Container
+        assert_eq!(config.visible_columns().len(), 4); // 2 defaults + Hostname + Container
     }
 
     #[test]


### PR DESCRIPTION
Default columns now show only Time and Log per updated log-table.md spec. All other columns (Level, ProcessName, Pid, Tid, Component, etc.) are hidden by default but accessible via `c` column selector.

Closes #249