### PR TITLE
feat: add Ctrl+s shortcut for quick export

### DIFF
--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -105,7 +105,7 @@ Components notify App via return values or callbacks. App updates shared state (
 | `S` | Stats summary |
 | `]`/`[` | Relative time jump (forward/backward) |
 | `Ctrl+]` | Toggle follow mode |
-| `Ctrl+s` | Save/export to file |
+| `Ctrl+s` | Quick export filtered records to auto-named file |
 | `Esc` | Close current overlay |
 | `q` | Quit |
 | `?` | Help |

--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -1271,10 +1271,15 @@ impl App {
         }
     }
     /// Generate default save filename based on current time.
-    #[allow(dead_code)]
     pub fn default_save_filename() -> String {
         let now = chrono::Local::now();
         now.format("filtered_%Y%m%d_%H%M%S.log").to_string()
+    }
+
+    /// Export filtered records to a file with an auto-generated filename (Ctrl+s).
+    pub fn export_with_default_filename(&mut self) {
+        let filename = Self::default_save_filename();
+        self.save_to_file(&filename);
     }
 
     /// Execute a command entered in command mode.

--- a/crates/scouty-tui/src/keybinding.rs
+++ b/crates/scouty-tui/src/keybinding.rs
@@ -49,6 +49,7 @@ pub enum Action {
     // Copy & Export
     CopyRaw,
     CopyFormat,
+    Export,
 
     // General
     Help,
@@ -160,6 +161,7 @@ pub struct KeybindingConfig {
     pub bookmark_manager: Option<KeyOrKeys>,
     pub copy_raw: Option<KeyOrKeys>,
     pub copy_format: Option<KeyOrKeys>,
+    pub export: Option<KeyOrKeys>,
     pub help: Option<KeyOrKeys>,
     pub quit: Option<KeyOrKeys>,
     pub command: Option<KeyOrKeys>,
@@ -268,6 +270,7 @@ impl KeybindingConfig {
             Action::BookmarkManager => self.bookmark_manager.as_ref(),
             Action::CopyRaw => self.copy_raw.as_ref(),
             Action::CopyFormat => self.copy_format.as_ref(),
+            Action::Export => self.export.as_ref(),
             Action::Help => self.help.as_ref(),
             Action::Quit => self.quit.as_ref(),
             Action::Command => self.command.as_ref(),
@@ -315,6 +318,8 @@ fn default_bindings() -> Vec<(Action, Vec<&'static str>)> {
         // Copy
         (Action::CopyRaw, vec!["y"]),
         (Action::CopyFormat, vec!["Y"]),
+        // Export
+        (Action::Export, vec!["ctrl+s"]),
         // General
         (Action::Help, vec!["?"]),
         (Action::Quit, vec!["q"]),

--- a/crates/scouty-tui/src/keybinding_tests.rs
+++ b/crates/scouty-tui/src/keybinding_tests.rs
@@ -147,4 +147,11 @@ move_down: ["j", "down"]
         let plus = KeyEvent::new(KeyCode::Char('+'), KeyModifiers::NONE);
         assert_eq!(keymap.action(&plus), Some(Action::FieldInclude));
     }
+
+    #[test]
+    fn test_ctrl_s_export() {
+        let keymap = Keymap::default_keymap();
+        let ctrl_s = KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL);
+        assert_eq!(keymap.action(&ctrl_s), Some(Action::Export));
+    }
 }

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -324,6 +324,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     app.input_mode = InputMode::CopyFormat;
                                     app.copy_format_cursor = 0;
                                 }
+                                Action::Export => {
+                                    app.export_with_default_filename();
+                                }
                                 Action::ColumnSelector => {
                                     app.input_mode = InputMode::ColumnSelector;
                                     app.column_config.cursor = 0;


### PR DESCRIPTION
Implement Ctrl+s as a keyboard shortcut that exports filtered records to an auto-generated filename (`filtered_YYYYMMDD_HHMMSS.log`). This provides the familiar save shortcut listed in overview.md spec.

- Added `Export` action and `Ctrl+s` default keybinding in keybinding.rs
- Added `export_with_default_filename()` method using existing `save_to_file()` logic
- Wired the action in main.rs event handler
- Added test for Ctrl+s keybinding mapping
- Updated overview.md spec description for accuracy

All 205 tests pass, clippy clean.

Closes #252