### PR TITLE
fix: add NOTICE to ISO log regex parser

### DIFF
--- a/crates/scouty/src/parser/factory.rs
+++ b/crates/scouty/src/parser/factory.rs
@@ -134,7 +134,7 @@ impl ParserFactory {
         // ISO timestamp + level + message: "2024-01-15 10:30:00 INFO message"
         if let Ok(p) = RegexParser::new(
             "iso-level-msg",
-            r"^(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<level>TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL|CRITICAL)\s+(?P<message>.*)",
+            r"^(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<level>TRACE|DEBUG|INFO|NOTICE|WARN(?:ING)?|ERROR|FATAL|CRITICAL)\s+(?P<message>.*)",
             None,
         ) {
             group.add_parser(Box::new(p));
@@ -152,7 +152,7 @@ impl ParserFactory {
         // Level first: "INFO 2024-01-15 10:30:00 message"
         if let Ok(p) = RegexParser::new(
             "level-iso-msg",
-            r"^(?P<level>TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL|CRITICAL)\s+(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<message>.*)",
+            r"^(?P<level>TRACE|DEBUG|INFO|NOTICE|WARN(?:ING)?|ERROR|FATAL|CRITICAL)\s+(?P<timestamp>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\s+(?P<message>.*)",
             None,
         ) {
             group.add_parser(Box::new(p));

--- a/crates/scouty/src/parser/factory_tests.rs
+++ b/crates/scouty/src/parser/factory_tests.rs
@@ -280,6 +280,34 @@ mod tests {
     }
 
     #[test]
+    fn test_iso_notice_level_parsed_correctly() {
+        let info = text_loader_info(vec![
+            "2026-06-24T10:00:01Z INFO Starting application".to_string(),
+            "2026-06-24T10:00:14Z NOTICE System maintenance scheduled".to_string(),
+            "2026-06-24T10:00:15Z FATAL Out of memory".to_string(),
+        ]);
+        let group = ParserFactory::create_parser_group(&info);
+        let record = group
+            .parse(
+                "2026-06-24T10:00:14Z NOTICE System maintenance scheduled",
+                "test",
+                "loader",
+                2,
+            )
+            .unwrap();
+        assert_eq!(record.level, Some(crate::record::LogLevel::Notice));
+        assert_eq!(
+            record.timestamp,
+            chrono::NaiveDate::from_ymd_opt(2026, 6, 24)
+                .unwrap()
+                .and_hms_opt(10, 0, 14)
+                .unwrap()
+                .and_utc()
+        );
+        assert!(record.message.contains("System maintenance scheduled"));
+    }
+
+    #[test]
     fn test_swss_not_detected_as_sairedis() {
         let info = text_loader_info(vec![
             "2025-11-13.22:19:35.512358|SWITCH_TABLE:switch|SET|k:v".to_string(),


### PR DESCRIPTION
Add NOTICE to the level alternation in both iso-level-msg and level-iso-msg regex parsers. Previously NOTICE lines fell through to a fallback parser, producing wrong timestamps (system time) and incorrect sort order.

- Added NOTICE to both regex patterns in factory.rs
- Added test verifying NOTICE level parsing with correct timestamp and level

All 275 tests pass.

Closes #251