### PR TITLE
feat: snap density chart time labels to standard intervals

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -28,6 +28,36 @@ fn spans_display_width(spans: &[Span]) -> usize {
 }
 
 impl StatusBarWidget {
+    /// Snap a raw ms-per-bucket value up to the nearest standard interval.
+    /// Standard intervals: 5s, 15s, 30s, 5m, 15m, 30m, 1h, 2h, 6h, 12h, 24h.
+    /// Values below 5s are returned as-is (milliseconds).
+    fn snap_to_standard(ms: f64) -> f64 {
+        // Only snap values >= 5s; below that show raw milliseconds
+        if ms < 5_000.0 {
+            return ms;
+        }
+        const INTERVALS_MS: &[f64] = &[
+            5_000.0,      // 5s
+            15_000.0,     // 15s
+            30_000.0,     // 30s
+            300_000.0,    // 5m
+            900_000.0,    // 15m
+            1_800_000.0,  // 30m
+            3_600_000.0,  // 1h
+            7_200_000.0,  // 2h
+            21_600_000.0, // 6h
+            43_200_000.0, // 12h
+            86_400_000.0, // 24h
+        ];
+        for &iv in INTERVALS_MS {
+            if ms <= iv {
+                return iv;
+            }
+        }
+        // Beyond 24h, return as-is
+        ms
+    }
+
     /// Format the time-per-column label for the density chart.
     /// Returns the label string (e.g. "[█=5s]") or None if not applicable.
     fn time_per_column_label(cache: &crate::app::DensityCache) -> Option<String> {
@@ -35,7 +65,8 @@ impl StatusBarWidget {
             return None;
         }
         let range_ms = (cache.max_ts - cache.min_ts).num_milliseconds() as f64;
-        let ms_per_bucket = range_ms / cache.num_buckets as f64;
+        let raw_ms = range_ms / cache.num_buckets as f64;
+        let ms_per_bucket = Self::snap_to_standard(raw_ms);
 
         let label = if ms_per_bucket < 1000.0 {
             format!("[█={}ms]", ms_per_bucket.round() as u64)

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
@@ -71,7 +71,7 @@ mod tests {
             chart_width: 50,
         };
         let label = StatusBarWidget::time_per_column_label(&cache).unwrap();
-        assert_eq!(label, "[█=2m]");
+        assert_eq!(label, "[█=5m]");
     }
 
     #[test]
@@ -114,7 +114,7 @@ mod tests {
             chart_width: 50,
         };
         let label = StatusBarWidget::time_per_column_label(&cache).unwrap();
-        assert_eq!(label, "[█=5.5s]");
+        assert_eq!(label, "[█=15s]");
     }
 
     #[test]
@@ -129,7 +129,7 @@ mod tests {
             chart_width: 50,
         };
         let label = StatusBarWidget::time_per_column_label(&cache).unwrap();
-        assert_eq!(label, "[█=2.5m]");
+        assert_eq!(label, "[█=5m]");
     }
 
     #[test]
@@ -144,6 +144,28 @@ mod tests {
             chart_width: 50,
         };
         let label = StatusBarWidget::time_per_column_label(&cache).unwrap();
-        assert_eq!(label, "[█=1.5h]");
+        assert_eq!(label, "[█=2h]");
+    }
+
+    #[test]
+    fn test_snap_to_standard_intervals() {
+        // Below 5s: no snap
+        assert_eq!(StatusBarWidget::snap_to_standard(500.0), 500.0);
+        assert_eq!(StatusBarWidget::snap_to_standard(3000.0), 3000.0);
+        // Seconds
+        assert_eq!(StatusBarWidget::snap_to_standard(5_000.0), 5_000.0);
+        assert_eq!(StatusBarWidget::snap_to_standard(8_000.0), 15_000.0);
+        assert_eq!(StatusBarWidget::snap_to_standard(20_000.0), 30_000.0);
+        // Minutes
+        assert_eq!(StatusBarWidget::snap_to_standard(40_000.0), 300_000.0); // 40s → 5m
+        assert_eq!(StatusBarWidget::snap_to_standard(480_000.0), 900_000.0); // 8m → 15m
+        assert_eq!(StatusBarWidget::snap_to_standard(2_700_000.0), 3_600_000.0); // 45m → 1h
+                                                                                 // Hours
+        assert_eq!(StatusBarWidget::snap_to_standard(3_600_000.0), 3_600_000.0); // 1h
+        assert_eq!(StatusBarWidget::snap_to_standard(5_000_000.0), 7_200_000.0); // → 2h
+        assert_eq!(
+            StatusBarWidget::snap_to_standard(10_000_000.0),
+            21_600_000.0
+        ); // → 6h
     }
 }


### PR DESCRIPTION
Snap raw ms-per-bucket up to the nearest standard interval for cleaner density chart labels.

**Standard intervals:** 5s, 15s, 30s, 5m, 15m, 30m, 1h, 2h, 6h, 12h, 24h
**Below 5s:** shown as raw milliseconds (no snapping)

Examples: raw 3s→`[█=5s]`, 8s→`[█=15s]`, 40s→`[█=5m]`, 45m→`[█=1h]`

- Added `snap_to_standard()` method
- Updated existing label tests for snapped values
- Added dedicated snap interval test
- 212 tests pass

Closes #275