### PR TITLE
[PM Spec] Save dialog, SSH remote, level filter, filter presets, density source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ Each source gets its own loader, and a single session can combine multiple loade
 - **Custom highlight** — `h` to add highlight rule, `H` for highlight manager, full-row background coloring, auto color rotation
 - **Time jump** — `]` jump forward / `[` jump backward by relative time (5m, 30s, 2h)
 - **Stats overlay** — `S` shows log level distribution, top components
-- **Save/export** — `:w <filename>` in command mode to export filtered logs to file
+- **Save/export** — `s` opens save dialog with path input and format selection (Raw/JSON/YAML)
+- **Remote logs** — `scouty-tui ssh://user@host:/var/log/syslog` reads logs via SSH
+- **Level filter** — `l` opens level selector (1=ALL, 2=DEBUG+, 3=INFO+, 4=WARN+, 5=ERROR+)
+- **Filter presets** — save/load filter sets in `~/.scouty/filters/` via filter manager
+- **Density chart modes** — `d`/`D` to show density by level or highlight group
 - **Pipe input** — `cat log | scouty-tui` with auto follow mode
 - **Copy to clipboard** — Raw, JSON, or YAML format via OSC 52
 - **Component architecture** — Unified `UiComponent` trait with standardized keyboard dispatch
@@ -165,6 +169,9 @@ journalctl -f | scouty-tui
 |-----|--------|
 | `y` | Copy selected row (raw text) |
 | `Y` | Copy with format dialog (Raw/JSON/YAML) |
+| `s` | Save/export dialog (path + format) |
+| `l` | Log level quick filter (1-5) |
+| `d` / `D` | Cycle / select density chart source |
 
 ### General
 

--- a/crates/scouty-tui/spec/config.md
+++ b/crates/scouty-tui/spec/config.md
@@ -85,9 +85,15 @@ keybindings:
   prev_bookmark: '"'
   bookmark_manager: "M"
 
-  # Copy & Export (saving via ":w" in command mode)
+  # Copy & Export (saving via "s" dialog)
   copy_raw: "y"
   copy_format: "Y"
+  save_export: "s"
+
+  # Level & Density
+  level_filter: "l"
+  density_cycle: "d"
+  density_select: "D"
 
   # General
   help: "?"

--- a/crates/scouty-tui/spec/copy-and-export.md
+++ b/crates/scouty-tui/spec/copy-and-export.md
@@ -16,13 +16,39 @@ Features for copying log records to clipboard and exporting filtered results to 
 - Uses **OSC 52 escape sequence** for cross-terminal clipboard access
 - Dialog supports j/k/↑/↓ navigation
 
-### Export (Command Mode)
+### Save / Export (`s` key)
 
-- `:` — enter command mode, status bar: `[CMD] :█`
-- `:w <filename>` — export current filtered view's records (`raw` field, one line per record)
-- Completion: `Saved 5,678 records to filtered.log`
-- No filename: error `Usage: :w <filename>`
-- Command mode extensible for future commands
+Press `s` to open the save dialog:
+
+```
+┌─ Save Logs ──────────────────────────────┐
+│                                          │
+│  Path: ~/export.log█                     │
+│                                          │
+│  Format:                                 │
+│    > Raw (one line per record)           │
+│      JSON                                │
+│      YAML                                │
+│                                          │
+│              [Enter] Save  [Esc] Cancel  │
+└──────────────────────────────────────────┘
+```
+
+**Behavior:**
+- Path input field is focused by default, with a sensible default path (e.g., `./scouty-export.log`)
+- `Tab` or `↓` moves focus to format selector
+- Format selector uses `↑`/`↓` or `j`/`k` to navigate, `Enter` to confirm
+- Format options: **Raw** (default) / **JSON** / **YAML**
+  - Raw: one `raw` field per line (as-is from log)
+  - JSON: array of LogRecord objects with all structured fields
+  - YAML: list of LogRecord objects with all structured fields
+- `Enter` on Save: exports current filtered view's records to the specified path
+- Completion message in status bar: `Saved 5,678 records to ~/export.log (raw)`
+- Path supports `~` expansion
+- Empty path: show inline error "Path required"
+- Write failure: show error in status bar (e.g., `Save failed: Permission denied`)
+
+**Replaces:** The old `:w <filename>` command mode export is removed. Command mode (`:`) remains available for future extensibility.
 
 ## Change Log
 
@@ -30,3 +56,4 @@ Features for copying log records to clipboard and exporting filtered results to 
 |------|--------|
 | 2026-02-20 | Copy to clipboard (y/Y with format selection, OSC 52) |
 | 2026-02-22 | Command mode `:w` export |
+| 2026-02-24 | Replace `:w` with `s` key save dialog (path input + format selection) |

--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -100,6 +100,9 @@ Components notify App via return values or callbacks. App updates shared state (
 | `F` | Filter manager |
 | `c` | Column selector |
 | `y`/`Y` | Copy raw / format selection |
+| `s` | Save/export dialog (path + format) |
+| `l` | Log level quick filter (1-5) |
+| `d`/`D` | Cycle / select density chart source (level/highlight) |
 | `h`/`H` | Add highlight / highlight manager |
 | `m` | Toggle bookmark |
 | `'`/`"` | Next/prev bookmark |

--- a/crates/scouty-tui/spec/search-and-filter.md
+++ b/crates/scouty-tui/spec/search-and-filter.md
@@ -58,6 +58,82 @@ Shared dialog component, differing only in initial action (exclude vs include):
 - Add new, delete individual, clear all
 - j/k navigation, PageUp/PageDown
 
+### Log Level Quick Filter (`l`)
+
+Press `l` to open a level selector overlay:
+
+```
+┌─ Level Filter ──────────┐
+│                         │
+│  1. ALL (no filter)     │
+│  2. DEBUG+              │
+│  3. INFO+               │
+│  4. WARN+               │
+│  5. ERROR+              │
+│                         │
+│  Current: ALL           │
+└─────────────────────────┘
+```
+
+**Behavior:**
+- Press `1`-`5` to instantly apply level filter (overlay closes immediately)
+- Or use `↑`/`↓`/`j`/`k` to navigate, `Enter` to confirm
+- `Esc` closes without changing
+- Level filter is additive — it combines with other active filters
+- Applied filter shown in filter manager as a level filter entry
+- Selecting a new level replaces the previous level filter (not stacked)
+- Level mappings:
+  - `1` ALL: no level filter
+  - `2` DEBUG+: TRACE excluded
+  - `3` INFO+: TRACE, DEBUG excluded
+  - `4` WARN+: TRACE, DEBUG, INFO excluded
+  - `5` ERROR+: TRACE, DEBUG, INFO, WARN, NOTICE excluded
+- Current active level shown in the overlay
+
+### Filter Presets (Save/Load)
+
+Filter presets are stored in `~/.scouty/filters/` as YAML files.
+
+**Save preset** — in filter manager (`F`), press `s`:
+```
+┌─ Save Filter Preset ────────────────┐
+│                                     │
+│  Name: my-error-filters█            │
+│                                     │
+│         [Enter] Save  [Esc] Cancel  │
+└─────────────────────────────────────┘
+```
+
+**Load preset** — in filter manager (`F`), press `l`:
+```
+┌─ Load Filter Preset ────────────────┐
+│                                     │
+│  > my-error-filters                 │
+│    network-debug                    │
+│    production-noise                 │
+│                                     │
+│  [Enter] Load  [d] Delete  [Esc]   │
+└─────────────────────────────────────┘
+```
+
+**Behavior:**
+- Save: saves all current active filters (exclude + include + level) as a named preset
+- File format: `~/.scouty/filters/<name>.yaml`
+- Load: replaces all current filters with the preset's filters
+- Delete: `d` key deletes the selected preset (with confirmation)
+- Preset YAML format:
+  ```yaml
+  # ~/.scouty/filters/my-error-filters.yaml
+  filters:
+    - type: include
+      expression: 'level == "Error" OR level == "Fatal"'
+    - type: exclude
+      expression: 'component == "healthcheck"'
+  level_filter: 4    # WARN+ (0=ALL, 1=TRACE+, 2=DEBUG+, 3=INFO+, 4=WARN+, 5=ERROR+)
+  ```
+- Empty filter list: show "No presets found" in load dialog
+- Name collision on save: overwrite with confirmation prompt
+
 ### Time Range Filtering
 
 Via the field filter dialog's time options:
@@ -73,3 +149,5 @@ Via the field filter dialog's time options:
 | 2026-02-20 | Search, filter expression, quick exclude/include, field dialog, filter manager |
 | 2026-02-22 | Time range options in field filter dialog |
 | 2026-02-23 | Filter preserves cursor position (stay on same record or nearest preceding) |
+| 2026-02-24 | Log level quick filter (l key, 1-5 selection) |
+| 2026-02-24 | Filter presets save/load in filter manager (s/l keys, stored in ~/.scouty/filters/) |

--- a/crates/scouty-tui/spec/status-bar.md
+++ b/crates/scouty-tui/spec/status-bar.md
@@ -49,7 +49,37 @@ The number of buckets should be adjusted accordingly so that the chart covers th
 - [ ] Label width deducted from chart width, no layout overflow
 - [ ] Hidden when insufficient data
 
-### Line 2: Interactive State (Three Mutually Exclusive Modes)
+### Density Chart Level/Highlight Selector
+
+The density chart can be switched to show only a specific log level or highlight group, making it easy to visually locate error clusters or highlighted regions.
+
+**Trigger:** Press `d` to cycle through density chart modes, or `D` to open a selector overlay:
+
+```
+┌─ Density Chart Source ──────────────┐
+│                                     │
+│  > All records (default)            │
+│    FATAL only                       │
+│    ERROR only                       │
+│    WARN only                        │
+│    INFO only                        │
+│    ── Highlights ──                 │
+│    Highlight #1: "timeout"          │
+│    Highlight #2: "connection"       │
+│                                     │
+│         [Enter] Select  [Esc] Close │
+└─────────────────────────────────────┘
+```
+
+**Behavior:**
+- Default: density chart shows all filtered records (current behavior)
+- When a level is selected: chart only counts records of that level → spikes = error clusters
+- When a highlight is selected: chart only counts records matching that highlight rule
+- Current selection shown in the density label: `[█=5s ERROR]` or `[█=5s "timeout"]`
+- `d` quick-cycles: All → ERROR → WARN → current highlights → All
+- `D` opens full selector overlay with all options
+- Selection persists until changed or reset
+- Cursor marker still works in filtered density view
 
 **Mode A — Default (shortcut hints):**
 ```
@@ -97,3 +127,4 @@ Navigation (j/k/PageUp/PageDown/g/G) does **not** trigger recomputation. Only th
 | 2026-02-22 | Add time-per-column label spec for density chart |
 | 2026-02-23 | Label format changed from [Xs/█] to [█=Xs] |
 | 2026-02-23 | Time per column snaps up to standard intervals (5/15/30 for s and m) |
+| 2026-02-24 | Density chart level/highlight selector (d/D keys) |

--- a/spec/remote-ssh.md
+++ b/spec/remote-ssh.md
@@ -1,0 +1,79 @@
+# Remote Log Reading (SSH)
+
+## Overview
+
+Support reading log files from remote hosts via SSH, allowing users to view remote logs without manually copying files.
+
+## Design
+
+### Usage
+
+```
+scouty-tui ssh://user@host:/path/to/logfile
+scouty-tui ssh://user@host:22:/var/log/syslog
+scouty-tui ssh://host:/var/log/syslog              # uses current user
+scouty-tui local.log ssh://prod:/var/log/app.log   # mixed local + remote
+```
+
+### URL Format
+
+```
+ssh://[user@]host[:port]:/absolute/path
+```
+
+- `user` — optional, defaults to current system user
+- `host` — hostname or IP
+- `port` — optional, defaults to 22
+- `/absolute/path` — path on the remote host (must be absolute)
+
+### Connection
+
+- Use system SSH config (`~/.ssh/config`) for host aliases, identity files, proxy jumps, etc.
+- Authentication: relies on SSH agent / key-based auth (no interactive password prompt in TUI)
+- Connection failure: show friendly error with details (e.g., `SSH: Connection refused to prod:22`)
+- Timeout: configurable in `config.yaml`, default 10s
+
+### Data Flow
+
+1. Establish SSH connection
+2. Execute `cat <path>` (or `tail -f <path>` in follow mode) on remote host
+3. Stream stdout into the same LogStore pipeline as local files
+4. Source field: `ssh://user@host:/path`
+
+### Follow Mode
+
+- When follow mode is active (`Ctrl+]`), use `tail -f` instead of `cat`
+- SSH connection stays open, streaming new records in real-time
+- Connection drop: show `[SSH DISCONNECTED]` in status bar, auto-retry with backoff
+
+### Multi-source
+
+- Remote sources can be mixed with local files and stdin
+- Each source gets independent loader, all merge into shared LogStore
+- Loading screen shows all sources (local and remote)
+
+### Configuration
+
+```yaml
+# In config.yaml
+ssh:
+  connect_timeout: 10       # seconds
+  keepalive_interval: 30    # seconds, 0 to disable
+```
+
+## Acceptance Criteria
+
+- [ ] `ssh://` URL scheme recognized and parsed correctly
+- [ ] Remote log loaded via SSH and displayed in log table
+- [ ] System SSH config respected (host aliases, keys, proxy)
+- [ ] Follow mode works with remote sources (tail -f)
+- [ ] Connection errors shown as friendly messages
+- [ ] Mixed local + remote sources work in same session
+- [ ] Source field shows full SSH URL
+- [ ] Glob patterns in `default_paths` do NOT apply to SSH URLs
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| 2026-02-24 | Initial remote log reading via SSH |


### PR DESCRIPTION
Five new feature specs:

**1. Save dialog (`s` key)** — replaces `:w` command
- Dialog with path input + format selector (Raw/JSON/YAML)
- `Tab`/`↓` to switch between path and format
- `~` expansion, error handling

**2. Remote log reading (SSH)**
- `scouty-tui ssh://user@host:/var/log/syslog`
- Uses system SSH config, supports follow mode (`tail -f`)
- Mixed local + remote sources

**3. Log level quick filter (`l` key)**
- Overlay with 1-5 instant selection
- 1=ALL, 2=DEBUG+, 3=INFO+, 4=WARN+, 5=ERROR+
- Additive with other filters, shown in filter manager

**4. Filter presets (save/load)**
- In filter manager (`F`): `s` to save, `l` to load
- Stored as YAML in `~/.scouty/filters/`
- Saves all active filters + level filter

**5. Density chart source selector (`d`/`D` keys)**
- `d` quick-cycles: All → ERROR → WARN → highlights → All
- `D` opens full selector overlay
- Label shows source: `[█=5s ERROR]`

Files: copy-and-export.md, remote-ssh.md (new), search-and-filter.md, status-bar.md, overview.md, config.md, README.md