### PR TITLE
[PM Spec] --generate-config and --generate-theme CLI commands

### DIFF
--- a/spec/cli.md
+++ b/spec/cli.md
@@ -19,6 +19,64 @@ scouty-tui [OPTIONS] [file1] [file2] ...
 |------|-------------|
 | `--theme <name>` | Override theme selection |
 | `--config <path>` | Load additional config file (overrides system and user configs) |
+| `--generate-config` | Generate default config file to stdout |
+| `--generate-theme <name>` | Generate a built-in theme file to stdout |
+
+### Config Generation
+
+**`--generate-config`** — prints the full default config to stdout with comments explaining each field.
+
+```bash
+# Generate and save as user config
+scouty-tui --generate-config > ~/.scouty/config.yaml
+
+# Generate to current directory as project config
+scouty-tui --generate-config > ./scouty.yaml
+```
+
+Output includes all configurable fields with their default values and brief comments:
+
+```yaml
+# Scouty configuration file
+# Place at ~/.scouty/config.yaml (user) or ./scouty.yaml (project)
+# See: https://github.com/r12f/scouty
+
+# Theme selection (built-in: default, dark, light, solarized, landmine)
+theme: default
+
+# Default log paths (glob supported)
+default_paths: []
+
+# Keybindings (uncomment to override)
+# keybindings:
+#   quit: "q"
+#   search: "/"
+#   filter: "f"
+#   ...
+
+# SSH settings
+# ssh:
+#   connect_timeout: 10
+#   keepalive_interval: 30
+```
+
+**`--generate-theme <name>`** — prints the specified built-in theme's full YAML definition to stdout.
+
+```bash
+# Export the landmine theme as a starting point for customization
+scouty-tui --generate-theme landmine > ~/.scouty/themes/my-theme.yaml
+
+# List available built-in themes
+scouty-tui --generate-theme list
+```
+
+When `name` is `list`, prints all available built-in theme names (one per line).
+
+**Behavior:**
+- Both commands print to stdout and exit immediately (TUI does not launch)
+- Output is valid YAML that can be directly used as config/theme file
+- All fields included with defaults, commented-out optional sections for discoverability
+- Exit code 0 on success, non-zero if theme name is unknown
 
 ### Argument Handling
 
@@ -53,3 +111,4 @@ scouty-tui [OPTIONS] [file1] [file2] ...
 |------|--------|
 | 2026-02-22 | Multi-file support, Linux default syslog, stdin pipe input |
 | 2026-02-23 | Added --theme and --config CLI flags |
+| 2026-02-24 | Added --generate-config and --generate-theme for default config generation |


### PR DESCRIPTION
New CLI commands to generate default config/theme files for easy customization.

**`--generate-config`**
```bash
scouty-tui --generate-config > ~/.scouty/config.yaml
```
Prints full default config with comments explaining each field.

**`--generate-theme <name>`**
```bash
scouty-tui --generate-theme landmine > ~/.scouty/themes/my-theme.yaml
scouty-tui --generate-theme list  # lists available themes
```
Prints built-in theme YAML, ready to customize.

Both commands output to stdout and exit without launching TUI.