### PR TITLE
feat: add filter preset save/load in filter manager

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -36,6 +36,8 @@ pub enum InputMode {
     Highlight,
     HighlightManager,
     LevelFilter,
+    SavePreset,
+    LoadPreset,
 }
 
 /// Column identifiers for the log table.
@@ -290,6 +292,12 @@ pub struct App {
     pub level_filter: Option<LevelFilterPreset>,
     /// Level filter cursor for overlay navigation.
     pub level_filter_cursor: usize,
+    /// Save preset name input.
+    pub preset_name_input: TextInput,
+    /// Available preset names for load dialog.
+    pub preset_list: Vec<String>,
+    /// Load preset cursor.
+    pub preset_list_cursor: usize,
 }
 
 /// Level filter presets.
@@ -503,6 +511,9 @@ impl App {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         })
     }
 
@@ -862,6 +873,84 @@ impl App {
         }
         self.reapply_filters();
         self.set_status(format!("Level filter: {}", preset.label()));
+    }
+
+    /// Save current filters as a named preset.
+    pub fn save_filter_preset(&mut self, name: &str) {
+        use crate::config::filter_preset::{save_preset, FilterPreset, FilterPresetEntry};
+
+        let preset = FilterPreset {
+            filters: self
+                .filters
+                .iter()
+                .map(|f| FilterPresetEntry {
+                    expr: f.label.clone(),
+                    exclude: f.exclude,
+                })
+                .collect(),
+            level_filter: self.level_filter.map(|l| l.label().to_string()),
+        };
+
+        match save_preset(name, &preset) {
+            Ok(_) => self.set_status(format!("Preset '{}' saved", name)),
+            Err(e) => self.set_status(format!("Error saving preset: {}", e)),
+        }
+    }
+
+    /// Load a filter preset by name, replacing current filters.
+    pub fn load_filter_preset(&mut self, name: &str) {
+        use crate::config::filter_preset::load_preset;
+
+        let preset = match load_preset(name) {
+            Ok(p) => p,
+            Err(e) => {
+                self.set_status(format!("Error loading preset: {}", e));
+                return;
+            }
+        };
+
+        // Clear existing filters
+        self.filters.clear();
+
+        // Load expression filters
+        for entry in &preset.filters {
+            match expr::parse(&entry.expr) {
+                Ok(parsed) => {
+                    self.filters.push(FilterEntry {
+                        label: entry.expr.clone(),
+                        expr: parsed,
+                        exclude: entry.exclude,
+                    });
+                }
+                Err(e) => {
+                    self.set_status(format!(
+                        "Warning: filter '{}' failed to parse: {}",
+                        entry.expr, e
+                    ));
+                }
+            }
+        }
+
+        // Load level filter
+        if let Some(ref level_str) = preset.level_filter {
+            match level_str.as_str() {
+                "ALL" => self.level_filter = None,
+                "DEBUG+" => self.level_filter = Some(LevelFilterPreset::DebugPlus),
+                "INFO+" => self.level_filter = Some(LevelFilterPreset::InfoPlus),
+                "WARN+" => self.level_filter = Some(LevelFilterPreset::WarnPlus),
+                "ERROR+" => self.level_filter = Some(LevelFilterPreset::ErrorPlus),
+                _ => {}
+            }
+        } else {
+            self.level_filter = None;
+        }
+
+        self.reapply_filters();
+        self.set_status(format!(
+            "Preset '{}' loaded ({} filters)",
+            name,
+            self.filters.len()
+        ));
     }
 
     pub fn apply_field_filter(&mut self) {
@@ -1625,6 +1714,9 @@ mod tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -1680,6 +1772,9 @@ mod tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -1732,6 +1827,9 @@ mod tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -2238,6 +2336,9 @@ mod field_filter_v2_tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -2415,6 +2516,9 @@ mod column_follow_tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -2606,6 +2710,9 @@ mod copy_tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -2768,6 +2875,9 @@ mod time_jump_tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -2893,6 +3003,9 @@ mod command_tests {
             theme: Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
     #[test]

--- a/crates/scouty-tui/src/config/filter_preset.rs
+++ b/crates/scouty-tui/src/config/filter_preset.rs
@@ -1,0 +1,99 @@
+//! Filter preset persistence — save/load filter sets as YAML files.
+
+#[cfg(test)]
+#[path = "filter_preset_tests.rs"]
+mod filter_preset_tests;
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Serializable filter preset (saved to ~/.scouty/filters/<name>.yaml).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilterPreset {
+    /// List of filter expressions.
+    #[serde(default)]
+    pub filters: Vec<FilterPresetEntry>,
+    /// Active level filter (None = ALL).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level_filter: Option<String>,
+}
+
+/// Single filter entry in a preset.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FilterPresetEntry {
+    /// The filter expression string.
+    pub expr: String,
+    /// Whether this is an exclude filter.
+    #[serde(default)]
+    pub exclude: bool,
+}
+
+/// Directory for filter presets.
+fn presets_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".scouty")
+        .join("filters")
+}
+
+/// Ensure the presets directory exists.
+fn ensure_presets_dir() -> std::io::Result<PathBuf> {
+    let dir = presets_dir();
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Save a filter preset to disk.
+pub fn save_preset(name: &str, preset: &FilterPreset) -> Result<PathBuf, String> {
+    let dir = ensure_presets_dir().map_err(|e| format!("Failed to create presets dir: {}", e))?;
+    let path = dir.join(format!("{}.yaml", sanitize_name(name)));
+    let yaml =
+        serde_yaml::to_string(preset).map_err(|e| format!("Failed to serialize preset: {}", e))?;
+    std::fs::write(&path, yaml).map_err(|e| format!("Failed to write preset: {}", e))?;
+    Ok(path)
+}
+
+/// Load a filter preset from disk.
+pub fn load_preset(name: &str) -> Result<FilterPreset, String> {
+    let path = presets_dir().join(format!("{}.yaml", name));
+    let content =
+        std::fs::read_to_string(&path).map_err(|e| format!("Failed to read preset: {}", e))?;
+    serde_yaml::from_str(&content).map_err(|e| format!("Failed to parse preset: {}", e))
+}
+
+/// List available preset names (without .yaml extension).
+pub fn list_presets() -> Vec<String> {
+    let dir = presets_dir();
+    let mut names = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("yaml") {
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    names.push(stem.to_string());
+                }
+            }
+        }
+    }
+    names.sort();
+    names
+}
+
+/// Delete a preset file.
+pub fn delete_preset(name: &str) -> Result<(), String> {
+    let path = presets_dir().join(format!("{}.yaml", name));
+    std::fs::remove_file(&path).map_err(|e| format!("Failed to delete preset: {}", e))
+}
+
+/// Sanitize preset name for use as filename.
+fn sanitize_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/crates/scouty-tui/src/config/filter_preset_tests.rs
+++ b/crates/scouty-tui/src/config/filter_preset_tests.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod tests {
+    use super::super::{sanitize_name, FilterPreset, FilterPresetEntry};
+    use std::sync::Mutex;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Override HOME for testing, serialized to avoid races.
+    fn with_test_home<F: FnOnce()>(test_name: &str, f: F) {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("scouty_preset_{}", test_name));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let old_home = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", &dir) };
+        f();
+        if let Some(h) = old_home {
+            unsafe { std::env::set_var("HOME", h) };
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_sanitize_name() {
+        assert_eq!(sanitize_name("my-preset"), "my-preset");
+        assert_eq!(sanitize_name("foo bar"), "foo_bar");
+        assert_eq!(sanitize_name("test/bad"), "test_bad");
+        assert_eq!(sanitize_name("under_score"), "under_score");
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        with_test_home("roundtrip", || {
+            let preset = FilterPreset {
+                filters: vec![
+                    FilterPresetEntry {
+                        expr: "level == \"ERROR\"".to_string(),
+                        exclude: false,
+                    },
+                    FilterPresetEntry {
+                        expr: "timeout".to_string(),
+                        exclude: true,
+                    },
+                ],
+                level_filter: Some("WARN+".to_string()),
+            };
+
+            super::super::save_preset("test-preset", &preset).unwrap();
+            let loaded = super::super::load_preset("test-preset").unwrap();
+            assert_eq!(loaded.filters.len(), 2);
+            assert_eq!(loaded.filters[0].expr, "level == \"ERROR\"");
+            assert!(!loaded.filters[0].exclude);
+            assert_eq!(loaded.filters[1].expr, "timeout");
+            assert!(loaded.filters[1].exclude);
+            assert_eq!(loaded.level_filter, Some("WARN+".to_string()));
+        });
+    }
+
+    #[test]
+    fn test_list_presets() {
+        with_test_home("list", || {
+            let p1 = FilterPreset {
+                filters: vec![],
+                level_filter: None,
+            };
+            super::super::save_preset("alpha", &p1).unwrap();
+            super::super::save_preset("beta", &p1).unwrap();
+
+            let names = super::super::list_presets();
+            assert!(names.contains(&"alpha".to_string()));
+            assert!(names.contains(&"beta".to_string()));
+        });
+    }
+
+    #[test]
+    fn test_delete_preset() {
+        with_test_home("delete", || {
+            let p = FilterPreset {
+                filters: vec![],
+                level_filter: None,
+            };
+            super::super::save_preset("to-delete", &p).unwrap();
+            assert!(super::super::list_presets().contains(&"to-delete".to_string()));
+
+            super::super::delete_preset("to-delete").unwrap();
+            assert!(!super::super::list_presets().contains(&"to-delete".to_string()));
+        });
+    }
+
+    #[test]
+    fn test_load_nonexistent() {
+        with_test_home("nonexistent", || {
+            let result = super::super::load_preset("nonexistent");
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_empty_preset() {
+        with_test_home("empty", || {
+            let preset = FilterPreset {
+                filters: vec![],
+                level_filter: None,
+            };
+            super::super::save_preset("empty", &preset).unwrap();
+            let loaded = super::super::load_preset("empty").unwrap();
+            assert!(loaded.filters.is_empty());
+            assert!(loaded.level_filter.is_none());
+        });
+    }
+}

--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -8,6 +8,7 @@
 //! 5. CLI flags (`--theme`, `--config`, file arguments)
 
 pub mod color;
+pub mod filter_preset;
 pub mod theme;
 
 pub use color::ThemeColor;

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -492,7 +492,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let result = ui::dispatch_key(&mut window, key);
                         window.apply_to_app(&mut app);
                         if result == ui::ComponentResult::Close {
-                            app.input_mode = InputMode::Normal;
+                            match window.action {
+                                Some("save_preset") => {
+                                    app.preset_name_input.clear();
+                                    app.input_mode = InputMode::SavePreset;
+                                }
+                                Some("load_preset") => {
+                                    app.preset_list = crate::config::filter_preset::list_presets();
+                                    app.preset_list_cursor = 0;
+                                    app.input_mode = InputMode::LoadPreset;
+                                }
+                                _ => {
+                                    app.input_mode = InputMode::Normal;
+                                }
+                            }
                         }
                     }
                     InputMode::ColumnSelector => {
@@ -601,6 +614,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             if window.confirmed {
                                 if let Some(preset) = window.selected {
                                     app.apply_level_filter(preset);
+                                }
+                            }
+                            app.input_mode = InputMode::Normal;
+                        }
+                    }
+                    InputMode::SavePreset => {
+                        use ui::windows::save_preset_window::SavePresetWindow;
+                        let mut window = SavePresetWindow::new();
+                        window.input = app.preset_name_input.clone();
+                        let result = ui::dispatch_key(&mut window, key);
+                        app.preset_name_input = window.input;
+                        if result == ui::ComponentResult::Close {
+                            if window.confirmed {
+                                let name = app.preset_name_input.value().to_string();
+                                app.save_filter_preset(&name);
+                            }
+                            app.input_mode = InputMode::Normal;
+                        }
+                    }
+                    InputMode::LoadPreset => {
+                        use ui::windows::load_preset_window::LoadPresetWindow;
+                        let mut window = LoadPresetWindow::new(app.preset_list.clone());
+                        window.cursor = app.preset_list_cursor;
+                        let result = ui::dispatch_key(&mut window, key);
+                        // Handle deletion
+                        if let Some(ref name) = window.delete_name {
+                            let _ = crate::config::filter_preset::delete_preset(name);
+                        }
+                        app.preset_list = window.presets;
+                        app.preset_list_cursor = window.cursor;
+                        if result == ui::ComponentResult::Close {
+                            if window.confirmed {
+                                if let Some(ref name) = window.selected {
+                                    app.load_filter_preset(name);
                                 }
                             }
                             app.input_mode = InputMode::Normal;

--- a/crates/scouty-tui/src/ui/windows/filter_manager_window.rs
+++ b/crates/scouty-tui/src/ui/windows/filter_manager_window.rs
@@ -71,7 +71,7 @@ impl FilterManagerWindow {
 
         lines.push(Line::from(""));
         lines.push(Line::styled(
-            " d: Delete  c: Clear all  Esc: Close",
+            " d: Delete  c: Clear  s: Save preset  l: Load preset  Esc: Close",
             theme.dialog.muted.to_style(),
         ));
 
@@ -160,6 +160,14 @@ impl UiComponent for FilterManagerWindow {
             'c' => {
                 self.action = Some("clear");
                 ComponentResult::Consumed
+            }
+            's' => {
+                self.action = Some("save_preset");
+                ComponentResult::Close
+            }
+            'l' => {
+                self.action = Some("load_preset");
+                ComponentResult::Close
             }
             _ => ComponentResult::Ignored,
         }

--- a/crates/scouty-tui/src/ui/windows/load_preset_window.rs
+++ b/crates/scouty-tui/src/ui/windows/load_preset_window.rs
@@ -1,0 +1,116 @@
+//! Load preset dialog — list of available presets with navigation.
+
+#[cfg(test)]
+#[path = "load_preset_window_tests.rs"]
+mod load_preset_window_tests;
+
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+pub struct LoadPresetWindow {
+    pub presets: Vec<String>,
+    pub cursor: usize,
+    pub selected: Option<String>,
+    pub delete_name: Option<String>,
+    pub confirmed: bool,
+}
+
+impl LoadPresetWindow {
+    pub fn new(presets: Vec<String>) -> Self {
+        Self {
+            cursor: 0,
+            presets,
+            selected: None,
+            delete_name: None,
+            confirmed: false,
+        }
+    }
+}
+
+impl UiComponent for LoadPresetWindow {
+    fn enable_jk_navigation(&self) -> bool {
+        true
+    }
+
+    fn on_up(&mut self) -> ComponentResult {
+        self.cursor = self.cursor.saturating_sub(1);
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        if !self.presets.is_empty() && self.cursor + 1 < self.presets.len() {
+            self.cursor += 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        if !self.presets.is_empty() {
+            self.selected = Some(self.presets[self.cursor].clone());
+            self.confirmed = true;
+            ComponentResult::Close
+        } else {
+            ComponentResult::Consumed
+        }
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        if c == 'd' && !self.presets.is_empty() {
+            self.delete_name = Some(self.presets[self.cursor].clone());
+            self.presets.remove(self.cursor);
+            if self.cursor > 0 && self.cursor >= self.presets.len() {
+                self.cursor = self.presets.len().saturating_sub(1);
+            }
+            ComponentResult::Consumed
+        } else {
+            ComponentResult::Ignored
+        }
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect) {
+        let width = 40u16.min(area.width.saturating_sub(4));
+        let height = (self.presets.len() as u16 + 5)
+            .min(area.height.saturating_sub(4))
+            .max(6);
+        let x = (area.width.saturating_sub(width)) / 2;
+        let y = (area.height.saturating_sub(height)) / 2;
+        let overlay = Rect::new(x, y, width, height);
+
+        frame.render_widget(Clear, overlay);
+
+        let block = Block::default()
+            .title(" Load Filter Preset ")
+            .borders(Borders::ALL);
+        let inner = block.inner(overlay);
+        frame.render_widget(block, overlay);
+
+        let mut lines = Vec::new();
+
+        if self.presets.is_empty() {
+            lines.push(Line::from(" (no saved presets)"));
+        } else {
+            for (i, name) in self.presets.iter().enumerate() {
+                let style = if i == self.cursor {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                };
+                lines.push(Line::styled(format!(" {}", name), style));
+            }
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(" Enter: Load  d: Delete  Esc: Close"));
+
+        let content = Paragraph::new(lines);
+        frame.render_widget(content, inner);
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/load_preset_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/load_preset_window_tests.rs
@@ -1,0 +1,75 @@
+#[cfg(test)]
+mod tests {
+    use super::super::LoadPresetWindow;
+    use crate::ui::{dispatch_key, ComponentResult};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn sample_presets() -> Vec<String> {
+        vec!["alpha".into(), "beta".into(), "gamma".into()]
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let mut w = LoadPresetWindow::new(sample_presets());
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+        assert!(!w.confirmed);
+    }
+
+    #[test]
+    fn test_navigate_and_select() {
+        let mut w = LoadPresetWindow::new(sample_presets());
+        dispatch_key(&mut w, key(KeyCode::Char('j')));
+        assert_eq!(w.cursor, 1);
+        dispatch_key(&mut w, key(KeyCode::Down));
+        assert_eq!(w.cursor, 2);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+        assert!(w.confirmed);
+        assert_eq!(w.selected, Some("gamma".to_string()));
+    }
+
+    #[test]
+    fn test_delete_preset() {
+        let mut w = LoadPresetWindow::new(sample_presets());
+        dispatch_key(&mut w, key(KeyCode::Char('j'))); // cursor at "beta"
+        dispatch_key(&mut w, key(KeyCode::Char('d')));
+        assert_eq!(w.delete_name, Some("beta".to_string()));
+        assert_eq!(w.presets, vec!["alpha", "gamma"]);
+        assert_eq!(w.cursor, 1); // stays at same index
+    }
+
+    #[test]
+    fn test_delete_last_adjusts_cursor() {
+        let mut w = LoadPresetWindow::new(sample_presets());
+        // Go to last
+        dispatch_key(&mut w, key(KeyCode::Down));
+        dispatch_key(&mut w, key(KeyCode::Down));
+        assert_eq!(w.cursor, 2);
+        dispatch_key(&mut w, key(KeyCode::Char('d'))); // delete "gamma"
+        assert_eq!(w.cursor, 1); // adjusted to last item
+    }
+
+    #[test]
+    fn test_empty_presets_enter_does_nothing() {
+        let mut w = LoadPresetWindow::new(vec![]);
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Consumed
+        );
+        assert!(!w.confirmed);
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/mod.rs
+++ b/crates/scouty-tui/src/ui/windows/mod.rs
@@ -9,4 +9,6 @@ pub mod goto_line_window;
 pub mod help_window;
 pub mod highlight_manager_window;
 pub mod level_filter_window;
+pub mod load_preset_window;
+pub mod save_preset_window;
 pub mod stats_window;

--- a/crates/scouty-tui/src/ui/windows/save_preset_window.rs
+++ b/crates/scouty-tui/src/ui/windows/save_preset_window.rs
@@ -1,0 +1,98 @@
+//! Save preset dialog — text input for preset name.
+
+#[cfg(test)]
+#[path = "save_preset_window_tests.rs"]
+mod save_preset_window_tests;
+
+use crate::text_input::TextInput;
+use crate::ui::{ComponentResult, UiComponent};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::layout::Rect;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+pub struct SavePresetWindow {
+    pub input: TextInput,
+    pub confirmed: bool,
+}
+
+impl SavePresetWindow {
+    pub fn new() -> Self {
+        Self {
+            input: TextInput::new(),
+            confirmed: false,
+        }
+    }
+}
+
+impl UiComponent for SavePresetWindow {
+    fn enable_jk_navigation(&self) -> bool {
+        false
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        if !self.input.is_empty() {
+            self.confirmed = true;
+            ComponentResult::Close
+        } else {
+            ComponentResult::Consumed
+        }
+    }
+
+    fn on_cancel(&mut self) -> ComponentResult {
+        ComponentResult::Close
+    }
+
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        self.input.insert(c);
+        ComponentResult::Consumed
+    }
+
+    fn on_key(&mut self, key: KeyEvent) -> ComponentResult {
+        match key.code {
+            KeyCode::Backspace => {
+                self.input.backspace();
+                ComponentResult::Consumed
+            }
+            KeyCode::Delete => {
+                self.input.delete();
+                ComponentResult::Consumed
+            }
+            KeyCode::Left => {
+                self.input.move_left();
+                ComponentResult::Consumed
+            }
+            KeyCode::Right => {
+                self.input.move_right();
+                ComponentResult::Consumed
+            }
+            _ => ComponentResult::Ignored,
+        }
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect) {
+        let width = 40u16.min(area.width.saturating_sub(4));
+        let height = 5u16;
+        let x = (area.width.saturating_sub(width)) / 2;
+        let y = (area.height.saturating_sub(height)) / 2;
+        let overlay = Rect::new(x, y, width, height);
+
+        frame.render_widget(Clear, overlay);
+
+        let block = Block::default()
+            .title(" Save Filter Preset ")
+            .borders(Borders::ALL);
+
+        let inner = block.inner(overlay);
+        frame.render_widget(block, overlay);
+
+        if inner.height >= 2 {
+            let label = Paragraph::new(" Name:");
+            frame.render_widget(label, Rect::new(inner.x, inner.y, inner.width, 1));
+
+            let input_text = format!(" {}", self.input.value());
+            let input_line = Paragraph::new(input_text);
+            frame.render_widget(input_line, Rect::new(inner.x, inner.y + 1, inner.width, 1));
+        }
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/save_preset_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/save_preset_window_tests.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod tests {
+    use super::super::SavePresetWindow;
+    use crate::ui::{dispatch_key, ComponentResult};
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let mut w = SavePresetWindow::new();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Esc)),
+            ComponentResult::Close
+        );
+        assert!(!w.confirmed);
+    }
+
+    #[test]
+    fn test_enter_with_empty_stays() {
+        let mut w = SavePresetWindow::new();
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Consumed
+        );
+        assert!(!w.confirmed);
+    }
+
+    #[test]
+    fn test_type_and_confirm() {
+        let mut w = SavePresetWindow::new();
+        dispatch_key(&mut w, key(KeyCode::Char('t')));
+        dispatch_key(&mut w, key(KeyCode::Char('e')));
+        dispatch_key(&mut w, key(KeyCode::Char('s')));
+        dispatch_key(&mut w, key(KeyCode::Char('t')));
+        assert_eq!(w.input.value(), "test");
+        assert_eq!(
+            dispatch_key(&mut w, key(KeyCode::Enter)),
+            ComponentResult::Close
+        );
+        assert!(w.confirmed);
+    }
+
+    #[test]
+    fn test_backspace() {
+        let mut w = SavePresetWindow::new();
+        dispatch_key(&mut w, key(KeyCode::Char('a')));
+        dispatch_key(&mut w, key(KeyCode::Char('b')));
+        dispatch_key(&mut w, key(KeyCode::Backspace));
+        assert_eq!(w.input.value(), "a");
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -82,6 +82,9 @@ mod tests {
             theme: crate::config::Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         }
     }
 
@@ -172,6 +175,9 @@ mod tests {
             theme: crate::config::Theme::default(),
             level_filter: None,
             level_filter_cursor: 0,
+            preset_name_input: TextInput::new(),
+            preset_list: Vec::new(),
+            preset_list_cursor: 0,
         };
         let stats = StatsData::compute(&app);
         assert_eq!(stats.total_records, 0);

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -117,6 +117,21 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         let window = LevelFilterWindow::from_app(app);
         UiComponent::render(&window, frame, area);
     }
+
+    if app.input_mode == InputMode::SavePreset {
+        use crate::ui::windows::save_preset_window::SavePresetWindow;
+        use crate::ui::UiComponent;
+        let mut window = SavePresetWindow::new();
+        window.input = app.preset_name_input.clone();
+        UiComponent::render(&window, frame, area);
+    }
+
+    if app.input_mode == InputMode::LoadPreset {
+        use crate::ui::windows::load_preset_window::LoadPresetWindow;
+        use crate::ui::UiComponent;
+        let window = LoadPresetWindow::new(app.preset_list.clone());
+        UiComponent::render(&window, frame, area);
+    }
 }
 
 fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary

Add filter preset persistence — save and load filter sets as YAML files stored in `~/.scouty/filters/`.

### Usage
1. Open filter manager with `F`
2. Press `s` to save current filters as a named preset
3. Press `l` to load a saved preset (replaces current filters)
4. Press `d` in load dialog to delete a preset
5. `Esc` to cancel

### Changes

**`config/filter_preset.rs`** (new):
- `FilterPreset` and `FilterPresetEntry` serde structs
- `save_preset`, `load_preset`, `list_presets`, `delete_preset` functions
- Filename sanitization for safety

**`ui/windows/save_preset_window.rs`** (new): Text input dialog for preset name

**`ui/windows/load_preset_window.rs`** (new): List dialog with navigation and delete

**`filter_manager_window.rs`**: Added `s` (save) and `l` (load) keybindings

**`app.rs`**: `save_filter_preset()` and `load_filter_preset()` methods

**`main.rs`**: Event handling for SavePreset/LoadPreset input modes

### Preset Format
```yaml
filters:
  - expr: 'level == "ERROR"'
    exclude: false
  - expr: timeout
    exclude: true
level_filter: WARN+
```

### Test Plan
- 6 preset persistence tests (save/load roundtrip, list, delete, empty, nonexistent)
- 4 save dialog tests + 5 load dialog tests
- 1 name sanitization test
- All 548 tests pass

Closes #306