### PR TITLE
fix: save dialog path input ignoring typed chars

### DIFF
--- a/crates/scouty-tui/src/ui/windows/save_dialog_window.rs
+++ b/crates/scouty-tui/src/ui/windows/save_dialog_window.rs
@@ -234,6 +234,27 @@ impl UiComponent for SaveDialogWindow {
         ComponentResult::Close
     }
 
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        if self.focus == Focus::Path {
+            self.path_input.insert(c);
+            self.error = None;
+            ComponentResult::Consumed
+        } else {
+            ComponentResult::Ignored
+        }
+    }
+
+    fn on_toggle(&mut self) -> ComponentResult {
+        // Space in path input should insert a space character
+        if self.focus == Focus::Path {
+            self.path_input.insert(' ');
+            self.error = None;
+            ComponentResult::Consumed
+        } else {
+            ComponentResult::Ignored
+        }
+    }
+
     fn on_key(&mut self, key: crossterm::event::KeyEvent) -> ComponentResult {
         use crossterm::event::KeyCode;
 

--- a/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
@@ -216,4 +216,49 @@ mod tests {
         window.on_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
         assert!(!window.enable_jk_navigation());
     }
+
+    #[test]
+    fn test_char_input_via_dispatch() {
+        let app = make_test_app(1);
+        let mut window = SaveDialogWindow::from_app(&app);
+        // Clear default path
+        window.path_input.clear();
+
+        // Type via dispatch_key (same path as main.rs)
+        let result = crate::ui::dispatch_key(
+            &mut window,
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+        );
+        assert_eq!(result, ComponentResult::Consumed);
+        crate::ui::dispatch_key(
+            &mut window,
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE),
+        );
+        crate::ui::dispatch_key(
+            &mut window,
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+        );
+        assert_eq!(window.path_input.value(), "abc");
+    }
+
+    #[test]
+    fn test_space_in_path_input() {
+        let app = make_test_app(1);
+        let mut window = SaveDialogWindow::from_app(&app);
+        window.path_input.clear();
+
+        crate::ui::dispatch_key(
+            &mut window,
+            KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+        );
+        crate::ui::dispatch_key(
+            &mut window,
+            KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+        );
+        crate::ui::dispatch_key(
+            &mut window,
+            KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE),
+        );
+        assert_eq!(window.path_input.value(), "a b");
+    }
 }


### PR DESCRIPTION
## Bug

Save dialog path input didn't respond to typed characters. Users couldn't modify the file path.

## Root Cause

`dispatch_key()` routes `KeyCode::Char(c)` to `on_char(c)` and space to `on_toggle()`, but `SaveDialogWindow` only handled input in `on_key()` (the fallback). The default `on_char`/`on_toggle` return `Ignored`, so characters were silently dropped.

## Fix

Override `on_char()` and `on_toggle()` in `SaveDialogWindow` to forward to `path_input` when focus is `Path`.

## Tests

2 new tests verify character input and space via `dispatch_key`. All 566 tests pass.

Closes #326