### PR TITLE
fix: add TRACE+, NOTICE+, FATAL only to level filter

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -321,34 +321,46 @@ pub struct App {
 pub enum LevelFilterPreset {
     /// Show all levels.
     All,
+    /// TRACE and above.
+    TracePlus,
     /// DEBUG and above.
     DebugPlus,
     /// INFO and above.
     InfoPlus,
+    /// NOTICE and above.
+    NoticePlus,
     /// WARN and above.
     WarnPlus,
     /// ERROR and above.
     ErrorPlus,
+    /// FATAL only.
+    FatalOnly,
 }
 
 impl LevelFilterPreset {
     pub fn label(&self) -> &'static str {
         match self {
             Self::All => "ALL",
+            Self::TracePlus => "TRACE+",
             Self::DebugPlus => "DEBUG+",
             Self::InfoPlus => "INFO+",
+            Self::NoticePlus => "NOTICE+",
             Self::WarnPlus => "WARN+",
             Self::ErrorPlus => "ERROR+",
+            Self::FatalOnly => "FATAL",
         }
     }
 
     pub fn from_number(n: u8) -> Option<Self> {
         match n {
             1 => Some(Self::All),
-            2 => Some(Self::DebugPlus),
-            3 => Some(Self::InfoPlus),
-            4 => Some(Self::WarnPlus),
-            5 => Some(Self::ErrorPlus),
+            2 => Some(Self::TracePlus),
+            3 => Some(Self::DebugPlus),
+            4 => Some(Self::InfoPlus),
+            5 => Some(Self::NoticePlus),
+            6 => Some(Self::WarnPlus),
+            7 => Some(Self::ErrorPlus),
+            8 => Some(Self::FatalOnly),
             _ => None,
         }
     }
@@ -356,10 +368,13 @@ impl LevelFilterPreset {
     pub fn as_number(&self) -> u8 {
         match self {
             Self::All => 1,
-            Self::DebugPlus => 2,
-            Self::InfoPlus => 3,
-            Self::WarnPlus => 4,
-            Self::ErrorPlus => 5,
+            Self::TracePlus => 2,
+            Self::DebugPlus => 3,
+            Self::InfoPlus => 4,
+            Self::NoticePlus => 5,
+            Self::WarnPlus => 6,
+            Self::ErrorPlus => 7,
+            Self::FatalOnly => 8,
         }
     }
 
@@ -368,6 +383,18 @@ impl LevelFilterPreset {
         use scouty::record::LogLevel;
         match self {
             Self::All => true,
+            Self::TracePlus => matches!(
+                level,
+                Some(
+                    LogLevel::Trace
+                        | LogLevel::Debug
+                        | LogLevel::Info
+                        | LogLevel::Notice
+                        | LogLevel::Warn
+                        | LogLevel::Error
+                        | LogLevel::Fatal
+                )
+            ),
             Self::DebugPlus => matches!(
                 level,
                 Some(
@@ -389,11 +416,16 @@ impl LevelFilterPreset {
                         | LogLevel::Fatal
                 )
             ),
+            Self::NoticePlus => matches!(
+                level,
+                Some(LogLevel::Notice | LogLevel::Warn | LogLevel::Error | LogLevel::Fatal)
+            ),
             Self::WarnPlus => matches!(
                 level,
                 Some(LogLevel::Warn | LogLevel::Error | LogLevel::Fatal)
             ),
             Self::ErrorPlus => matches!(level, Some(LogLevel::Error | LogLevel::Fatal)),
+            Self::FatalOnly => matches!(level, Some(LogLevel::Fatal)),
         }
     }
 }
@@ -1031,10 +1063,13 @@ impl App {
         if let Some(ref level_str) = preset.level_filter {
             match level_str.as_str() {
                 "ALL" => self.level_filter = None,
+                "TRACE+" => self.level_filter = Some(LevelFilterPreset::TracePlus),
                 "DEBUG+" => self.level_filter = Some(LevelFilterPreset::DebugPlus),
                 "INFO+" => self.level_filter = Some(LevelFilterPreset::InfoPlus),
+                "NOTICE+" => self.level_filter = Some(LevelFilterPreset::NoticePlus),
                 "WARN+" => self.level_filter = Some(LevelFilterPreset::WarnPlus),
                 "ERROR+" => self.level_filter = Some(LevelFilterPreset::ErrorPlus),
+                "FATAL" => self.level_filter = Some(LevelFilterPreset::FatalOnly),
                 _ => {}
             }
         } else {

--- a/crates/scouty-tui/src/ui/windows/level_filter_window.rs
+++ b/crates/scouty-tui/src/ui/windows/level_filter_window.rs
@@ -10,12 +10,15 @@ use crate::ui::{ComponentResult, UiComponent};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
-const OPTIONS: [(u8, LevelFilterPreset); 5] = [
+const OPTIONS: [(u8, LevelFilterPreset); 8] = [
     (1, LevelFilterPreset::All),
-    (2, LevelFilterPreset::DebugPlus),
-    (3, LevelFilterPreset::InfoPlus),
-    (4, LevelFilterPreset::WarnPlus),
-    (5, LevelFilterPreset::ErrorPlus),
+    (2, LevelFilterPreset::TracePlus),
+    (3, LevelFilterPreset::DebugPlus),
+    (4, LevelFilterPreset::InfoPlus),
+    (5, LevelFilterPreset::NoticePlus),
+    (6, LevelFilterPreset::WarnPlus),
+    (7, LevelFilterPreset::ErrorPlus),
+    (8, LevelFilterPreset::FatalOnly),
 ];
 
 pub struct LevelFilterWindow<'a> {
@@ -74,7 +77,7 @@ impl<'a> UiComponent for LevelFilterWindow<'a> {
 
     fn on_char(&mut self, c: char) -> ComponentResult {
         if let Some(n) = c.to_digit(10) {
-            if (1..=5).contains(&n) {
+            if (1..=8).contains(&n) {
                 if let Some(preset) = LevelFilterPreset::from_number(n as u8) {
                     self.selected = Some(preset);
                     self.confirmed = true;

--- a/crates/scouty-tui/src/ui/windows/level_filter_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/level_filter_window_tests.rs
@@ -31,10 +31,13 @@ mod tests {
         let theme = Theme::default();
         for (n, expected) in [
             ('1', LevelFilterPreset::All),
-            ('2', LevelFilterPreset::DebugPlus),
-            ('3', LevelFilterPreset::InfoPlus),
-            ('4', LevelFilterPreset::WarnPlus),
-            ('5', LevelFilterPreset::ErrorPlus),
+            ('2', LevelFilterPreset::TracePlus),
+            ('3', LevelFilterPreset::DebugPlus),
+            ('4', LevelFilterPreset::InfoPlus),
+            ('5', LevelFilterPreset::NoticePlus),
+            ('6', LevelFilterPreset::WarnPlus),
+            ('7', LevelFilterPreset::ErrorPlus),
+            ('8', LevelFilterPreset::FatalOnly),
         ] {
             let mut w = LevelFilterWindow::new(None, &theme);
             let result = dispatch_key(&mut w, key(KeyCode::Char(n)));
@@ -50,6 +53,7 @@ mod tests {
         let mut w = LevelFilterWindow::new(None, &theme);
         assert_eq!(w.cursor, 0);
 
+        // j moves down
         assert_eq!(
             dispatch_key(&mut w, key(KeyCode::Char('j'))),
             ComponentResult::Consumed
@@ -62,10 +66,11 @@ mod tests {
         );
         assert_eq!(w.cursor, 2);
 
+        // cursor=2 is DebugPlus (0=All, 1=TracePlus, 2=DebugPlus)
         let result = dispatch_key(&mut w, key(KeyCode::Enter));
         assert_eq!(result, ComponentResult::Close);
         assert!(w.confirmed);
-        assert_eq!(w.selected, Some(LevelFilterPreset::InfoPlus));
+        assert_eq!(w.selected, Some(LevelFilterPreset::DebugPlus));
     }
 
     #[test]
@@ -73,50 +78,67 @@ mod tests {
         let theme = Theme::default();
         let mut w = LevelFilterWindow::new(None, &theme);
 
+        // Can't go above 0
         assert_eq!(
             dispatch_key(&mut w, key(KeyCode::Up)),
             ComponentResult::Consumed
         );
         assert_eq!(w.cursor, 0);
 
-        for _ in 0..10 {
+        // Navigate past the end
+        for _ in 0..20 {
             dispatch_key(&mut w, key(KeyCode::Char('j')));
         }
-        assert_eq!(w.cursor, 4);
-
-        assert_eq!(
-            dispatch_key(&mut w, key(KeyCode::Char('j'))),
-            ComponentResult::Consumed
-        );
-        assert_eq!(w.cursor, 4);
+        assert_eq!(w.cursor, 7); // 8 options, max index = 7
     }
 
     #[test]
     fn test_current_level_cursor_position() {
         let theme = Theme::default();
+        // WarnPlus is number 6, index 5
         let w = LevelFilterWindow::new(Some(LevelFilterPreset::WarnPlus), &theme);
-        assert_eq!(w.cursor, 3);
+        assert_eq!(w.cursor, 5);
     }
 
     #[test]
     fn test_level_filter_preset_matches() {
         use scouty::record::LogLevel;
 
+        // All matches everything
         assert!(LevelFilterPreset::All.matches_level(Some(&LogLevel::Trace)));
         assert!(LevelFilterPreset::All.matches_level(None));
 
+        // TracePlus
+        assert!(LevelFilterPreset::TracePlus.matches_level(Some(&LogLevel::Trace)));
+        assert!(LevelFilterPreset::TracePlus.matches_level(Some(&LogLevel::Fatal)));
+        assert!(!LevelFilterPreset::TracePlus.matches_level(None));
+
+        // DebugPlus
         assert!(!LevelFilterPreset::DebugPlus.matches_level(Some(&LogLevel::Trace)));
         assert!(LevelFilterPreset::DebugPlus.matches_level(Some(&LogLevel::Debug)));
         assert!(LevelFilterPreset::DebugPlus.matches_level(Some(&LogLevel::Fatal)));
 
+        // InfoPlus
         assert!(!LevelFilterPreset::InfoPlus.matches_level(Some(&LogLevel::Debug)));
         assert!(LevelFilterPreset::InfoPlus.matches_level(Some(&LogLevel::Info)));
 
-        assert!(!LevelFilterPreset::WarnPlus.matches_level(Some(&LogLevel::Info)));
+        // NoticePlus
+        assert!(!LevelFilterPreset::NoticePlus.matches_level(Some(&LogLevel::Info)));
+        assert!(LevelFilterPreset::NoticePlus.matches_level(Some(&LogLevel::Notice)));
+        assert!(LevelFilterPreset::NoticePlus.matches_level(Some(&LogLevel::Fatal)));
+
+        // WarnPlus
+        assert!(!LevelFilterPreset::WarnPlus.matches_level(Some(&LogLevel::Notice)));
         assert!(LevelFilterPreset::WarnPlus.matches_level(Some(&LogLevel::Warn)));
 
+        // ErrorPlus
         assert!(!LevelFilterPreset::ErrorPlus.matches_level(Some(&LogLevel::Warn)));
         assert!(LevelFilterPreset::ErrorPlus.matches_level(Some(&LogLevel::Error)));
         assert!(LevelFilterPreset::ErrorPlus.matches_level(Some(&LogLevel::Fatal)));
+
+        // FatalOnly
+        assert!(!LevelFilterPreset::FatalOnly.matches_level(Some(&LogLevel::Error)));
+        assert!(LevelFilterPreset::FatalOnly.matches_level(Some(&LogLevel::Fatal)));
+        assert!(!LevelFilterPreset::FatalOnly.matches_level(None));
     }
 }


### PR DESCRIPTION
## Summary

Expand the level quick filter from 5 to 8 options per the updated spec.

### Before
1=ALL, 2=DEBUG+, 3=INFO+, 4=WARN+, 5=ERROR+

### After
1=ALL, 2=TRACE+, 3=DEBUG+, 4=INFO+, 5=NOTICE+, 6=WARN+, 7=ERROR+, 8=FATAL

### Changes
- **`app.rs`**: Add `TracePlus`, `NoticePlus`, `FatalOnly` variants to `LevelFilterPreset`; update `label()`, `from_number()`, `as_number()`, `matches_level()`; update preset loading
- **`level_filter_window.rs`**: Expand OPTIONS to 8 entries, update number key range to 1-8
- **`level_filter_window_tests.rs`**: Update all tests for new numbering, add coverage for TracePlus/NoticePlus/FatalOnly

### Test Plan
All 554 tests pass.

Closes #312