### PR TITLE
docs: align NOTICE level color spec with theme.md

### DIFF
--- a/crates/scouty-tui/spec/log-table.md
+++ b/crates/scouty-tui/spec/log-table.md
@@ -23,7 +23,7 @@ Time | Log
 | FATAL | Red bold |
 | ERROR | Red |
 | WARN | Yellow |
-| NOTICE | Yellow (dim) |
+| NOTICE | Cyan |
 | INFO | Green |
 | DEBUG | Gray |
 | TRACE | Dark gray |


### PR DESCRIPTION
Update log-table.md Level Coloring table to change NOTICE from 'Yellow (dim)' to 'Cyan', matching theme.md and current code behavior.

Spec-only change, no code modifications.

Closes #254