### PR TITLE
feat: add log level quick filter (l key)

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -34,6 +34,7 @@ pub enum InputMode {
 
     Highlight,
     HighlightManager,
+    LevelFilter,
 }
 
 /// Column identifiers for the log table.
@@ -284,6 +285,92 @@ pub struct App {
     pub bookmark_manager_cursor: usize,
     /// Theme for UI colors.
     pub theme: Theme,
+    /// Active level filter (None = ALL).
+    pub level_filter: Option<LevelFilterPreset>,
+    /// Level filter cursor for overlay navigation.
+    pub level_filter_cursor: usize,
+}
+
+/// Level filter presets.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LevelFilterPreset {
+    /// Show all levels.
+    All,
+    /// DEBUG and above.
+    DebugPlus,
+    /// INFO and above.
+    InfoPlus,
+    /// WARN and above.
+    WarnPlus,
+    /// ERROR and above.
+    ErrorPlus,
+}
+
+impl LevelFilterPreset {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::All => "ALL",
+            Self::DebugPlus => "DEBUG+",
+            Self::InfoPlus => "INFO+",
+            Self::WarnPlus => "WARN+",
+            Self::ErrorPlus => "ERROR+",
+        }
+    }
+
+    pub fn from_number(n: u8) -> Option<Self> {
+        match n {
+            1 => Some(Self::All),
+            2 => Some(Self::DebugPlus),
+            3 => Some(Self::InfoPlus),
+            4 => Some(Self::WarnPlus),
+            5 => Some(Self::ErrorPlus),
+            _ => None,
+        }
+    }
+
+    pub fn as_number(&self) -> u8 {
+        match self {
+            Self::All => 1,
+            Self::DebugPlus => 2,
+            Self::InfoPlus => 3,
+            Self::WarnPlus => 4,
+            Self::ErrorPlus => 5,
+        }
+    }
+
+    /// Returns the minimum log level ordinal that passes this filter.
+    pub fn matches_level(&self, level: Option<&scouty::record::LogLevel>) -> bool {
+        use scouty::record::LogLevel;
+        match self {
+            Self::All => true,
+            Self::DebugPlus => matches!(
+                level,
+                Some(
+                    LogLevel::Debug
+                        | LogLevel::Info
+                        | LogLevel::Notice
+                        | LogLevel::Warn
+                        | LogLevel::Error
+                        | LogLevel::Fatal
+                )
+            ),
+            Self::InfoPlus => matches!(
+                level,
+                Some(
+                    LogLevel::Info
+                        | LogLevel::Notice
+                        | LogLevel::Warn
+                        | LogLevel::Error
+                        | LogLevel::Fatal
+                )
+            ),
+            Self::WarnPlus => matches!(
+                level,
+                Some(LogLevel::Warn | LogLevel::Error | LogLevel::Fatal)
+            ),
+            Self::ErrorPlus => matches!(level, Some(LogLevel::Error | LogLevel::Fatal)),
+        }
+    }
 }
 
 /// Cached density chart — avoids O(N) recomputation on every frame.
@@ -398,6 +485,8 @@ impl App {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         })
     }
 
@@ -534,6 +623,12 @@ impl App {
         self.filtered_indices = (0..self.records.len())
             .filter(|&i| {
                 let record = &self.records[i];
+                // Apply level filter first
+                if let Some(ref lf) = self.level_filter {
+                    if !lf.matches_level(record.level.as_ref()) {
+                        return false;
+                    }
+                }
                 for f in &self.filters {
                     let matches = eval::eval(&f.expr, record);
                     if f.exclude && matches {
@@ -742,6 +837,17 @@ impl App {
     }
 
     /// Apply the field filter dialog selections.
+    /// Apply a level filter preset. None = clear level filter (show ALL).
+    pub fn apply_level_filter(&mut self, preset: LevelFilterPreset) {
+        if preset == LevelFilterPreset::All {
+            self.level_filter = None;
+        } else {
+            self.level_filter = Some(preset);
+        }
+        self.reapply_filters();
+        self.set_status(format!("Level filter: {}", preset.label()));
+    }
+
     pub fn apply_field_filter(&mut self) {
         let state = match self.field_filter.clone() {
             Some(s) => s,
@@ -1501,6 +1607,8 @@ mod tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -1554,6 +1662,8 @@ mod tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -1604,6 +1714,8 @@ mod tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -2108,6 +2220,8 @@ mod field_filter_v2_tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -2283,6 +2397,8 @@ mod column_follow_tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -2472,6 +2588,8 @@ mod copy_tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -2632,6 +2750,8 @@ mod time_jump_tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -2755,6 +2875,8 @@ mod command_tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
     #[test]

--- a/crates/scouty-tui/src/keybinding.rs
+++ b/crates/scouty-tui/src/keybinding.rs
@@ -30,6 +30,7 @@ pub enum Action {
     FieldExclude,
     FieldInclude,
     FilterManager,
+    LevelFilter,
 
     // Display
     ToggleDetail,
@@ -150,6 +151,7 @@ pub struct KeybindingConfig {
     pub field_exclude: Option<KeyOrKeys>,
     pub field_include: Option<KeyOrKeys>,
     pub filter_manager: Option<KeyOrKeys>,
+    pub level_filter: Option<KeyOrKeys>,
     pub toggle_detail: Option<KeyOrKeys>,
     pub column_selector: Option<KeyOrKeys>,
     pub stats: Option<KeyOrKeys>,
@@ -259,6 +261,7 @@ impl KeybindingConfig {
             Action::FieldExclude => self.field_exclude.as_ref(),
             Action::FieldInclude => self.field_include.as_ref(),
             Action::FilterManager => self.filter_manager.as_ref(),
+            Action::LevelFilter => self.level_filter.as_ref(),
             Action::ToggleDetail => self.toggle_detail.as_ref(),
             Action::ColumnSelector => self.column_selector.as_ref(),
             Action::Stats => self.stats.as_ref(),
@@ -303,6 +306,7 @@ fn default_bindings() -> Vec<(Action, Vec<&'static str>)> {
         (Action::FieldExclude, vec!["_"]),
         (Action::FieldInclude, vec!["+"]),
         (Action::FilterManager, vec!["F", "ctrl+f"]),
+        (Action::LevelFilter, vec!["l"]),
         // Display
         (Action::ToggleDetail, vec!["enter"]),
         (Action::ColumnSelector, vec!["c"]),

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -323,6 +323,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     app.input_mode = InputMode::FilterManager;
                                     app.filter_manager_cursor = 0;
                                 }
+                                Action::LevelFilter => {
+                                    app.input_mode = InputMode::LevelFilter;
+                                    app.level_filter_cursor = app
+                                        .level_filter
+                                        .map(|l| (l.as_number() - 1) as usize)
+                                        .unwrap_or(0);
+                                }
                                 Action::GotoLine => {
                                     app.input_mode = InputMode::GotoLine;
                                     app.goto_input.clear();
@@ -580,6 +587,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let result = ui::dispatch_key(&mut window, key);
                         window.apply_to_app(&mut app);
                         if result == ui::ComponentResult::Close {
+                            app.input_mode = InputMode::Normal;
+                        }
+                    }
+                    InputMode::LevelFilter => {
+                        use ui::windows::level_filter_window::LevelFilterWindow;
+                        let mut window = LevelFilterWindow::from_app(&app);
+                        let result = ui::dispatch_key(&mut window, key);
+                        if result == ui::ComponentResult::Close {
+                            if window.confirmed {
+                                if let Some(preset) = window.selected {
+                                    app.apply_level_filter(preset);
+                                }
+                            }
                             app.input_mode = InputMode::Normal;
                         }
                     }

--- a/crates/scouty-tui/src/ui/windows/level_filter_window.rs
+++ b/crates/scouty-tui/src/ui/windows/level_filter_window.rs
@@ -1,0 +1,129 @@
+//! Level filter overlay — quick log level selection.
+
+#[cfg(test)]
+#[path = "level_filter_window_tests.rs"]
+mod level_filter_window_tests;
+
+use crate::app::LevelFilterPreset;
+use crate::config::Theme;
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+const OPTIONS: [(u8, LevelFilterPreset); 5] = [
+    (1, LevelFilterPreset::All),
+    (2, LevelFilterPreset::DebugPlus),
+    (3, LevelFilterPreset::InfoPlus),
+    (4, LevelFilterPreset::WarnPlus),
+    (5, LevelFilterPreset::ErrorPlus),
+];
+
+pub struct LevelFilterWindow<'a> {
+    pub cursor: usize,
+    pub selected: Option<LevelFilterPreset>,
+    pub confirmed: bool,
+    pub current_level: Option<LevelFilterPreset>,
+    pub theme: &'a Theme,
+}
+
+impl<'a> LevelFilterWindow<'a> {
+    pub fn new(current: Option<LevelFilterPreset>, theme: &'a Theme) -> Self {
+        let cursor = current.map(|l| (l.as_number() - 1) as usize).unwrap_or(0);
+        Self {
+            cursor,
+            selected: None,
+            confirmed: false,
+            current_level: current,
+            theme,
+        }
+    }
+
+    pub fn from_app(app: &'a crate::app::App) -> Self {
+        Self::new(app.level_filter, &app.theme)
+    }
+}
+
+impl<'a> UiComponent for LevelFilterWindow<'a> {
+    fn enable_jk_navigation(&self) -> bool {
+        true
+    }
+
+    fn on_up(&mut self) -> ComponentResult {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        if self.cursor < OPTIONS.len() - 1 {
+            self.cursor += 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        self.selected = Some(OPTIONS[self.cursor].1);
+        self.confirmed = true;
+        ComponentResult::Close
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        if let Some(n) = c.to_digit(10) {
+            if (1..=5).contains(&n) {
+                if let Some(preset) = LevelFilterPreset::from_number(n as u8) {
+                    self.selected = Some(preset);
+                    self.confirmed = true;
+                    return ComponentResult::Close;
+                }
+            }
+        }
+        ComponentResult::Consumed
+    }
+
+    fn render(&self, frame: &mut Frame, _area: Rect) {
+        let area = frame.area();
+        let width = 24u16;
+        let height = (OPTIONS.len() as u16) + 2;
+        let x = area.x + (area.width.saturating_sub(width)) / 2;
+        let y = area.y + (area.height.saturating_sub(height)) / 2;
+        let overlay = Rect::new(x, y, width.min(area.width), height.min(area.height));
+
+        frame.render_widget(Clear, overlay);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(self.theme.dialog.border.to_style())
+            .title(" Level Filter ")
+            .title_style(self.theme.dialog.title.to_style());
+
+        let inner = block.inner(overlay);
+        frame.render_widget(block, overlay);
+
+        for (i, (num, preset)) in OPTIONS.iter().enumerate() {
+            if i as u16 >= inner.height {
+                break;
+            }
+            let is_current = self
+                .current_level
+                .map_or(*preset == LevelFilterPreset::All, |l| l == *preset);
+            let is_selected = i == self.cursor;
+
+            let marker = if is_current { "●" } else { " " };
+            let line = format!(" {} {}  {}", num, preset.label(), marker);
+
+            let style = if is_selected {
+                self.theme.dialog.selected.to_style()
+            } else {
+                self.theme.dialog.text.to_style()
+            };
+
+            let row_area = Rect::new(inner.x, inner.y + i as u16, inner.width, 1);
+            frame.render_widget(Paragraph::new(line).style(style), row_area);
+        }
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/level_filter_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/level_filter_window_tests.rs
@@ -1,0 +1,122 @@
+#[cfg(test)]
+mod tests {
+    use super::super::LevelFilterWindow;
+    use crate::app::LevelFilterPreset;
+    use crate::config::Theme;
+    use crate::ui::{dispatch_key, ComponentResult};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let theme = Theme::default();
+        let mut w = LevelFilterWindow::new(None, &theme);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+        assert!(!w.confirmed);
+    }
+
+    #[test]
+    fn test_number_keys_instant_select() {
+        let theme = Theme::default();
+        for (n, expected) in [
+            ('1', LevelFilterPreset::All),
+            ('2', LevelFilterPreset::DebugPlus),
+            ('3', LevelFilterPreset::InfoPlus),
+            ('4', LevelFilterPreset::WarnPlus),
+            ('5', LevelFilterPreset::ErrorPlus),
+        ] {
+            let mut w = LevelFilterWindow::new(None, &theme);
+            let result = dispatch_key(&mut w, key(KeyCode::Char(n)));
+            assert_eq!(result, ComponentResult::Close);
+            assert!(w.confirmed);
+            assert_eq!(w.selected, Some(expected));
+        }
+    }
+
+    #[test]
+    fn test_navigation_and_enter() {
+        let theme = Theme::default();
+        let mut w = LevelFilterWindow::new(None, &theme);
+        assert_eq!(w.cursor, 0);
+
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('j'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 1);
+
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Down)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 2);
+
+        let result = dispatch_key(&mut w, key(KeyCode::Enter));
+        assert_eq!(result, ComponentResult::Close);
+        assert!(w.confirmed);
+        assert_eq!(w.selected, Some(LevelFilterPreset::InfoPlus));
+    }
+
+    #[test]
+    fn test_navigation_bounds() {
+        let theme = Theme::default();
+        let mut w = LevelFilterWindow::new(None, &theme);
+
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Up)),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 0);
+
+        for _ in 0..10 {
+            dispatch_key(&mut w, key(KeyCode::Char('j')));
+        }
+        assert_eq!(w.cursor, 4);
+
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Char('j'))),
+            ComponentResult::Consumed
+        );
+        assert_eq!(w.cursor, 4);
+    }
+
+    #[test]
+    fn test_current_level_cursor_position() {
+        let theme = Theme::default();
+        let w = LevelFilterWindow::new(Some(LevelFilterPreset::WarnPlus), &theme);
+        assert_eq!(w.cursor, 3);
+    }
+
+    #[test]
+    fn test_level_filter_preset_matches() {
+        use scouty::record::LogLevel;
+
+        assert!(LevelFilterPreset::All.matches_level(Some(&LogLevel::Trace)));
+        assert!(LevelFilterPreset::All.matches_level(None));
+
+        assert!(!LevelFilterPreset::DebugPlus.matches_level(Some(&LogLevel::Trace)));
+        assert!(LevelFilterPreset::DebugPlus.matches_level(Some(&LogLevel::Debug)));
+        assert!(LevelFilterPreset::DebugPlus.matches_level(Some(&LogLevel::Fatal)));
+
+        assert!(!LevelFilterPreset::InfoPlus.matches_level(Some(&LogLevel::Debug)));
+        assert!(LevelFilterPreset::InfoPlus.matches_level(Some(&LogLevel::Info)));
+
+        assert!(!LevelFilterPreset::WarnPlus.matches_level(Some(&LogLevel::Info)));
+        assert!(LevelFilterPreset::WarnPlus.matches_level(Some(&LogLevel::Warn)));
+
+        assert!(!LevelFilterPreset::ErrorPlus.matches_level(Some(&LogLevel::Warn)));
+        assert!(LevelFilterPreset::ErrorPlus.matches_level(Some(&LogLevel::Error)));
+        assert!(LevelFilterPreset::ErrorPlus.matches_level(Some(&LogLevel::Fatal)));
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/mod.rs
+++ b/crates/scouty-tui/src/ui/windows/mod.rs
@@ -8,4 +8,5 @@ pub mod filter_manager_window;
 pub mod goto_line_window;
 pub mod help_window;
 pub mod highlight_manager_window;
+pub mod level_filter_window;
 pub mod stats_window;

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -80,6 +80,8 @@ mod tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: crate::config::Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         }
     }
 
@@ -168,6 +170,8 @@ mod tests {
             bookmarks: std::collections::HashSet::new(),
             bookmark_manager_cursor: 0,
             theme: crate::config::Theme::default(),
+            level_filter: None,
+            level_filter_cursor: 0,
         };
         let stats = StatsData::compute(&app);
         assert_eq!(stats.total_records, 0);

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -110,6 +110,13 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         let window = BookmarkManagerWindow::from_app(app);
         window.render_with_app(frame, app, area);
     }
+
+    if app.input_mode == InputMode::LevelFilter {
+        use crate::ui::windows::level_filter_window::LevelFilterWindow;
+        use crate::ui::UiComponent;
+        let window = LevelFilterWindow::from_app(app);
+        UiComponent::render(&window, frame, area);
+    }
 }
 
 fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary

Add a quick level filter overlay triggered by the `l` key for fast log level filtering.

### Usage
- Press `l` to open level filter overlay
- Press `1`-`5` to instantly apply: 1=ALL, 2=DEBUG+, 3=INFO+, 4=WARN+, 5=ERROR+
- Or navigate with `j`/`k`/arrows + Enter
- Esc closes without changing
- Current active level shown with ● marker

### Changes

**`app.rs`**:
- `LevelFilterPreset` enum with match logic per log level
- `level_filter` field integrated into `reapply_filters()` pipeline
- `apply_level_filter()` method

**`keybinding.rs`**: `LevelFilter` action mapped to `l` key

**`level_filter_window.rs`** (new): Overlay window implementing `UiComponent`

**`main.rs`**: Event handling for `InputMode::LevelFilter`

**`ui_legacy.rs`**: Render call for level filter overlay

### Behavior
- Level filter combines with expression filters (additive)
- New selection replaces previous level filter (not stacked)
- Records without a level field are hidden by all presets except ALL

### Test Plan
- 6 new window tests (esc, number keys, navigation, bounds, cursor position)
- 1 preset matching test covering all levels
- All 513 tests pass

Closes #305