### PR TITLE
[PM Spec] Theme: fix color swatches for GitHub rendering

### DIFF
--- a/crates/scouty-tui/spec/theme.md
+++ b/crates/scouty-tui/spec/theme.md
@@ -96,71 +96,71 @@ general:
 
 ### Built-in Presets — Color Reference
 
-> Each cell shows `fg / bg` hex values. ![color](https://via.placeholder.com/12/HEX/HEX) swatch for quick visual reference.
+> Each cell shows `fg / bg` hex values with a color swatch for quick visual reference.
 
 #### Log Levels
 
 | Area | default | dark | light | solarized |
 |------|---------|------|-------|-----------|
-| FATAL fg | ![](https://via.placeholder.com/12/FF0000/FF0000) `red` bold | ![](https://via.placeholder.com/12/CC0000/CC0000) `#CC0000` bold | ![](https://via.placeholder.com/12/CC0000/CC0000) `#CC0000` bold | ![](https://via.placeholder.com/12/DC322F/DC322F) `#DC322F` bold |
-| ERROR fg | ![](https://via.placeholder.com/12/FF6B6B/FF6B6B) `#FF6B6B` | ![](https://via.placeholder.com/12/CC6666/CC6666) `#CC6666` | ![](https://via.placeholder.com/12/CC0000/CC0000) `#CC0000` | ![](https://via.placeholder.com/12/DC322F/DC322F) `#DC322F` |
-| WARN fg | ![](https://via.placeholder.com/12/FFD93D/FFD93D) `#FFD93D` | ![](https://via.placeholder.com/12/CCAA33/CCAA33) `#CCAA33` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` |
-| NOTICE fg | ![](https://via.placeholder.com/12/6BCB77/6BCB77) `#6BCB77` | ![](https://via.placeholder.com/12/5A9A65/5A9A65) `#5A9A65` | ![](https://via.placeholder.com/12/2AA198/2AA198) `#2AA198` | ![](https://via.placeholder.com/12/2AA198/2AA198) `#2AA198` |
-| INFO fg | ![](https://via.placeholder.com/12/4FC3F7/4FC3F7) `#4FC3F7` | ![](https://via.placeholder.com/12/6699CC/6699CC) `#6699CC` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` |
-| DEBUG fg | ![](https://via.placeholder.com/12/8B8B8B/8B8B8B) `#8B8B8B` | ![](https://via.placeholder.com/12/666666/666666) `#666666` | ![](https://via.placeholder.com/12/888888/888888) `#888888` | ![](https://via.placeholder.com/12/839496/839496) `#839496` |
-| TRACE fg | ![](https://via.placeholder.com/12/5C5C5C/5C5C5C) `#5C5C5C` | ![](https://via.placeholder.com/12/444444/444444) `#444444` | ![](https://via.placeholder.com/12/AAAAAA/AAAAAA) `#AAAAAA` | ![](https://via.placeholder.com/12/657B83/657B83) `#657B83` |
+| FATAL fg | ![](https://placehold.co/16x16/FF0000/FF0000.png) `red` bold | ![](https://placehold.co/16x16/CC0000/CC0000.png) `#CC0000` bold | ![](https://placehold.co/16x16/CC0000/CC0000.png) `#CC0000` bold | ![](https://placehold.co/16x16/DC322F/DC322F.png) `#DC322F` bold |
+| ERROR fg | ![](https://placehold.co/16x16/FF6B6B/FF6B6B.png) `#FF6B6B` | ![](https://placehold.co/16x16/CC6666/CC6666.png) `#CC6666` | ![](https://placehold.co/16x16/CC0000/CC0000.png) `#CC0000` | ![](https://placehold.co/16x16/DC322F/DC322F.png) `#DC322F` |
+| WARN fg | ![](https://placehold.co/16x16/FFD93D/FFD93D.png) `#FFD93D` | ![](https://placehold.co/16x16/CCAA33/CCAA33.png) `#CCAA33` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` |
+| NOTICE fg | ![](https://placehold.co/16x16/6BCB77/6BCB77.png) `#6BCB77` | ![](https://placehold.co/16x16/5A9A65/5A9A65.png) `#5A9A65` | ![](https://placehold.co/16x16/2AA198/2AA198.png) `#2AA198` | ![](https://placehold.co/16x16/2AA198/2AA198.png) `#2AA198` |
+| INFO fg | ![](https://placehold.co/16x16/4FC3F7/4FC3F7.png) `#4FC3F7` | ![](https://placehold.co/16x16/6699CC/6699CC.png) `#6699CC` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` |
+| DEBUG fg | ![](https://placehold.co/16x16/8B8B8B/8B8B8B.png) `#8B8B8B` | ![](https://placehold.co/16x16/666666/666666.png) `#666666` | ![](https://placehold.co/16x16/888888/888888.png) `#888888` | ![](https://placehold.co/16x16/839496/839496.png) `#839496` |
+| TRACE fg | ![](https://placehold.co/16x16/5C5C5C/5C5C5C.png) `#5C5C5C` | ![](https://placehold.co/16x16/444444/444444.png) `#444444` | ![](https://placehold.co/16x16/AAAAAA/AAAAAA.png) `#AAAAAA` | ![](https://placehold.co/16x16/657B83/657B83.png) `#657B83` |
 
 #### Table
 
 | Area | default | dark | light | solarized |
 |------|---------|------|-------|-----------|
-| Header fg | ![](https://via.placeholder.com/12/B8C4CE/B8C4CE) `#B8C4CE` bold | ![](https://via.placeholder.com/12/999999/999999) `#999999` bold | ![](https://via.placeholder.com/12/333333/333333) `#333333` bold | ![](https://via.placeholder.com/12/586E75/586E75) `#586E75` bold |
-| Header bg | ![](https://via.placeholder.com/12/1E2A38/1E2A38) `#1E2A38` | ![](https://via.placeholder.com/12/1A1A1A/1A1A1A) `#1A1A1A` | ![](https://via.placeholder.com/12/E8E8E8/E8E8E8) `#E8E8E8` | ![](https://via.placeholder.com/12/073642/073642) `#073642` |
-| Selected bg | ![](https://via.placeholder.com/12/2A3F55/2A3F55) `#2A3F55` | ![](https://via.placeholder.com/12/2A2A2A/2A2A2A) `#2A2A2A` | ![](https://via.placeholder.com/12/D0E4F7/D0E4F7) `#D0E4F7` | ![](https://via.placeholder.com/12/073642/073642) `#073642` |
-| Alternating bg | ![](https://via.placeholder.com/12/0D1117/0D1117) `#0D1117` | ![](https://via.placeholder.com/12/111111/111111) `#111111` | ![](https://via.placeholder.com/12/F8F8F8/F8F8F8) `#F8F8F8` | ![](https://via.placeholder.com/12/002B36/002B36) `#002B36` |
-| Separator fg | ![](https://via.placeholder.com/12/3B4252/3B4252) `#3B4252` | ![](https://via.placeholder.com/12/333333/333333) `#333333` | ![](https://via.placeholder.com/12/CCCCCC/CCCCCC) `#CCCCCC` | ![](https://via.placeholder.com/12/586E75/586E75) `#586E75` |
+| Header fg | ![](https://placehold.co/16x16/B8C4CE/B8C4CE.png) `#B8C4CE` bold | ![](https://placehold.co/16x16/999999/999999.png) `#999999` bold | ![](https://placehold.co/16x16/333333/333333.png) `#333333` bold | ![](https://placehold.co/16x16/586E75/586E75.png) `#586E75` bold |
+| Header bg | ![](https://placehold.co/16x16/1E2A38/1E2A38.png) `#1E2A38` | ![](https://placehold.co/16x16/1A1A1A/1A1A1A.png) `#1A1A1A` | ![](https://placehold.co/16x16/E8E8E8/E8E8E8.png) `#E8E8E8` | ![](https://placehold.co/16x16/073642/073642.png) `#073642` |
+| Selected bg | ![](https://placehold.co/16x16/2A3F55/2A3F55.png) `#2A3F55` | ![](https://placehold.co/16x16/2A2A2A/2A2A2A.png) `#2A2A2A` | ![](https://placehold.co/16x16/D0E4F7/D0E4F7.png) `#D0E4F7` | ![](https://placehold.co/16x16/073642/073642.png) `#073642` |
+| Alternating bg | ![](https://placehold.co/16x16/0D1117/0D1117.png) `#0D1117` | ![](https://placehold.co/16x16/111111/111111.png) `#111111` | ![](https://placehold.co/16x16/F8F8F8/F8F8F8.png) `#F8F8F8` | ![](https://placehold.co/16x16/002B36/002B36.png) `#002B36` |
+| Separator fg | ![](https://placehold.co/16x16/3B4252/3B4252.png) `#3B4252` | ![](https://placehold.co/16x16/333333/333333.png) `#333333` | ![](https://placehold.co/16x16/CCCCCC/CCCCCC.png) `#CCCCCC` | ![](https://placehold.co/16x16/586E75/586E75.png) `#586E75` |
 
 #### Status Bar
 
 | Area | default | dark | light | solarized |
 |------|---------|------|-------|-----------|
-| Line 1 fg | ![](https://via.placeholder.com/12/D4D4D4/D4D4D4) `#D4D4D4` | ![](https://via.placeholder.com/12/AAAAAA/AAAAAA) `#AAAAAA` | ![](https://via.placeholder.com/12/333333/333333) `#333333` | ![](https://via.placeholder.com/12/839496/839496) `#839496` |
-| Line 1 bg | ![](https://via.placeholder.com/12/1B2838/1B2838) `#1B2838` | ![](https://via.placeholder.com/12/1A1A1A/1A1A1A) `#1A1A1A` | ![](https://via.placeholder.com/12/E0E0E0/E0E0E0) `#E0E0E0` | ![](https://via.placeholder.com/12/073642/073642) `#073642` |
-| Line 2 fg | ![](https://via.placeholder.com/12/A0A0A0/A0A0A0) `#A0A0A0` | ![](https://via.placeholder.com/12/777777/777777) `#777777` | ![](https://via.placeholder.com/12/555555/555555) `#555555` | ![](https://via.placeholder.com/12/657B83/657B83) `#657B83` |
-| Line 2 bg | ![](https://via.placeholder.com/12/0D1117/0D1117) `#0D1117` | ![](https://via.placeholder.com/12/0D0D0D/0D0D0D) `#0D0D0D` | ![](https://via.placeholder.com/12/F0F0F0/F0F0F0) `#F0F0F0` | ![](https://via.placeholder.com/12/002B36/002B36) `#002B36` |
-| Mode label fg/bg | ![](https://via.placeholder.com/12/1B2838/1B2838) `#1B2838` / ![](https://via.placeholder.com/12/4FC3F7/4FC3F7) `#4FC3F7` bold | ![](https://via.placeholder.com/12/0D0D0D/0D0D0D) `#0D0D0D` / ![](https://via.placeholder.com/12/6699CC/6699CC) `#6699CC` bold | ![](https://via.placeholder.com/12/FFFFFF/FFFFFF) `white` / ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` bold | ![](https://via.placeholder.com/12/FDF6E3/FDF6E3) `#FDF6E3` / ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` bold |
-| Density chart fg | ![](https://via.placeholder.com/12/4FC3F7/4FC3F7) `#4FC3F7` | ![](https://via.placeholder.com/12/6699CC/6699CC) `#6699CC` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` |
-| Density label fg | ![](https://via.placeholder.com/12/6B7B8D/6B7B8D) `#6B7B8D` | ![](https://via.placeholder.com/12/555555/555555) `#555555` | ![](https://via.placeholder.com/12/888888/888888) `#888888` | ![](https://via.placeholder.com/12/657B83/657B83) `#657B83` |
-| Position fg | ![](https://via.placeholder.com/12/E8E8E8/E8E8E8) `#E8E8E8` | ![](https://via.placeholder.com/12/CCCCCC/CCCCCC) `#CCCCCC` | ![](https://via.placeholder.com/12/222222/222222) `#222222` | ![](https://via.placeholder.com/12/93A1A1/93A1A1) `#93A1A1` |
-| Cursor marker fg | ![](https://via.placeholder.com/12/FFD93D/FFD93D) `#FFD93D` | ![](https://via.placeholder.com/12/CCAA33/CCAA33) `#CCAA33` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` |
+| Line 1 fg | ![](https://placehold.co/16x16/D4D4D4/D4D4D4.png) `#D4D4D4` | ![](https://placehold.co/16x16/AAAAAA/AAAAAA.png) `#AAAAAA` | ![](https://placehold.co/16x16/333333/333333.png) `#333333` | ![](https://placehold.co/16x16/839496/839496.png) `#839496` |
+| Line 1 bg | ![](https://placehold.co/16x16/1B2838/1B2838.png) `#1B2838` | ![](https://placehold.co/16x16/1A1A1A/1A1A1A.png) `#1A1A1A` | ![](https://placehold.co/16x16/E0E0E0/E0E0E0.png) `#E0E0E0` | ![](https://placehold.co/16x16/073642/073642.png) `#073642` |
+| Line 2 fg | ![](https://placehold.co/16x16/A0A0A0/A0A0A0.png) `#A0A0A0` | ![](https://placehold.co/16x16/777777/777777.png) `#777777` | ![](https://placehold.co/16x16/555555/555555.png) `#555555` | ![](https://placehold.co/16x16/657B83/657B83.png) `#657B83` |
+| Line 2 bg | ![](https://placehold.co/16x16/0D1117/0D1117.png) `#0D1117` | ![](https://placehold.co/16x16/0D0D0D/0D0D0D.png) `#0D0D0D` | ![](https://placehold.co/16x16/F0F0F0/F0F0F0.png) `#F0F0F0` | ![](https://placehold.co/16x16/002B36/002B36.png) `#002B36` |
+| Mode label fg/bg | ![](https://placehold.co/16x16/1B2838/1B2838.png) `#1B2838` / ![](https://placehold.co/16x16/4FC3F7/4FC3F7.png) `#4FC3F7` bold | ![](https://placehold.co/16x16/0D0D0D/0D0D0D.png) `#0D0D0D` / ![](https://placehold.co/16x16/6699CC/6699CC.png) `#6699CC` bold | ![](https://placehold.co/16x16/FFFFFF/FFFFFF.png) `white` / ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` bold | ![](https://placehold.co/16x16/FDF6E3/FDF6E3.png) `#FDF6E3` / ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` bold |
+| Density chart fg | ![](https://placehold.co/16x16/4FC3F7/4FC3F7.png) `#4FC3F7` | ![](https://placehold.co/16x16/6699CC/6699CC.png) `#6699CC` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` |
+| Density label fg | ![](https://placehold.co/16x16/6B7B8D/6B7B8D.png) `#6B7B8D` | ![](https://placehold.co/16x16/555555/555555.png) `#555555` | ![](https://placehold.co/16x16/888888/888888.png) `#888888` | ![](https://placehold.co/16x16/657B83/657B83.png) `#657B83` |
+| Position fg | ![](https://placehold.co/16x16/E8E8E8/E8E8E8.png) `#E8E8E8` | ![](https://placehold.co/16x16/CCCCCC/CCCCCC.png) `#CCCCCC` | ![](https://placehold.co/16x16/222222/222222.png) `#222222` | ![](https://placehold.co/16x16/93A1A1/93A1A1.png) `#93A1A1` |
+| Cursor marker fg | ![](https://placehold.co/16x16/FFD93D/FFD93D.png) `#FFD93D` | ![](https://placehold.co/16x16/CCAA33/CCAA33.png) `#CCAA33` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` |
 
 #### Search & Dialogs
 
 | Area | default | dark | light | solarized |
 |------|---------|------|-------|-----------|
-| Match fg/bg | `black` / ![](https://via.placeholder.com/12/FFD93D/FFD93D) `#FFD93D` | `black` / ![](https://via.placeholder.com/12/CCAA33/CCAA33) `#CCAA33` | `black` / ![](https://via.placeholder.com/12/FFD93D/FFD93D) `#FFD93D` | `black` / ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` |
-| Current match fg/bg | `black` / ![](https://via.placeholder.com/12/FF8C42/FF8C42) `#FF8C42` | `black` / ![](https://via.placeholder.com/12/CC7733/CC7733) `#CC7733` | `black` / ![](https://via.placeholder.com/12/FF8C42/FF8C42) `#FF8C42` | `black` / ![](https://via.placeholder.com/12/CB4B16/CB4B16) `#CB4B16` |
-| Dialog border fg | ![](https://via.placeholder.com/12/4FC3F7/4FC3F7) `#4FC3F7` | ![](https://via.placeholder.com/12/6699CC/6699CC) `#6699CC` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` |
-| Input prompt fg | ![](https://via.placeholder.com/12/FFD93D/FFD93D) `#FFD93D` | ![](https://via.placeholder.com/12/CCAA33/CCAA33) `#CCAA33` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` |
+| Match fg/bg | `black` / ![](https://placehold.co/16x16/FFD93D/FFD93D.png) `#FFD93D` | `black` / ![](https://placehold.co/16x16/CCAA33/CCAA33.png) `#CCAA33` | `black` / ![](https://placehold.co/16x16/FFD93D/FFD93D.png) `#FFD93D` | `black` / ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` |
+| Current match fg/bg | `black` / ![](https://placehold.co/16x16/FF8C42/FF8C42.png) `#FF8C42` | `black` / ![](https://placehold.co/16x16/CC7733/CC7733.png) `#CC7733` | `black` / ![](https://placehold.co/16x16/FF8C42/FF8C42.png) `#FF8C42` | `black` / ![](https://placehold.co/16x16/CB4B16/CB4B16.png) `#CB4B16` |
+| Dialog border fg | ![](https://placehold.co/16x16/4FC3F7/4FC3F7.png) `#4FC3F7` | ![](https://placehold.co/16x16/6699CC/6699CC.png) `#6699CC` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` |
+| Input prompt fg | ![](https://placehold.co/16x16/FFD93D/FFD93D.png) `#FFD93D` | ![](https://placehold.co/16x16/CCAA33/CCAA33.png) `#CCAA33` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` |
 
 #### General & Accents
 
 | Area | default | dark | light | solarized |
 |------|---------|------|-------|-----------|
-| Accent fg | ![](https://via.placeholder.com/12/4FC3F7/4FC3F7) `#4FC3F7` | ![](https://via.placeholder.com/12/6699CC/6699CC) `#6699CC` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` |
-| Border fg | ![](https://via.placeholder.com/12/3B4252/3B4252) `#3B4252` | ![](https://via.placeholder.com/12/333333/333333) `#333333` | ![](https://via.placeholder.com/12/CCCCCC/CCCCCC) `#CCCCCC` | ![](https://via.placeholder.com/12/586E75/586E75) `#586E75` |
-| Muted fg | ![](https://via.placeholder.com/12/6B7B8D/6B7B8D) `#6B7B8D` | ![](https://via.placeholder.com/12/555555/555555) `#555555` | ![](https://via.placeholder.com/12/999999/999999) `#999999` | ![](https://via.placeholder.com/12/657B83/657B83) `#657B83` |
+| Accent fg | ![](https://placehold.co/16x16/4FC3F7/4FC3F7.png) `#4FC3F7` | ![](https://placehold.co/16x16/6699CC/6699CC.png) `#6699CC` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` |
+| Border fg | ![](https://placehold.co/16x16/3B4252/3B4252.png) `#3B4252` | ![](https://placehold.co/16x16/333333/333333.png) `#333333` | ![](https://placehold.co/16x16/CCCCCC/CCCCCC.png) `#CCCCCC` | ![](https://placehold.co/16x16/586E75/586E75.png) `#586E75` |
+| Muted fg | ![](https://placehold.co/16x16/6B7B8D/6B7B8D.png) `#6B7B8D` | ![](https://placehold.co/16x16/555555/555555.png) `#555555` | ![](https://placehold.co/16x16/999999/999999.png) `#999999` | ![](https://placehold.co/16x16/657B83/657B83.png) `#657B83` |
 
 #### Highlight Palette (color rotation order)
 
 | # | default | dark | light | solarized |
 |---|---------|------|-------|-----------|
-| 1 | ![](https://via.placeholder.com/12/FF6B6B/FF6B6B) `#FF6B6B` | ![](https://via.placeholder.com/12/CC6666/CC6666) `#CC6666` | ![](https://via.placeholder.com/12/DC322F/DC322F) `#DC322F` | ![](https://via.placeholder.com/12/DC322F/DC322F) `#DC322F` |
-| 2 | ![](https://via.placeholder.com/12/6BCB77/6BCB77) `#6BCB77` | ![](https://via.placeholder.com/12/5A9A65/5A9A65) `#5A9A65` | ![](https://via.placeholder.com/12/2AA198/2AA198) `#2AA198` | ![](https://via.placeholder.com/12/2AA198/2AA198) `#2AA198` |
-| 3 | ![](https://via.placeholder.com/12/4FC3F7/4FC3F7) `#4FC3F7` | ![](https://via.placeholder.com/12/6699CC/6699CC) `#6699CC` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` | ![](https://via.placeholder.com/12/268BD2/268BD2) `#268BD2` |
-| 4 | ![](https://via.placeholder.com/12/FFD93D/FFD93D) `#FFD93D` | ![](https://via.placeholder.com/12/CCAA33/CCAA33) `#CCAA33` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` | ![](https://via.placeholder.com/12/B58900/B58900) `#B58900` |
-| 5 | ![](https://via.placeholder.com/12/CE93D8/CE93D8) `#CE93D8` | ![](https://via.placeholder.com/12/9977AA/9977AA) `#9977AA` | ![](https://via.placeholder.com/12/6C71C4/6C71C4) `#6C71C4` | ![](https://via.placeholder.com/12/6C71C4/6C71C4) `#6C71C4` |
-| 6 | ![](https://via.placeholder.com/12/4DD0E1/4DD0E1) `#4DD0E1` | ![](https://via.placeholder.com/12/5599AA/5599AA) `#5599AA` | ![](https://via.placeholder.com/12/2AA198/2AA198) `#2AA198` | ![](https://via.placeholder.com/12/2AA198/2AA198) `#2AA198` |
+| 1 | ![](https://placehold.co/16x16/FF6B6B/FF6B6B.png) `#FF6B6B` | ![](https://placehold.co/16x16/CC6666/CC6666.png) `#CC6666` | ![](https://placehold.co/16x16/DC322F/DC322F.png) `#DC322F` | ![](https://placehold.co/16x16/DC322F/DC322F.png) `#DC322F` |
+| 2 | ![](https://placehold.co/16x16/6BCB77/6BCB77.png) `#6BCB77` | ![](https://placehold.co/16x16/5A9A65/5A9A65.png) `#5A9A65` | ![](https://placehold.co/16x16/2AA198/2AA198.png) `#2AA198` | ![](https://placehold.co/16x16/2AA198/2AA198.png) `#2AA198` |
+| 3 | ![](https://placehold.co/16x16/4FC3F7/4FC3F7.png) `#4FC3F7` | ![](https://placehold.co/16x16/6699CC/6699CC.png) `#6699CC` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` |
+| 4 | ![](https://placehold.co/16x16/FFD93D/FFD93D.png) `#FFD93D` | ![](https://placehold.co/16x16/CCAA33/CCAA33.png) `#CCAA33` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` | ![](https://placehold.co/16x16/B58900/B58900.png) `#B58900` |
+| 5 | ![](https://placehold.co/16x16/CE93D8/CE93D8.png) `#CE93D8` | ![](https://placehold.co/16x16/9977AA/9977AA.png) `#9977AA` | ![](https://placehold.co/16x16/6C71C4/6C71C4.png) `#6C71C4` | ![](https://placehold.co/16x16/6C71C4/6C71C4.png) `#6C71C4` |
+| 6 | ![](https://placehold.co/16x16/4DD0E1/4DD0E1.png) `#4DD0E1` | ![](https://placehold.co/16x16/5599AA/5599AA.png) `#5599AA` | ![](https://placehold.co/16x16/2AA198/2AA198.png) `#2AA198` | ![](https://placehold.co/16x16/2AA198/2AA198.png) `#2AA198` |
 
 ### Integration
 


### PR DESCRIPTION
Switch color swatch images from via.placeholder.com to placehold.co (16x16 PNG) for reliable rendering in GitHub markdown.