### PR TITLE
fix: change filter equality operator from = to ==

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -163,7 +163,7 @@ pub struct FilterEntry {
 /// Kind of field filter entry.
 #[derive(Clone, Debug, PartialEq)]
 pub enum FieldEntryKind {
-    /// Regular field: generates `field = "value"`.
+    /// Regular field: generates `field == "value"`.
     Field,
     /// Time before: generates `timestamp < "rfc3339"` (exclude) or `<= "rfc3339"` (include).
     TimeBefore { rfc3339: String },
@@ -772,7 +772,7 @@ impl App {
                 }
                 FieldEntryKind::Field => {
                     field_parts.push(format!(
-                        "{} = \"{}\"",
+                        "{} == \"{}\"",
                         entry.name,
                         entry.value.replace('"', "\\\"")
                     ));
@@ -1898,7 +1898,7 @@ mod tests {
             ("warn msg", Some(LogLevel::Warn)),
         ]);
 
-        app.filter_input.set(r#"level = "ERROR""#);
+        app.filter_input.set(r#"level == "ERROR""#);
         app.apply_filter();
         // The filter parser requires string values in quotes
         assert_eq!(app.filters.len(), 1);

--- a/crates/scouty/src/filter/engine_tests.rs
+++ b/crates/scouty/src/filter/engine_tests.rs
@@ -115,7 +115,7 @@ mod tests {
     fn expr_filter_exclude() {
         let mut engine = FilterEngine::new();
         engine
-            .add_expr_filter(FilterAction::Exclude, r#"level = "ERROR""#)
+            .add_expr_filter(FilterAction::Exclude, r#"level == "ERROR""#)
             .unwrap();
 
         let records = vec![
@@ -130,7 +130,7 @@ mod tests {
     fn expr_filter_include() {
         let mut engine = FilterEngine::new();
         engine
-            .add_expr_filter(FilterAction::Include, r#"level = "WARN""#)
+            .add_expr_filter(FilterAction::Include, r#"level == "WARN""#)
             .unwrap();
 
         let records = vec![
@@ -146,7 +146,7 @@ mod tests {
         engine
             .add_expr_filter(
                 FilterAction::Include,
-                r#"level = "ERROR" OR level = "FATAL""#,
+                r#"level == "ERROR" OR level == "FATAL""#,
             )
             .unwrap();
         engine
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn expr_filter_invalid_expression() {
         let mut engine = FilterEngine::new();
-        let result = engine.add_expr_filter(FilterAction::Include, r#"level = "#);
+        let result = engine.add_expr_filter(FilterAction::Include, r#"level == "#);
         assert!(result.is_err());
     }
 

--- a/crates/scouty/src/filter/eval_tests.rs
+++ b/crates/scouty/src/filter/eval_tests.rs
@@ -31,14 +31,14 @@ mod tests {
 
     #[test]
     fn eval_eq_level() {
-        let expr = parse(r#"level = "ERROR""#).unwrap();
+        let expr = parse(r#"level == "ERROR""#).unwrap();
         let r = make_record(LogLevel::Error, "boom", None);
         assert!(eval(&expr, &r));
     }
 
     #[test]
     fn eval_eq_level_no_match() {
-        let expr = parse(r#"level = "ERROR""#).unwrap();
+        let expr = parse(r#"level == "ERROR""#).unwrap();
         let r = make_record(LogLevel::Info, "ok", None);
         assert!(!eval(&expr, &r));
     }
@@ -94,35 +94,36 @@ mod tests {
 
     #[test]
     fn eval_and() {
-        let expr = parse(r#"level = "ERROR" AND component = "auth""#).unwrap();
+        let expr = parse(r#"level == "ERROR" AND component == "auth""#).unwrap();
         let r = make_record(LogLevel::Error, "fail", Some("auth"));
         assert!(eval(&expr, &r));
     }
 
     #[test]
     fn eval_and_one_fails() {
-        let expr = parse(r#"level = "ERROR" AND component = "db""#).unwrap();
+        let expr = parse(r#"level == "ERROR" AND component == "db""#).unwrap();
         let r = make_record(LogLevel::Error, "fail", Some("auth"));
         assert!(!eval(&expr, &r));
     }
 
     #[test]
     fn eval_or() {
-        let expr = parse(r#"level = "ERROR" OR level = "FATAL""#).unwrap();
+        let expr = parse(r#"level == "ERROR" OR level == "FATAL""#).unwrap();
         let r = make_record(LogLevel::Error, "fail", None);
         assert!(eval(&expr, &r));
     }
 
     #[test]
     fn eval_not() {
-        let expr = parse(r#"NOT level = "DEBUG""#).unwrap();
+        let expr = parse(r#"NOT level == "DEBUG""#).unwrap();
         let r = make_record(LogLevel::Error, "fail", None);
         assert!(eval(&expr, &r));
     }
 
     #[test]
     fn eval_complex_nested() {
-        let expr = parse(r#"(level = "ERROR" OR level = "FATAL") AND component = "auth""#).unwrap();
+        let expr =
+            parse(r#"(level == "ERROR" OR level == "FATAL") AND component == "auth""#).unwrap();
         let r = make_record(LogLevel::Error, "fail", Some("auth"));
         assert!(eval(&expr, &r));
 
@@ -132,28 +133,28 @@ mod tests {
 
     #[test]
     fn eval_metadata_field() {
-        let expr = parse(r#"metadata.env = "prod""#).unwrap();
+        let expr = parse(r#"metadata.env == "prod""#).unwrap();
         let r = make_record(LogLevel::Info, "ok", None);
         assert!(eval(&expr, &r));
     }
 
     #[test]
     fn eval_missing_field_returns_false() {
-        let expr = parse(r#"component = "auth""#).unwrap();
+        let expr = parse(r#"component == "auth""#).unwrap();
         let r = make_record(LogLevel::Info, "ok", None); // component is None
         assert!(!eval(&expr, &r));
     }
 
     #[test]
     fn eval_pid() {
-        let expr = parse("pid = 1234").unwrap();
+        let expr = parse("pid == 1234").unwrap();
         let r = make_record(LogLevel::Info, "ok", None);
         assert!(eval(&expr, &r));
     }
 
     #[test]
     fn eval_source() {
-        let expr = parse(r#"source = "test-source""#).unwrap();
+        let expr = parse(r#"source == "test-source""#).unwrap();
         let r = make_record(LogLevel::Info, "ok", None);
         assert!(eval(&expr, &r));
     }
@@ -162,7 +163,7 @@ mod tests {
     fn eval_context() {
         let mut r = make_record(LogLevel::Info, "ok", None);
         r.context = Some("Ethernet248".to_string());
-        let expr = parse(r#"context = "Ethernet248""#).unwrap();
+        let expr = parse(r#"context == "Ethernet248""#).unwrap();
         assert!(eval(&expr, &r));
         let expr2 = parse(r#"context contains "Ethernet""#).unwrap();
         assert!(eval(&expr2, &r));
@@ -172,9 +173,9 @@ mod tests {
     fn eval_function() {
         let mut r = make_record(LogLevel::Info, "ok", None);
         r.function = Some("SET".to_string());
-        let expr = parse(r#"function = "SET""#).unwrap();
+        let expr = parse(r#"function == "SET""#).unwrap();
         assert!(eval(&expr, &r));
-        let expr2 = parse(r#"function = "DEL""#).unwrap();
+        let expr2 = parse(r#"function == "DEL""#).unwrap();
         assert!(!eval(&expr2, &r));
     }
 }

--- a/crates/scouty/src/filter/expr.rs
+++ b/crates/scouty/src/filter/expr.rs
@@ -8,7 +8,7 @@
 //!   primary  = "(" expr ")" | comparison
 //!   comparison = field op value
 //!   field    = identifier (dotted allowed: "metadata.key")
-//!   op       = "=" | "!=" | ">" | ">=" | "<" | "<=" | "contains" | "starts_with" | "ends_with" | "regex"
+//!   op       = "==" | "!=" | ">" | ">=" | "<" | "<=" | "contains" | "starts_with" | "ends_with" | "regex"
 //!   value    = quoted_string | unquoted_token
 
 use std::fmt;
@@ -31,7 +31,7 @@ pub enum Op {
 impl fmt::Display for Op {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Op::Eq => write!(f, "="),
+            Op::Eq => write!(f, "=="),
             Op::Ne => write!(f, "!="),
             Op::Gt => write!(f, ">"),
             Op::Ge => write!(f, ">="),
@@ -128,12 +128,14 @@ fn tokenize(input: &str) -> Result<Vec<Token>, String> {
             continue;
         }
 
-        // Single-char operators
-        if chars[i] == '=' {
+        // == equality operator
+        if chars[i] == '=' && i + 1 < len && chars[i + 1] == '=' {
             tokens.push(Token::Op(Op::Eq));
-            i += 1;
+            i += 2;
             continue;
         }
+
+        // Single = is not supported — skip to produce a parse error
         if chars[i] == '>' {
             tokens.push(Token::Op(Op::Gt));
             i += 1;

--- a/crates/scouty/src/filter/expr_tests.rs
+++ b/crates/scouty/src/filter/expr_tests.rs
@@ -4,7 +4,7 @@ mod tests {
 
     #[test]
     fn simple_comparison() {
-        let expr = parse(r#"level = "Error""#).unwrap();
+        let expr = parse(r#"level == "Error""#).unwrap();
         assert_eq!(
             expr,
             Expr::Comparison {
@@ -17,7 +17,7 @@ mod tests {
 
     #[test]
     fn and_expression() {
-        let expr = parse(r#"level = "Error" AND component = "auth""#).unwrap();
+        let expr = parse(r#"level == "Error" AND component == "auth""#).unwrap();
         match expr {
             Expr::And(left, right) => {
                 assert_eq!(
@@ -43,7 +43,7 @@ mod tests {
 
     #[test]
     fn or_expression() {
-        let expr = parse(r#"level = "Error" OR level = "Fatal""#).unwrap();
+        let expr = parse(r#"level == "Error" OR level == "Fatal""#).unwrap();
         match expr {
             Expr::Or(left, right) => {
                 assert_eq!(
@@ -69,7 +69,8 @@ mod tests {
 
     #[test]
     fn parenthesized_expression() {
-        let expr = parse(r#"(level = "Error" OR level = "Fatal") AND component = "auth""#).unwrap();
+        let expr =
+            parse(r#"(level == "Error" OR level == "Fatal") AND component == "auth""#).unwrap();
         match expr {
             Expr::And(left, right) => {
                 assert!(matches!(*left, Expr::Or(_, _)));
@@ -88,7 +89,7 @@ mod tests {
 
     #[test]
     fn not_expression() {
-        let expr = parse(r#"NOT level = "Debug""#).unwrap();
+        let expr = parse(r#"NOT level == "Debug""#).unwrap();
         match expr {
             Expr::Not(inner) => {
                 assert_eq!(
@@ -106,7 +107,7 @@ mod tests {
 
     #[test]
     fn nested_not() {
-        let expr = parse(r#"NOT NOT level = "Info""#).unwrap();
+        let expr = parse(r#"NOT NOT level == "Info""#).unwrap();
         match expr {
             Expr::Not(inner) => assert!(matches!(*inner, Expr::Not(_))),
             _ => panic!("Expected nested Not"),
@@ -116,7 +117,7 @@ mod tests {
     #[test]
     fn all_operators() {
         for (op_str, expected_op) in &[
-            ("=", Op::Eq),
+            ("==", Op::Eq),
             ("!=", Op::Ne),
             (">", Op::Gt),
             (">=", Op::Ge),
@@ -143,7 +144,7 @@ mod tests {
     #[test]
     fn and_has_higher_precedence_than_or() {
         // "a OR b AND c" should parse as "a OR (b AND c)"
-        let expr = parse(r#"level = "A" OR level = "B" AND level = "C""#).unwrap();
+        let expr = parse(r#"level == "A" OR level == "B" AND level == "C""#).unwrap();
         match expr {
             Expr::Or(_, right) => assert!(matches!(*right, Expr::And(_, _))),
             _ => panic!("Expected OR at top level"),
@@ -165,7 +166,7 @@ mod tests {
 
     #[test]
     fn metadata_dot_field() {
-        let expr = parse(r#"metadata.env = "prod""#).unwrap();
+        let expr = parse(r#"metadata.env == "prod""#).unwrap();
         assert_eq!(
             expr,
             Expr::Comparison {
@@ -178,7 +179,7 @@ mod tests {
 
     #[test]
     fn complex_nested() {
-        let expr = parse(r#"(level = "Error" OR level = "Fatal") AND (component = "auth" OR component = "db") AND NOT source = "test""#).unwrap();
+        let expr = parse(r#"(level == "Error" OR level == "Fatal") AND (component == "auth" OR component == "db") AND NOT source == "test""#).unwrap();
         // Should parse without error
         assert!(matches!(expr, Expr::And(_, _)));
     }
@@ -195,12 +196,12 @@ mod tests {
 
     #[test]
     fn unclosed_paren_error() {
-        assert!(parse(r#"(level = "Error""#).is_err());
+        assert!(parse(r#"(level == "Error""#).is_err());
     }
 
     #[test]
     fn single_quotes() {
-        let expr = parse("level = 'Error'").unwrap();
+        let expr = parse("level == 'Error'").unwrap();
         assert_eq!(
             expr,
             Expr::Comparison {
@@ -209,5 +210,10 @@ mod tests {
                 value: "Error".into()
             }
         );
+    }
+
+    #[test]
+    fn single_equals_is_error() {
+        assert!(parse(r#"level = "Error""#).is_err());
     }
 }

--- a/crates/scouty/src/integration_tests.rs
+++ b/crates/scouty/src/integration_tests.rs
@@ -76,7 +76,7 @@ mod tests {
         session.add_loader(Box::new(FileLoader::new(path, false)), group);
         session
             .filter_engine_mut()
-            .add_expr_filter(FilterAction::Include, "level = ERROR")
+            .add_expr_filter(FilterAction::Include, "level == ERROR")
             .unwrap();
 
         let filtered = session.run().unwrap();
@@ -110,7 +110,7 @@ mod tests {
         // Include only ERROR and WARN, then exclude messages containing "Fatal"
         session
             .filter_engine_mut()
-            .add_expr_filter(FilterAction::Include, "level = ERROR OR level = WARN")
+            .add_expr_filter(FilterAction::Include, "level == ERROR OR level == WARN")
             .unwrap();
         session
             .filter_engine_mut()
@@ -195,7 +195,7 @@ random garbage
         // Now add a filter and get filtered view without re-running load
         session
             .filter_engine_mut()
-            .add_expr_filter(FilterAction::Include, "level = ERROR")
+            .add_expr_filter(FilterAction::Include, "level == ERROR")
             .unwrap();
         session.refresh_active_view();
         let view = session.filtered_view();
@@ -355,7 +355,7 @@ random garbage
         // Now filter
         session
             .filter_engine_mut()
-            .add_expr_filter(FilterAction::Include, "level = ERROR")
+            .add_expr_filter(FilterAction::Include, "level == ERROR")
             .unwrap();
 
         session.refresh_active_view();

--- a/crates/scouty/src/view_tests.rs
+++ b/crates/scouty/src/view_tests.rs
@@ -61,7 +61,7 @@ mod tests {
         let store = make_store_with_records();
         let mut engine = FilterEngine::new();
         engine
-            .add_expr_filter(FilterAction::Exclude, r#"level = "ERROR""#)
+            .add_expr_filter(FilterAction::Exclude, r#"level == "ERROR""#)
             .unwrap();
 
         let mut view = LogStoreView::new(engine);
@@ -77,7 +77,7 @@ mod tests {
         let store = make_store_with_records();
         let mut engine = FilterEngine::new();
         engine
-            .add_expr_filter(FilterAction::Include, r#"level = "INFO""#)
+            .add_expr_filter(FilterAction::Include, r#"level == "INFO""#)
             .unwrap();
 
         let mut view = LogStoreView::new(engine);
@@ -93,10 +93,10 @@ mod tests {
         let mut engine = FilterEngine::new();
         // Include INFO and WARN
         engine
-            .add_expr_filter(FilterAction::Include, r#"level = "INFO""#)
+            .add_expr_filter(FilterAction::Include, r#"level == "INFO""#)
             .unwrap();
         engine
-            .add_expr_filter(FilterAction::Include, r#"level = "WARN""#)
+            .add_expr_filter(FilterAction::Include, r#"level == "WARN""#)
             .unwrap();
         // Exclude "all good"
         engine
@@ -142,7 +142,7 @@ mod tests {
         let store = make_store_with_records();
         let mut engine = FilterEngine::new();
         engine
-            .add_expr_filter(FilterAction::Include, r#"level = "FATAL""#)
+            .add_expr_filter(FilterAction::Include, r#"level == "FATAL""#)
             .unwrap();
 
         let mut view = LogStoreView::new(engine);
@@ -184,7 +184,7 @@ mod tests {
 
         let mut engine = FilterEngine::new();
         engine
-            .add_expr_filter(FilterAction::Include, r#"level = "INFO""#)
+            .add_expr_filter(FilterAction::Include, r#"level == "INFO""#)
             .unwrap();
 
         let mut view = LogStoreView::new(engine);
@@ -258,7 +258,7 @@ mod tests {
         let store = make_store_with_records();
         let mut engine = FilterEngine::new();
         engine
-            .add_expr_filter(FilterAction::Include, r#"level = "INFO""#)
+            .add_expr_filter(FilterAction::Include, r#"level == "INFO""#)
             .unwrap();
 
         let mut view = LogStoreView::new(engine);


### PR DESCRIPTION
Change the filter expression equality operator from single `=` to `==` per updated spec.

- Tokenizer: `==` parsed as equality, single `=` now produces parse error
- `Op::Eq` displays as `==`
- Updated grammar comment in expr.rs
- Field filter UI emits `==` instead of `=`
- Updated all tests across both crates (7 files, ~50 lines)
- Added `single_equals_is_error` test
- All 494 tests pass (277 scouty + 217 scouty-tui)

Closes #289