### PR TITLE
fix: prevent ISO+level logs from being misidentified as syslog

### DIFF
--- a/crates/scouty/src/parser/factory.rs
+++ b/crates/scouty/src/parser/factory.rs
@@ -74,6 +74,8 @@ impl ParserFactory {
                         && is_bsd_month(&b[5..8])
                 } else if b[4] == b'-' && b[10] == b'T' {
                     // ISO 8601: "YYYY-MM-DDT..."
+                    // But reject if the token after the timestamp is a known log level,
+                    // as that indicates iso-level-msg format, not syslog.
                     b.len() >= 20
                         && b[0..4].iter().all(|c| c.is_ascii_digit())
                         && b[5].is_ascii_digit()
@@ -81,6 +83,7 @@ impl ParserFactory {
                         && b[7] == b'-'
                         && b[8].is_ascii_digit()
                         && b[9].is_ascii_digit()
+                        && !is_iso_followed_by_level(l)
                 } else {
                     false
                 }
@@ -164,6 +167,32 @@ impl ParserFactory {
         if let Ok(p) = RegexParser::new("fallback", r"(?P<message>.+)", None) {
             group.add_parser(Box::new(p));
         }
+    }
+}
+
+/// Check if an ISO 8601 timestamped line has a known log level as the next token.
+/// This distinguishes "2026-06-24T10:00:01Z INFO msg" (iso-level-msg) from syslog.
+#[inline]
+fn is_iso_followed_by_level(line: &str) -> bool {
+    // Find the first whitespace after the timestamp (skip past 'T' at index 10)
+    if let Some(ws_pos) = line[10..].find(|c: char| c.is_ascii_whitespace()) {
+        let after_ts = line[10 + ws_pos..].trim_start();
+        // Extract the next token (up to whitespace)
+        let token = after_ts.split_ascii_whitespace().next().unwrap_or("");
+        matches!(
+            token,
+            "TRACE"
+                | "DEBUG"
+                | "INFO"
+                | "NOTICE"
+                | "WARN"
+                | "WARNING"
+                | "ERROR"
+                | "FATAL"
+                | "CRITICAL"
+        )
+    } else {
+        false
     }
 }
 

--- a/crates/scouty/src/parser/factory_tests.rs
+++ b/crates/scouty/src/parser/factory_tests.rs
@@ -324,4 +324,36 @@ mod tests {
             .unwrap();
         assert_eq!(record.component_name.as_deref(), Some("SWITCH_TABLE"));
     }
+
+    #[test]
+    fn test_iso_level_not_misidentified_as_syslog() {
+        // ISO timestamp + level should NOT be parsed as syslog
+        let info = text_loader_info(vec![
+            "2026-06-24T10:00:01Z INFO Starting application".to_string(),
+            "2026-06-24T10:00:09Z WARN Slow query detected: 2.5s".to_string(),
+            "2026-06-24T10:00:10Z ERROR Timeout waiting for response".to_string(),
+        ]);
+        let group = ParserFactory::create_parser_group(&info);
+
+        let record = group
+            .parse(
+                "2026-06-24T10:00:09Z WARN Slow query detected: 2.5s",
+                "test",
+                "loader",
+                2,
+            )
+            .unwrap();
+
+        assert_eq!(record.level, Some(crate::record::LogLevel::Warn));
+        assert!(
+            record.hostname.is_none(),
+            "hostname should be None, got: {:?}",
+            record.hostname
+        );
+        assert!(
+            record.message.contains("Slow query detected: 2.5s"),
+            "message should contain full text, got: {}",
+            record.message
+        );
+    }
 }


### PR DESCRIPTION
Fix P0 bug where ISO timestamp + level logs (e.g. `2026-06-24T10:00:09Z WARN Slow query`) were incorrectly parsed by the syslog parser, causing level to be mapped as hostname and messages to be truncated.

**Root cause:** `looks_like_syslog()` matched any ISO 8601 timestamp, causing `UnifiedSyslogParser` to be tried first and succeed with incorrect field mapping.

**Fix:** After detecting an ISO 8601 timestamp in `looks_like_syslog()`, peek at the next token. If it's a known log level (TRACE/DEBUG/INFO/NOTICE/WARN/WARNING/ERROR/FATAL/CRITICAL), reject the syslog classification so the `iso-level-msg` regex parser handles it.

- Added `is_iso_followed_by_level()` helper
- Added integration test verifying correct parsing of ISO+level format
- All 276 + 205 tests pass

Closes #258