### PR TITLE
feat: render highlights as full-row background color

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
@@ -9,7 +9,6 @@ use crate::config::Theme;
 use crate::ui::{ComponentResult, UiComponent};
 use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Row, Table};
 use ratatui::Frame;
 use scouty::record::LogLevel;
@@ -106,51 +105,22 @@ impl LogTableWidget {
                             Cell::from(record.component_name.as_deref().unwrap_or("").to_string())
                         }
                         Column::Source => Cell::from(record.source.to_string()),
-                        Column::Log => {
-                            if app.highlight_rules.is_empty() {
-                                Cell::from(record.message.clone())
-                            } else {
-                                // Build highlighted spans for the message
-                                let msg = &record.message;
-                                // Collect all matches: (start, end, color)
-                                let mut matches: Vec<(usize, usize, Color)> = Vec::new();
-                                for rule in &app.highlight_rules {
-                                    for m in rule.regex.find_iter(msg) {
-                                        matches.push((m.start(), m.end(), rule.color));
-                                    }
-                                }
-                                if matches.is_empty() {
-                                    Cell::from(record.message.clone())
-                                } else {
-                                    // Sort by start position
-                                    matches.sort_by_key(|m| m.0);
-                                    let mut spans: Vec<Span> = Vec::new();
-                                    let mut pos = 0usize;
-                                    for (start, end, color) in &matches {
-                                        let start = *start;
-                                        let end = *end;
-                                        if start < pos {
-                                            // Overlapping match, skip
-                                            continue;
-                                        }
-                                        if start > pos {
-                                            spans.push(Span::raw(msg[pos..start].to_string()));
-                                        }
-                                        spans.push(Span::styled(
-                                            msg[start..end].to_string(),
-                                            Style::default().fg(*color),
-                                        ));
-                                        pos = end;
-                                    }
-                                    if pos < msg.len() {
-                                        spans.push(Span::raw(msg[pos..].to_string()));
-                                    }
-                                    Cell::from(Line::from(spans))
-                                }
-                            }
-                        }
+                        Column::Log => Cell::from(record.message.clone()),
                     })
                     .collect();
+
+                // Determine highlight row background: last matching rule wins
+                let highlight_bg: Option<Color> = if app.highlight_rules.is_empty() {
+                    None
+                } else {
+                    let mut bg = None;
+                    for rule in &app.highlight_rules {
+                        if rule.regex.is_match(&record.message) {
+                            bg = Some(rule.color);
+                        }
+                    }
+                    bg
+                };
 
                 let mut row = Row::new(cells).style(row_style);
                 if is_selected && is_match {
@@ -163,6 +133,8 @@ impl LogTableWidget {
                     row = row.style(row_style.bg(theme.table.search_match.bg_color()));
                 } else if is_bookmarked {
                     row = row.style(row_style.bg(theme.table.bookmark.bg_color()));
+                } else if let Some(bg) = highlight_bg {
+                    row = row.style(Style::default().bg(bg).fg(Color::Black));
                 }
                 row
             })


### PR DESCRIPTION
Change highlight rendering from per-match text coloring to full-row background color per highlight.md spec.

**Changes:**
- When a row matches a highlight rule, the entire row gets the rule's color as background with black foreground for readability
- Later-added rules take priority (last match wins) for overlapping highlights
- Selected/search/bookmark row backgrounds take precedence over highlight backgrounds
- Removed per-match span coloring in the Log column

All 205 tests pass, clippy clean.

Closes #256