### PR TITLE
perf: stream exports to file via BufWriter

### DIFF
--- a/crates/scouty-tui/src/ui/windows/save_dialog_window.rs
+++ b/crates/scouty-tui/src/ui/windows/save_dialog_window.rs
@@ -104,9 +104,8 @@ impl SaveDialogWindow {
                     .and_then(|_| writeln!(writer))
             }
             ExportFormat::Yaml => {
-                // Write records one at a time to avoid building a huge
-                // intermediate string. serde_yaml's Serializer writes
-                // directly to the underlying writer.
+                // Stream YAML directly to the writer to avoid building a huge
+                // intermediate String (using `to_writer` instead of `to_string`).
                 let records: Vec<&scouty::record::LogRecord> = app
                     .filtered_indices
                     .iter()


### PR DESCRIPTION
## Bug

YAML export was extremely slow for large files due to building a huge intermediate String via `serde_yaml::to_string`.

## Fix

Stream all export formats directly to a `BufWriter<File>`:
- **Raw**: `write!/writeln!` per line instead of `Vec::join`
- **JSON**: `serde_json::to_writer_pretty` instead of `to_string_pretty`
- **YAML**: `serde_yaml::to_writer` instead of `to_string`

This eliminates the large intermediate String allocation and reduces peak memory usage.

## Test Plan

All 566 tests pass. Export format correctness verified by existing tests.

Closes #327