### PR TITLE
[PM Spec] Fix spec and README inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Scouty helps developers and SREs browse, parse, filter, and analyze logs from mu
 - **Stdin/pipe input** — `cat log | scouty-tui` with auto follow mode
 - **Multi-file loading** — Multiple files merged by timestamp (merge-sort)
 - **Default syslog** — Opens `/var/log/syslog` on Linux when no file specified
+- **Configurable default paths** — `default_paths` in `~/.scouty/config.yaml` with glob support
 - **Live syslog** — Real-time syslog stream
 - **OpenTelemetry (OTLP)** — Receive logs via gRPC and HTTP
 
@@ -40,17 +41,18 @@ Each source gets its own loader, and a single session can combine multiple loade
 - **Any field** — Filter on timestamp, level, pid, tid, component, hostname, container, context, function, message, or custom metadata
 
 ### 🖥️ Interactive TUI
-- **Table view** with configurable columns and auto-width
+- **Table view** with configurable columns and auto-width (default: Time + Log; toggle more via `c`)
+- **Column separators** — vertical lines between columns for clarity
 - **Level colors** — FATAL red bold / ERROR red / WARN yellow / INFO green / DEBUG gray / TRACE dark gray / NOTICE cyan
 - **Detail panel** — Split-pane view: left 70% log content, right 30% structured fields table
 - **2-line status bar** — Line 1: density chart + position; Line 2: mode + shortcuts/input/status
 - **Regex search** with match highlighting and navigation
-- **Density graph** — Braille-character time distribution in status bar
-- **Filter dialogs** — Quick exclude/include, field-based multi-select, filter manager
-- **Custom highlight** — `h` to add highlight rule, `H` for highlight manager, auto color rotation
+- **Density graph** — Braille-character time distribution in status bar with `[█=Xs]` time-per-column label
+- **Filter dialogs** — Quick exclude/include, field-based multi-select, filter manager, cursor preserved after filter
+- **Custom highlight** — `h` to add highlight rule, `H` for highlight manager, full-row background coloring, auto color rotation
 - **Time jump** — `]` jump forward / `[` jump backward by relative time (5m, 30s, 2h)
 - **Stats overlay** — `S` shows log level distribution, top components
-- **Save/export** — `Ctrl+s` opens a save file prompt for exporting filtered logs
+- **Save/export** — `Ctrl+s` quick export filtered logs to auto-named file; `:w <filename>` for custom filename
 - **Pipe input** — `cat log | scouty-tui` with auto follow mode
 - **Copy to clipboard** — Raw, JSON, or YAML format via OSC 52
 - **Component architecture** — Unified `UiComponent` trait with standardized keyboard dispatch

--- a/crates/scouty-tui/spec/config.md
+++ b/crates/scouty-tui/spec/config.md
@@ -84,6 +84,7 @@ keybindings:
   # Copy & Export (saving via ":w" in command mode)
   copy_raw: "y"
   copy_format: "Y"
+  quick_export: "ctrl+s"
 
   # General
   help: "?"
@@ -104,7 +105,7 @@ keybindings:
    - Built-in name → use built-in theme
    - `~/.scouty/themes/<name>.yaml` exists → load and merge over default theme
    - Otherwise → warn and fall back to default
-4. CLI flags override config:
+5. CLI flags override config:
    - `--theme <name>` overrides `theme` in config
 
 ### Keybinding Resolution

--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -107,7 +107,7 @@ Components notify App via return values or callbacks. App updates shared state (
 | `S` | Stats summary |
 | `]`/`[` | Relative time jump (forward/backward) |
 | `Ctrl+]` | Toggle follow mode |
-| `Ctrl+s` | Quick export filtered records to auto-named file |
+| `Ctrl+s` | Quick export filtered records to file |
 | `Esc` | Close current overlay |
 | `q` | Quit |
 | `?` | Help |


### PR DESCRIPTION
Consistency fixes across specs and README:

**README.md:**
- Default columns updated: Time + Log only (was 7 columns)
- Added column separator mention
- Added configurable default_paths with glob support
- Added density chart time-per-column label
- Added full-row highlight description
- Added filter cursor preservation
- Fixed Ctrl+s description consistency

**config.md:**
- Fixed duplicate step 4 numbering in loading order
- Added missing quick_export: ctrl+s keybinding

**overview.md:**
- Fixed Ctrl+s description to match copy-and-export spec