### PR TITLE
fix: add Ctrl+a/e/k/u readline shortcuts

### DIFF
--- a/crates/scouty-tui/src/text_input.rs
+++ b/crates/scouty-tui/src/text_input.rs
@@ -137,6 +137,19 @@ impl TextInput {
         self.cursor
     }
 
+    /// Delete from cursor to end of line (Ctrl+k).
+    pub fn kill_to_end(&mut self) {
+        let byte_pos = self.byte_pos();
+        self.text.truncate(byte_pos);
+    }
+
+    /// Delete from start of line to cursor (Ctrl+u).
+    pub fn kill_to_start(&mut self) {
+        let byte_pos = self.byte_pos();
+        self.text.drain(..byte_pos);
+        self.cursor = 0;
+    }
+
     /// Handle a key event. Returns true if the key was consumed.
     pub fn handle_key(&mut self, key: KeyEvent) -> bool {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
@@ -144,6 +157,18 @@ impl TextInput {
         // Normalize Ctrl+H to Backspace (some terminals send ^H)
         if ctrl && key.code == KeyCode::Char('h') {
             self.backspace();
+            return true;
+        }
+
+        // Readline/emacs shortcuts
+        if ctrl {
+            match key.code {
+                KeyCode::Char('a') => self.home(),
+                KeyCode::Char('e') => self.end(),
+                KeyCode::Char('k') => self.kill_to_end(),
+                KeyCode::Char('u') => self.kill_to_start(),
+                _ => return false,
+            }
             return true;
         }
 

--- a/crates/scouty-tui/src/text_input_tests.rs
+++ b/crates/scouty-tui/src/text_input_tests.rs
@@ -156,4 +156,56 @@ mod tests {
         assert_eq!(ti.value(), "ac");
         assert_eq!(ti.cursor_position(), 1);
     }
+
+    #[test]
+    fn ctrl_a_moves_to_start() {
+        let mut ti = TextInput::with_text("hello");
+        assert_eq!(ti.cursor_position(), 5);
+        assert!(ti.handle_key(ctrl_key(KeyCode::Char('a'))));
+        assert_eq!(ti.cursor_position(), 0);
+        assert_eq!(ti.value(), "hello");
+    }
+
+    #[test]
+    fn ctrl_e_moves_to_end() {
+        let mut ti = TextInput::with_text("hello");
+        ti.home();
+        assert_eq!(ti.cursor_position(), 0);
+        assert!(ti.handle_key(ctrl_key(KeyCode::Char('e'))));
+        assert_eq!(ti.cursor_position(), 5);
+        assert_eq!(ti.value(), "hello");
+    }
+
+    #[test]
+    fn ctrl_k_kills_to_end() {
+        let mut ti = TextInput::with_text("hello world");
+        ti.cursor = 5; // after "hello"
+        assert!(ti.handle_key(ctrl_key(KeyCode::Char('k'))));
+        assert_eq!(ti.value(), "hello");
+        assert_eq!(ti.cursor_position(), 5);
+    }
+
+    #[test]
+    fn ctrl_k_at_end_is_noop() {
+        let mut ti = TextInput::with_text("hello");
+        assert!(ti.handle_key(ctrl_key(KeyCode::Char('k'))));
+        assert_eq!(ti.value(), "hello");
+    }
+
+    #[test]
+    fn ctrl_u_kills_to_start() {
+        let mut ti = TextInput::with_text("hello world");
+        ti.cursor = 5; // after "hello"
+        assert!(ti.handle_key(ctrl_key(KeyCode::Char('u'))));
+        assert_eq!(ti.value(), " world");
+        assert_eq!(ti.cursor_position(), 0);
+    }
+
+    #[test]
+    fn ctrl_u_at_start_is_noop() {
+        let mut ti = TextInput::with_text("hello");
+        ti.home();
+        assert!(ti.handle_key(ctrl_key(KeyCode::Char('u'))));
+        assert_eq!(ti.value(), "hello");
+    }
 }


### PR DESCRIPTION
## Summary

Add standard readline/emacs editing shortcuts to TextInput, making text editing in all input fields (filter, search, save dialog path, preset name, etc.) more convenient.

### Shortcuts Added
| Key | Action |
|-----|--------|
| Ctrl+a | Move cursor to beginning |
| Ctrl+e | Move cursor to end |
| Ctrl+k | Delete from cursor to end of line |
| Ctrl+u | Delete from beginning to cursor |

### Changes
- **`text_input.rs`**: Add `kill_to_end()` and `kill_to_start()` methods; add Ctrl+a/e/k/u handling in `handle_key()`
- **`text_input_tests.rs`**: 6 new tests for all shortcuts including edge cases

### Test Plan
All 570 tests pass (6 new).

Closes #318