### PR TITLE
fix: input cursor renders at correct position with arrow keys

### DIFF
--- a/crates/scouty-tui/src/text_input.rs
+++ b/crates/scouty-tui/src/text_input.rs
@@ -173,4 +173,18 @@ impl TextInput {
     fn char_count(&self) -> usize {
         self.text.chars().count()
     }
+
+    /// Split text at cursor position for rendering.
+    /// Returns (text_before_cursor, char_at_cursor_or_block, text_after_cursor).
+    pub fn render_parts(&self) -> (&str, String, &str) {
+        let byte_pos = self.byte_pos();
+        let before = &self.text[..byte_pos];
+        if byte_pos < self.text.len() {
+            let ch = self.text[byte_pos..].chars().next().unwrap();
+            let after_pos = byte_pos + ch.len_utf8();
+            (before, ch.to_string(), &self.text[after_pos..])
+        } else {
+            (before, "█".to_string(), "")
+        }
+    }
 }

--- a/crates/scouty-tui/src/text_input_tests.rs
+++ b/crates/scouty-tui/src/text_input_tests.rs
@@ -108,4 +108,52 @@ mod tests {
         assert!(!handled);
         assert_eq!(ti.value(), "");
     }
+
+    #[test]
+    fn render_parts_cursor_at_end() {
+        let ti = TextInput::with_text("abc");
+        let (before, cursor, after) = ti.render_parts();
+        assert_eq!(before, "abc");
+        assert_eq!(cursor, "█");
+        assert_eq!(after, "");
+    }
+
+    #[test]
+    fn render_parts_cursor_in_middle() {
+        let mut ti = TextInput::with_text("hello");
+        ti.move_left();
+        ti.move_left();
+        let (before, cursor, after) = ti.render_parts();
+        assert_eq!(before, "hel");
+        assert_eq!(cursor, "l");
+        assert_eq!(after, "o");
+    }
+
+    #[test]
+    fn render_parts_cursor_at_start() {
+        let mut ti = TextInput::with_text("ab");
+        ti.home();
+        let (before, cursor, after) = ti.render_parts();
+        assert_eq!(before, "");
+        assert_eq!(cursor, "a");
+        assert_eq!(after, "b");
+    }
+
+    #[test]
+    fn insert_at_cursor_middle() {
+        let mut ti = TextInput::with_text("ac");
+        ti.move_left(); // cursor before 'c'
+        ti.insert('b');
+        assert_eq!(ti.value(), "abc");
+        assert_eq!(ti.cursor_position(), 2);
+    }
+
+    #[test]
+    fn backspace_at_cursor_middle() {
+        let mut ti = TextInput::with_text("abc");
+        ti.move_left(); // cursor before 'c'
+        ti.backspace(); // delete 'b'
+        assert_eq!(ti.value(), "ac");
+        assert_eq!(ti.cursor_position(), 1);
+    }
 }

--- a/crates/scouty-tui/src/ui/widgets/filter_input_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/filter_input_widget.rs
@@ -19,10 +19,12 @@ pub struct FilterInputWidget;
 impl FilterInputWidget {
     pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
         let theme = &app.theme;
+        let (before, cursor_ch, after) = app.filter_input.render_parts();
         let mut spans = vec![
             Span::styled("Filter: ", theme.input.prompt.to_style()),
-            Span::raw(app.filter_input.value()),
-            Span::styled("█", theme.input.cursor.to_style()),
+            Span::raw(before),
+            Span::styled(cursor_ch, theme.input.cursor.to_style()),
+            Span::raw(after),
         ];
 
         if let Some(ref err) = app.filter_error {

--- a/crates/scouty-tui/src/ui/widgets/search_input_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/search_input_widget.rs
@@ -19,10 +19,12 @@ pub struct SearchInputWidget;
 impl SearchInputWidget {
     pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
         let theme = &app.theme;
+        let (before, cursor_ch, after) = app.search_input.render_parts();
         let input_line = Paragraph::new(Line::from(vec![
             Span::styled("/", theme.input.prompt.to_style()),
-            Span::raw(app.search_input.value()),
-            Span::styled("█", theme.input.cursor.to_style()),
+            Span::raw(before),
+            Span::styled(cursor_ch, theme.input.cursor.to_style()),
+            Span::raw(after),
         ]));
         frame.render_widget(input_line, area);
     }

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -179,10 +179,18 @@ impl StatusBarWidget {
                 " [CMD] ",
                 theme.status_bar.command_mode_label.to_style(),
             ));
+            let (before, cursor_ch, after) = app.command_input.render_parts();
             spans.push(Span::styled(
-                format!(" :{}█", app.command_input),
+                format!(" :{}", before),
                 theme.dialog.text.to_style(),
             ));
+            spans.push(Span::styled(cursor_ch, theme.input.cursor.to_style()));
+            if !after.is_empty() {
+                spans.push(Span::styled(
+                    after.to_string(),
+                    theme.dialog.text.to_style(),
+                ));
+            }
         } else if app.input_mode == crate::app::InputMode::JumpForward
             || app.input_mode == crate::app::InputMode::JumpBackward
         {
@@ -195,10 +203,18 @@ impl StatusBarWidget {
                 format!(" {} ", label),
                 theme.status_bar.mode_label.to_style(),
             ));
+            let (before, cursor_ch, after) = app.time_input.render_parts();
             spans.push(Span::styled(
-                format!(" {}█", app.time_input),
+                format!(" {}", before),
                 theme.dialog.text.to_style(),
             ));
+            spans.push(Span::styled(cursor_ch, theme.input.cursor.to_style()));
+            if !after.is_empty() {
+                spans.push(Span::styled(
+                    after.to_string(),
+                    theme.dialog.text.to_style(),
+                ));
+            }
         } else {
             let (mode_label, mode_style) = if app.follow_mode {
                 ("[FOLLOW]", theme.status_bar.mode_follow.to_style())

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -144,37 +144,23 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 frame,
                 line2_area,
                 "[FILTER]",
-                app.filter_input.value(),
+                &app.filter_input,
                 app.filter_error.as_deref(),
                 app,
             );
         }
         InputMode::Search => {
-            render_input_line2(
-                frame,
-                line2_area,
-                "[SEARCH]",
-                app.search_input.value(),
-                None,
-                app,
-            );
+            render_input_line2(frame, line2_area, "[SEARCH]", &app.search_input, None, app);
         }
         InputMode::GotoLine => {
-            render_input_line2(
-                frame,
-                line2_area,
-                "[GOTO]",
-                app.goto_input.value(),
-                None,
-                app,
-            );
+            render_input_line2(frame, line2_area, "[GOTO]", &app.goto_input, None, app);
         }
         InputMode::QuickExclude => {
             render_input_line2(
                 frame,
                 line2_area,
                 "[EXCLUDE]",
-                app.quick_filter_input.value(),
+                &app.quick_filter_input,
                 None,
                 app,
             );
@@ -184,7 +170,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 frame,
                 line2_area,
                 "[INCLUDE]",
-                app.quick_filter_input.value(),
+                &app.quick_filter_input,
                 None,
                 app,
             );
@@ -194,7 +180,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 frame,
                 line2_area,
                 "[HIGHLIGHT]",
-                app.highlight_input.value(),
+                &app.highlight_input,
                 None,
                 app,
             );
@@ -211,19 +197,21 @@ fn render_input_line2(
     frame: &mut Frame,
     area: Rect,
     mode: &str,
-    input: &str,
+    text_input: &crate::text_input::TextInput,
     error: Option<&str>,
     app: &App,
 ) {
     let theme = &app.theme;
+    let (before, cursor_ch, after) = text_input.render_parts();
     let mut spans = vec![
         Span::styled(
             format!(" {} ", mode),
             theme.status_bar.search_mode_label.to_style(),
         ),
         Span::raw(" "),
-        Span::raw(input),
-        Span::styled("█", theme.input.cursor.to_style()),
+        Span::raw(before),
+        Span::styled(cursor_ch, theme.input.cursor.to_style()),
+        Span::raw(after),
     ];
 
     if let Some(err) = error {


### PR DESCRIPTION
Fix cursor rendering in all input fields — arrow keys now visually move the cursor.

**Problem:** Cursor always rendered at the end of input text regardless of logical cursor position.

**Fix:** Added `TextInput::render_parts()` that splits text at cursor position into (before, cursor_char, after). When cursor is at end, shows `█` block; when in middle, highlights the character at cursor.

**Widgets updated:**
- `SearchInputWidget` — `/` search bar
- `FilterInputWidget` — filter expression bar
- `StatusBarWidget` — command mode (`:`) and jump mode inputs
- `ui_legacy.rs` — all legacy input line2 renders (filter, search, goto, exclude, include, highlight)

**Tests:** 5 new tests for render_parts + mid-position editing. All 222 tests pass.

Closes #294