### PR TITLE
[PM Spec] Remove Ctrl+s, export is via :w only

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each source gets its own loader, and a single session can combine multiple loade
 - **Custom highlight** — `h` to add highlight rule, `H` for highlight manager, full-row background coloring, auto color rotation
 - **Time jump** — `]` jump forward / `[` jump backward by relative time (5m, 30s, 2h)
 - **Stats overlay** — `S` shows log level distribution, top components
-- **Save/export** — `Ctrl+s` quick export filtered logs to auto-named file; `:w <filename>` for custom filename
+- **Save/export** — `:w <filename>` in command mode to export filtered logs to file
 - **Pipe input** — `cat log | scouty-tui` with auto follow mode
 - **Copy to clipboard** — Raw, JSON, or YAML format via OSC 52
 - **Component architecture** — Unified `UiComponent` trait with standardized keyboard dispatch
@@ -165,7 +165,6 @@ journalctl -f | scouty-tui
 |-----|--------|
 | `y` | Copy selected row (raw text) |
 | `Y` | Copy with format dialog (Raw/JSON/YAML) |
-| `Ctrl+s` | Save/export current view to file |
 
 ### General
 

--- a/crates/scouty-tui/spec/config.md
+++ b/crates/scouty-tui/spec/config.md
@@ -84,7 +84,6 @@ keybindings:
   # Copy & Export (saving via ":w" in command mode)
   copy_raw: "y"
   copy_format: "Y"
-  quick_export: "ctrl+s"
 
   # General
   help: "?"

--- a/crates/scouty-tui/spec/copy-and-export.md
+++ b/crates/scouty-tui/spec/copy-and-export.md
@@ -24,8 +24,6 @@ Features for copying log records to clipboard and exporting filtered results to 
 - No filename: error `Usage: :w <filename>`
 - Command mode extensible for future commands
 
-> **Note:** Prior to command mode implementation, export uses `Ctrl+s` with a `[SAVE]` prompt.
-
 ## Change Log
 
 | Date | Change |

--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -107,7 +107,6 @@ Components notify App via return values or callbacks. App updates shared state (
 | `S` | Stats summary |
 | `]`/`[` | Relative time jump (forward/backward) |
 | `Ctrl+]` | Toggle follow mode |
-| `Ctrl+s` | Quick export filtered records to file |
 | `Esc` | Close current overlay |
 | `q` | Quit |
 | `?` | Help |


### PR DESCRIPTION
Remove all Ctrl+s / quick_export references. Export is done via :w command in command mode only.

Files updated: README.md, config.md, copy-and-export.md, overview.md