### PR TITLE
[PM Spec] Keybindings grouped by context (global / log table view / dialog)

### DIFF
--- a/crates/scouty-tui/spec/help.md
+++ b/crates/scouty-tui/spec/help.md
@@ -13,10 +13,79 @@ A scrollable help overlay displaying all available keybindings, version informat
 
 ### Content
 
-- Complete keybinding reference table (all shortcuts with descriptions)
-- Grouped by category: Navigation, Search, Filter, Highlight, Copy/Export, Misc
+- Complete keybinding reference table grouped by context and category (see below)
 - Version number (from `Cargo.toml`)
 - GitHub repository URL: `https://github.com/r12f/scouty`
+
+### Keybinding Reference
+
+The help dialog shows keybindings organized by **context** (where they are active) and **category** (what they do). Keybindings marked "Log Table View" only appear when the main log table is focused (no overlay/dialog open).
+
+#### Global (always active)
+
+| Key | Function |
+|-----|----------|
+| `Esc` | Close current overlay / cancel input |
+| `q` | Quit |
+| `?` | Help |
+
+#### Log Table View — Navigation
+
+| Key | Function |
+|-----|----------|
+| `j` / `k` | Move up/down one row |
+| `Ctrl+j` / `Ctrl+k` | Page up/down |
+| `g` / `G` | First/last row |
+| `Ctrl+G` | Go to line number |
+| `]` / `[` | Relative time jump forward/backward |
+| `Ctrl+]` | Toggle follow mode |
+| `Enter` | Toggle detail panel |
+
+#### Log Table View — Search & Filter
+
+| Key | Function |
+|-----|----------|
+| `/` | Search (regex) |
+| `n` / `N` | Next/prev search match |
+| `f` | Filter expression input |
+| `-` / `=` | Quick exclude/include text |
+| `_` / `+` | Field exclude/include dialog |
+| `F` | Filter manager |
+| `l` | Log level quick filter (1-8) |
+
+#### Log Table View — Display & Analysis
+
+| Key | Function |
+|-----|----------|
+| `c` | Column selector |
+| `d` / `D` | Cycle / select density chart source |
+| `h` / `H` | Add highlight / highlight manager |
+| `S` | Stats summary |
+
+#### Log Table View — Bookmarks
+
+| Key | Function |
+|-----|----------|
+| `m` | Toggle bookmark |
+| `'` / `"` | Next/prev bookmark |
+| `M` | Bookmark manager |
+
+#### Log Table View — Copy & Export
+
+| Key | Function |
+|-----|----------|
+| `y` / `Y` | Copy raw / format selection |
+| `s` | Save/export dialog |
+
+#### Dialog Navigation (shared across all dialogs)
+
+| Key | Function |
+|-----|----------|
+| `j` / `k` / `↑` / `↓` | Move selection |
+| `PageUp` / `PageDown` | Page through options |
+| `Space` | Toggle selection (multi-select dialogs) |
+| `Enter` | Confirm |
+| `Esc` | Cancel / close |
 
 ### Behavior
 
@@ -29,3 +98,4 @@ A scrollable help overlay displaying all available keybindings, version informat
 | Date | Change |
 |------|--------|
 | 2026-02-20 | Help dialog with keybinding reference |
+| 2026-02-24 | Explicit keybinding groups by context (global vs log table view vs dialog) |

--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -85,6 +85,16 @@ Components notify App via return values or callbacks. App updates shared state (
 
 ### Keybinding Summary
 
+#### Global (always active)
+
+| Key | Function |
+|-----|----------|
+| `Esc` | Close current overlay / cancel input |
+| `q` | Quit |
+| `?` | Help |
+
+#### Log Table View (main view, no overlay open)
+
 | Key | Function |
 |-----|----------|
 | `j`/`k` | Move up/down one row |
@@ -98,10 +108,10 @@ Components notify App via return values or callbacks. App updates shared state (
 | `-`/`=` | Quick exclude/include text |
 | `_`/`+` | Field exclude/include dialog |
 | `F` | Filter manager |
+| `l` | Log level quick filter (1-8) |
 | `c` | Column selector |
 | `y`/`Y` | Copy raw / format selection |
 | `s` | Save/export dialog (path + format) |
-| `l` | Log level quick filter (1-8) |
 | `d`/`D` | Cycle / select density chart source (level/highlight) |
 | `h`/`H` | Add highlight / highlight manager |
 | `m` | Toggle bookmark |
@@ -110,9 +120,16 @@ Components notify App via return values or callbacks. App updates shared state (
 | `S` | Stats summary |
 | `]`/`[` | Relative time jump (forward/backward) |
 | `Ctrl+]` | Toggle follow mode |
-| `Esc` | Close current overlay |
-| `q` | Quit |
-| `?` | Help |
+
+#### Dialog Navigation (shared across all overlays/dialogs)
+
+| Key | Function |
+|-----|----------|
+| `j`/`k`/`↑`/`↓` | Move selection |
+| `PageUp`/`PageDown` | Page through options |
+| `Space` | Toggle selection (multi-select dialogs) |
+| `Enter` | Confirm |
+| `Esc` | Cancel / close |
 
 ## Change Log
 


### PR DESCRIPTION
Clarifies keybinding scope — most shortcuts (l, d/D, s, F, etc.) only work in log table view, not when dialogs are open.

**help.md:**
- Full keybinding reference grouped by context: Global → Log Table View (Navigation / Search & Filter / Display & Analysis / Bookmarks / Copy & Export) → Dialog Navigation
- Explicitly states 'Log Table View' keys only active when main table is focused

**overview.md:**
- Keybinding table split into 3 sections: Global / Log Table View / Dialog Navigation

Addresses issue #321 (help dialog missing l, d/D keys and showing Ctrl+F instead of F).