### PR TITLE
fix: filter preset save/load round-trip bug

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -159,6 +159,8 @@ impl ColumnConfig {
 pub struct FilterEntry {
     /// Human-readable label (e.g. "exclude: timeout", "level == ERROR").
     pub label: String,
+    /// The original parseable expression string.
+    pub expr_str: String,
     /// The compiled expression.
     pub expr: Expr,
     /// Whether this is an exclude (true) or include (false) filter.
@@ -840,6 +842,7 @@ impl App {
             Ok(parsed_expr) => {
                 self.filters.push(FilterEntry {
                     label: self.filter_input.value().to_string(),
+                    expr_str: self.filter_input.value().to_string(),
                     expr: parsed_expr,
                     exclude: false,
                 });
@@ -864,6 +867,7 @@ impl App {
             Ok(parsed_expr) => {
                 self.filters.push(FilterEntry {
                     label: format!("exclude: {}", text),
+                    expr_str: expr_str.clone(),
                     expr: parsed_expr,
                     exclude: true,
                 });
@@ -887,6 +891,7 @@ impl App {
             Ok(parsed_expr) => {
                 self.filters.push(FilterEntry {
                     label: format!("include: {}", text),
+                    expr_str: expr_str.clone(),
                     expr: parsed_expr,
                     exclude: false,
                 });
@@ -1012,7 +1017,7 @@ impl App {
                 .filters
                 .iter()
                 .map(|f| FilterPresetEntry {
-                    expr: f.label.clone(),
+                    expr: f.expr_str.clone(),
                     exclude: f.exclude,
                 })
                 .collect(),
@@ -1046,6 +1051,7 @@ impl App {
                 Ok(parsed) => {
                     self.filters.push(FilterEntry {
                         label: entry.expr.clone(),
+                        expr_str: entry.expr.clone(),
                         expr: parsed,
                         exclude: entry.exclude,
                     });
@@ -1145,6 +1151,7 @@ impl App {
                     };
                     self.filters.push(FilterEntry {
                         label,
+                        expr_str: part.to_string(),
                         expr: parsed_expr,
                         exclude: state.exclude,
                     });
@@ -1170,6 +1177,7 @@ impl App {
                 Ok(parsed_expr) => {
                     self.filters.push(FilterEntry {
                         label,
+                        expr_str: expr_str.clone(),
                         expr: parsed_expr,
                         exclude: state.exclude,
                     });

--- a/crates/scouty-tui/src/config/filter_preset_tests.rs
+++ b/crates/scouty-tui/src/config/filter_preset_tests.rs
@@ -108,4 +108,31 @@ mod tests {
             assert!(loaded.level_filter.is_none());
         });
     }
+
+    #[test]
+    fn test_round_trip_with_expressions() {
+        with_test_home("roundtrip_expr", || {
+            let preset = FilterPreset {
+                filters: vec![
+                    FilterPresetEntry {
+                        expr: "message contains \"timeout\"".to_string(),
+                        exclude: true,
+                    },
+                    FilterPresetEntry {
+                        expr: "message contains \"error\"".to_string(),
+                        exclude: false,
+                    },
+                ],
+                level_filter: Some("WARN+".to_string()),
+            };
+            super::super::save_preset("roundtrip_expr", &preset).unwrap();
+            let loaded = super::super::load_preset("roundtrip_expr").unwrap();
+            assert_eq!(loaded.filters.len(), 2);
+            assert_eq!(loaded.filters[0].expr, "message contains \"timeout\"");
+            assert!(loaded.filters[0].exclude);
+            assert_eq!(loaded.filters[1].expr, "message contains \"error\"");
+            assert!(!loaded.filters[1].exclude);
+            assert_eq!(loaded.level_filter, Some("WARN+".to_string()));
+        });
+    }
 }


### PR DESCRIPTION
## Bug

Quick exclude/include filters stored a display label (e.g. `exclude: timeout`) as the expression in saved presets, but the actual parseable expression was `message contains "timeout"`. Loading the preset tried to parse the display label, which failed silently — resulting in empty filters.

## Root Cause

`FilterEntry.label` was used for both display and serialization, but for quick filters the label differs from the parseable expression.

## Fix

Add `expr_str` field to `FilterEntry` that stores the original parseable expression string. Use `expr_str` (not `label`) when serializing presets.

## Changes

- **`app.rs`**: Add `expr_str: String` to `FilterEntry`; populate it in all 6 constructor sites; use it in `save_filter_preset`
- **`filter_preset_tests.rs`**: Add round-trip test with actual expressions

## Test Plan

All 555 tests pass (1 new round-trip test).

Closes #313