### PR TITLE
[PM Spec] Highlight full row + filter preserves cursor position

### DIFF
--- a/crates/scouty-tui/spec/highlight.md
+++ b/crates/scouty-tui/spec/highlight.md
@@ -13,7 +13,7 @@ Custom highlight rules allow users to visually mark multiple patterns simultaneo
 - Supports regex (same as search)
 - System auto-assigns color from a rotating palette: red, green, blue, yellow, magenta, cyan...
 - Multiple rules active simultaneously
-- Highlights render in the Log column of the log table
+- Highlights render as **full-row background color** in the log table (the entire row is colored, not just matching text)
 - Overlapping matches: later-added rule takes priority
 - **Highlights are purely visual** — they do not affect filtering
 
@@ -29,3 +29,4 @@ Custom highlight rules allow users to visually mark multiple patterns simultaneo
 | Date | Change |
 |------|--------|
 | 2026-02-22 | Custom highlight rules with manager dialog |
+| 2026-02-23 | Highlight renders full row, not just matching text |

--- a/crates/scouty-tui/spec/search-and-filter.md
+++ b/crates/scouty-tui/spec/search-and-filter.md
@@ -21,6 +21,7 @@ Interactive search and filtering in the TUI, providing regex search with match n
 - Opens input with field name hints
 - Full expression syntax (see `crates/scouty/spec/filter.md`)
 - Enter → creates pending LogStoreView → replaces active view on completion
+- **Cursor position after filter**: cursor stays on the same log record if it still exists in filtered results; if that record is filtered out, cursor moves to the nearest preceding record that remains visible (i.e., the last visible record before the original cursor position). Only if no preceding records remain does the cursor go to the first row.
 - Esc cancels
 
 ### Quick Exclude (`-`) / Quick Include (`=`)
@@ -71,3 +72,4 @@ Via the field filter dialog's time options:
 |------|--------|
 | 2026-02-20 | Search, filter expression, quick exclude/include, field dialog, filter manager |
 | 2026-02-22 | Time range options in field filter dialog |
+| 2026-02-23 | Filter preserves cursor position (stay on same record or nearest preceding) |


### PR DESCRIPTION
Two spec updates:

1. **highlight.md**: Highlight renders full-row background color, not just matching text
2. **search-and-filter.md**: After filter, cursor stays on same record or nearest preceding visible record (no jump to first row)