### PR TITLE
feat: multi-layer config loading with deep merge

### DIFF
--- a/crates/scouty-tui/src/config/config_tests.rs
+++ b/crates/scouty-tui/src/config/config_tests.rs
@@ -61,4 +61,60 @@ mod tests {
         let cfg = Config::default();
         assert!(cfg.default_paths.is_empty());
     }
+
+    #[test]
+    fn test_deep_merge_scalars() {
+        let base: serde_yaml::Value = serde_yaml::from_str("theme: default").unwrap();
+        let overlay: serde_yaml::Value = serde_yaml::from_str("theme: dark").unwrap();
+        let merged = super::super::deep_merge(base, overlay);
+        let cfg: Config = serde_yaml::from_value(merged).unwrap();
+        assert_eq!(cfg.theme, "dark");
+    }
+
+    #[test]
+    fn test_deep_merge_maps() {
+        let base: serde_yaml::Value =
+            serde_yaml::from_str("general:\n  follow_on_pipe: true\n  detail_panel_ratio: 0.3")
+                .unwrap();
+        let overlay: serde_yaml::Value =
+            serde_yaml::from_str("general:\n  detail_panel_ratio: 0.5").unwrap();
+        let merged = super::super::deep_merge(base, overlay);
+        let cfg: Config = serde_yaml::from_value(merged).unwrap();
+        // Deep merge: follow_on_pipe preserved, detail_panel_ratio overridden
+        assert!(cfg.general.follow_on_pipe);
+        assert!((cfg.general.detail_panel_ratio - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_deep_merge_list_replaces() {
+        let base: serde_yaml::Value =
+            serde_yaml::from_str("default_paths:\n  - /var/log/syslog").unwrap();
+        let overlay: serde_yaml::Value =
+            serde_yaml::from_str("default_paths:\n  - /tmp/a.log\n  - /tmp/b.log").unwrap();
+        let merged = super::super::deep_merge(base, overlay);
+        let cfg: Config = serde_yaml::from_value(merged).unwrap();
+        // List is fully replaced, not appended
+        assert_eq!(cfg.default_paths, vec!["/tmp/a.log", "/tmp/b.log"]);
+    }
+
+    #[test]
+    fn test_deep_merge_null_resets() {
+        let base: serde_yaml::Value = serde_yaml::from_str("theme: dark").unwrap();
+        let overlay: serde_yaml::Value = serde_yaml::from_str("theme: null").unwrap();
+        let merged = super::super::deep_merge(base, overlay);
+        // theme key removed → deserialization uses default
+        let cfg: Config = serde_yaml::from_value(merged).unwrap();
+        assert_eq!(cfg.theme, "default");
+    }
+
+    #[test]
+    fn test_load_config_layered_with_file() {
+        let dir = std::env::temp_dir().join("scouty_test_layered");
+        let _ = std::fs::create_dir_all(&dir);
+        let config_path = dir.join("override.yaml");
+        std::fs::write(&config_path, "theme: solarized\n").unwrap();
+        let cfg = super::super::load_config_layered(Some(config_path.to_str().unwrap()));
+        assert_eq!(cfg.theme, "solarized");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -1,6 +1,10 @@
 //! Configuration system for scouty-tui.
 //!
-//! Loads `~/.scouty/config.yaml` at startup, merging user overrides with defaults.
+//! Supports layered config loading:
+//! 1. Built-in defaults (compiled in)
+//! 2. `/etc/scouty/config.yaml` (system-wide, if exists)
+//! 3. `~/.scouty/config.yaml` (per-user, if exists)
+//! 4. CLI flags (`--theme`, `--config`, file arguments)
 
 pub mod color;
 pub mod theme;
@@ -9,7 +13,7 @@ pub use color::ThemeColor;
 pub use theme::Theme;
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Top-level configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -80,27 +84,95 @@ pub fn expand_default_paths(patterns: &[String]) -> Vec<String> {
     results
 }
 
+/// Return the system-wide config directory: `/etc/scouty/`.
+pub fn system_config_dir() -> PathBuf {
+    PathBuf::from("/etc/scouty")
+}
+
 /// Return the scouty config directory: `~/.scouty/`.
 pub fn config_dir() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".scouty"))
 }
 
-/// Load config from `~/.scouty/config.yaml`. Returns defaults if file missing or invalid.
-pub fn load_config() -> Config {
-    let Some(dir) = config_dir() else {
-        return Config::default();
-    };
-    let path = dir.join("config.yaml");
-    match std::fs::read_to_string(&path) {
-        Ok(content) => match serde_yaml::from_str::<Config>(&content) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                eprintln!("warning: invalid config {}: {e}", path.display());
-                Config::default()
+/// Deep-merge two serde_yaml Values.
+/// - Maps: recursively merge (later keys override).
+/// - Scalars/lists: later replaces earlier entirely.
+/// - Null in overlay resets the key (removes it so default applies).
+fn deep_merge(base: serde_yaml::Value, overlay: serde_yaml::Value) -> serde_yaml::Value {
+    use serde_yaml::Value;
+    match (base, overlay) {
+        (Value::Mapping(mut base_map), Value::Mapping(over_map)) => {
+            for (key, over_val) in over_map {
+                if over_val.is_null() {
+                    base_map.remove(&key);
+                } else if let Some(base_val) = base_map.remove(&key) {
+                    base_map.insert(key, deep_merge(base_val, over_val));
+                } else {
+                    base_map.insert(key, over_val);
+                }
             }
-        },
-        Err(_) => Config::default(),
+            Value::Mapping(base_map)
+        }
+        (_, overlay) => overlay,
     }
+}
+
+/// Load a YAML file and return it as a Value, or None if missing/invalid.
+fn load_yaml_file(path: &Path) -> Option<serde_yaml::Value> {
+    let content = std::fs::read_to_string(path).ok()?;
+    match serde_yaml::from_str(&content) {
+        Ok(v) => Some(v),
+        Err(e) => {
+            eprintln!("warning: invalid config {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+/// Load config with layered merge: defaults → /etc/scouty → ~/.scouty → optional CLI path.
+/// `cli_config_path` corresponds to `--config <path>`.
+pub fn load_config_layered(cli_config_path: Option<&str>) -> Config {
+    // Start with defaults as YAML value
+    let mut merged = serde_yaml::to_value(Config::default()).unwrap_or(serde_yaml::Value::Null);
+
+    // Layer 2: system-wide
+    let sys_path = system_config_dir().join("config.yaml");
+    if let Some(sys_val) = load_yaml_file(&sys_path) {
+        merged = deep_merge(merged, sys_val);
+    }
+
+    // Layer 3: per-user
+    if let Some(dir) = config_dir() {
+        let user_path = dir.join("config.yaml");
+        if let Some(user_val) = load_yaml_file(&user_path) {
+            merged = deep_merge(merged, user_val);
+        }
+    }
+
+    // Layer 4: CLI --config override
+    if let Some(cli_path) = cli_config_path {
+        let path = Path::new(cli_path);
+        if let Some(cli_val) = load_yaml_file(path) {
+            merged = deep_merge(merged, cli_val);
+        } else if !path.exists() {
+            eprintln!("warning: config file not found: {cli_path}");
+        }
+    }
+
+    // Deserialize merged value into Config
+    match serde_yaml::from_value(merged) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!("warning: failed to parse merged config: {e}");
+            Config::default()
+        }
+    }
+}
+
+/// Load config from `~/.scouty/config.yaml`. Returns defaults if file missing or invalid.
+/// Convenience wrapper that uses layered loading.
+pub fn load_config() -> Config {
+    load_config_layered(None)
 }
 
 /// Resolve the theme based on config and optional CLI override.
@@ -124,9 +196,18 @@ pub fn resolve_theme(config: &Config, cli_theme: Option<&str>) -> Theme {
         return theme;
     }
 
-    // Try loading from ~/.scouty/themes/<name>.yaml
-    if let Some(dir) = config_dir() {
-        let theme_path = dir.join("themes").join(format!("{theme_name}.yaml"));
+    // Try loading from ~/.scouty/themes/<name>.yaml, then /etc/scouty/themes/<name>.yaml
+    let theme_dirs: Vec<PathBuf> = {
+        let mut dirs = Vec::new();
+        if let Some(dir) = config_dir() {
+            dirs.push(dir.join("themes"));
+        }
+        dirs.push(system_config_dir().join("themes"));
+        dirs
+    };
+
+    for dir in &theme_dirs {
+        let theme_path = dir.join(format!("{theme_name}.yaml"));
         match std::fs::read_to_string(&theme_path) {
             Ok(content) => match Theme::from_yaml(&content) {
                 Ok(theme) => return theme,
@@ -134,12 +215,11 @@ pub fn resolve_theme(config: &Config, cli_theme: Option<&str>) -> Theme {
                     eprintln!("warning: invalid theme file {}: {e}", theme_path.display());
                 }
             },
-            Err(_) => {
-                eprintln!("warning: theme '{}' not found, using default", theme_name);
-            }
+            Err(_) => continue,
         }
     }
 
+    eprintln!("warning: theme '{}' not found, using default", theme_name);
     Theme::default()
 }
 

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Parse CLI flags
     let mut theme_override: Option<String> = None;
+    let mut config_override: Option<String> = None;
     let mut file_args: Vec<String> = Vec::new();
     let mut i = 1;
     while i < args.len() {
@@ -79,14 +80,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 theme_override = Some(arg.trim_start_matches("--theme=").to_string());
                 i += 1;
             }
+            "--config" => {
+                if i + 1 < args.len() {
+                    config_override = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --config requires a value");
+                    std::process::exit(1);
+                }
+            }
+            arg if arg.starts_with("--config=") => {
+                config_override = Some(arg.trim_start_matches("--config=").to_string());
+                i += 1;
+            }
             "--help" | "-h" => {
                 eprintln!("Usage: scouty-tui [OPTIONS] [FILES...]");
                 eprintln!();
                 eprintln!("Options:");
                 eprintln!(
-                    "  --theme <name>  Override theme (default, dark, light, solarized, or custom)"
+                    "  --theme <name>    Override theme (default, dark, light, solarized, or custom)"
                 );
-                eprintln!("  -h, --help      Show this help");
+                eprintln!("  --config <path>   Load additional config file (overrides file-based configs)");
+                eprintln!("  -h, --help        Show this help");
                 std::process::exit(0);
             }
             _ => {
@@ -104,7 +119,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Load config early so default_paths is available for file resolution
-    let cfg = config::load_config();
+    let cfg = config::load_config_layered(config_override.as_deref());
 
     let files: Vec<String> = if !piped && file_args.is_empty() {
         resolve_default_files(&cfg)?


### PR DESCRIPTION
Support layered config loading with field-level deep merge.

**Loading order (lowest → highest priority):**
1. Built-in defaults (compiled in)
2. `/etc/scouty/config.yaml` (system-wide)
3. `~/.scouty/config.yaml` (per-user)
4. CLI flags (`--theme`, `--config <path>`)

**Merge semantics:**
- Maps (keybindings, general): deep merge — only specified keys overridden
- Lists (default_paths): later layer replaces entire list
- Scalars: later replaces earlier
- `null` resets to built-in default

**Theme search order:** `~/.scouty/themes/` → `/etc/scouty/themes/` → built-in presets

- New `--config <path>` CLI flag
- Added `deep_merge()`, `load_config_layered()`, `system_config_dir()`
- 5 new tests for merge semantics and layered loading
- All 217 tests pass

Closes #283