### PR TITLE
fix: use workspace dependency for scouty crate version sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,8 +59,9 @@ jobs:
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
-          # Update workspace Cargo.toml
-          sed -i "s/^version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" Cargo.toml
+          # Update workspace Cargo.toml (package version and dependency version)
+          sed -i "0,/^version = \"$CURRENT\"/s/^version = \"$CURRENT\"/version = \"$NEW_VERSION\"/" Cargo.toml
+          sed -i "s/scouty = { path = \"crates\/scouty\", version = \"$CURRENT\" }/scouty = { path = \"crates\/scouty\", version = \"$NEW_VERSION\" }/" Cargo.toml
 
           # Update Cargo.lock
           cargo generate-lockfile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ rust-version = "1.70"
 license = "Apache-2.0"
 repository = "https://github.com/r12f/scouty"
 description = "A log viewing and analysis tool"
+
+[workspace.dependencies]
+scouty = { path = "crates/scouty", version = "0.1.2" }

--- a/crates/scouty-tui/Cargo.toml
+++ b/crates/scouty-tui/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Terminal UI for scouty log viewer"
 
 [dependencies]
-scouty = { path = "../scouty", version = "0.1.2" }
+scouty = { workspace = true }
 chrono = "0.4"
 ratatui = "0.29"
 crossterm = "0.28"


### PR DESCRIPTION
## Problem

`scouty-tui/Cargo.toml` had a hardcoded version for the scouty dependency:
```toml
scouty = { path = "../scouty", version = "0.1.2" }
```

The release pipeline only bumped `[workspace.package] version` in the root `Cargo.toml`, but did **not** update this dependency reference. This means after a version bump, `cargo publish -p scouty-tui` would fail because it references the old scouty version.

## Fix

1. Added `[workspace.dependencies]` section with `scouty = { path = "crates/scouty", version = "0.1.2" }`
2. Changed scouty-tui to use `scouty = { workspace = true }`
3. Updated release pipeline to bump **both** the workspace package version and the workspace dependency version

Now version bumps are centralized — only the root Cargo.toml needs updating.