### PR TITLE
feat: --generate-config and --generate-theme CLI

### DIFF
--- a/crates/scouty-tui/src/config/config_tests.rs
+++ b/crates/scouty-tui/src/config/config_tests.rs
@@ -187,4 +187,43 @@ mod tests {
         assert_eq!(cfg.theme, "solarized");
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    #[test]
+    fn test_generate_default_config_is_valid_yaml() {
+        let yaml = super::super::generate_default_config();
+        let cfg: super::super::Config = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(cfg.theme, "default");
+        assert_eq!(cfg.ssh.connect_timeout, 10);
+    }
+
+    #[test]
+    fn test_generate_theme_known() {
+        for name in super::super::Theme::builtin_names() {
+            let yaml = super::super::generate_theme(name);
+            assert!(yaml.is_some(), "theme {} should generate", name);
+            let yaml = yaml.unwrap();
+            assert!(yaml.contains(&format!("# Scouty theme: {}", name)));
+            // Should be parseable as a Theme
+            // Skip the comment lines and parse
+            let theme_yaml: String = yaml
+                .lines()
+                .filter(|l| !l.starts_with('#'))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let _theme: super::super::Theme = serde_yaml::from_str(&theme_yaml).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_generate_theme_unknown() {
+        assert!(super::super::generate_theme("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_builtin_names() {
+        let names = super::super::Theme::builtin_names();
+        assert!(names.contains(&"default"));
+        assert!(names.contains(&"landmine"));
+        assert_eq!(names.len(), 5);
+    }
 }

--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -264,6 +264,59 @@ pub fn resolve_theme(config: &Config, cli_theme: Option<&str>) -> Theme {
     Theme::default()
 }
 
+/// Generate a default config file with comments for `--generate-config`.
+pub fn generate_default_config() -> String {
+    r#"# Scouty configuration file
+# Place at ~/.scouty/config.yaml (user) or ./scouty.yaml (project)
+# See: https://github.com/r12f/scouty
+
+# Theme selection (built-in: default, dark, light, solarized, landmine)
+theme: default
+
+# Default log paths when no files specified (glob patterns supported)
+default_paths: []
+
+# Keybindings (uncomment to override)
+# keybindings:
+#   quit: "q"
+#   search: "/"
+#   filter: "f"
+
+# General settings
+general:
+  # Auto-enable follow mode when reading from pipe/stdin
+  follow_on_pipe: true
+  # Detail panel height ratio (0.0 - 1.0)
+  detail_panel_ratio: 0.3
+
+# SSH settings for remote log reading (ssh:// URLs)
+ssh:
+  # Connection timeout in seconds
+  connect_timeout: 10
+  # Keepalive interval in seconds (0 to disable)
+  keepalive_interval: 30
+"#
+    .to_string()
+}
+
+/// Generate a built-in theme as commented YAML for `--generate-theme`.
+/// Returns `None` if the theme name is unknown.
+pub fn generate_theme(name: &str) -> Option<String> {
+    let theme = Theme::builtin(name)?;
+    let yaml = serde_yaml::to_string(&theme).ok()?;
+    Some(format!(
+        "# Scouty theme: {}\n\
+         # Place at ~/.scouty/themes/<name>.yaml\n\
+         # Customize and load with: theme: <name> in config.yaml\n\
+         #\n\
+         # Color values: named (Red, Green, Blue, ...) or RGB hex (\"#ff5533\")\n\
+         # Style fields: fg, bg, bold, italic, underline\n\
+         \n\
+         {yaml}",
+        name
+    ))
+}
+
 #[cfg(test)]
 #[path = "config_tests.rs"]
 mod config_tests;

--- a/crates/scouty-tui/src/config/theme.rs
+++ b/crates/scouty-tui/src/config/theme.rs
@@ -386,6 +386,11 @@ impl Theme {
         }
     }
 
+    /// List all built-in theme names.
+    pub fn builtin_names() -> &'static [&'static str] {
+        &["default", "dark", "light", "solarized", "landmine"]
+    }
+
     /// Muted dark theme — lower contrast, softer colors.
     pub fn dark() -> Self {
         use Color::*;

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -104,8 +104,65 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     "  --theme <name>    Override theme (default, dark, light, solarized, or custom)"
                 );
                 eprintln!("  --config <path>   Load additional config file (overrides file-based configs)");
+                eprintln!("  --generate-config          Generate default config to stdout");
+                eprintln!(
+                    "  --generate-theme <name>    Generate built-in theme to stdout (or 'list')"
+                );
                 eprintln!("  -h, --help        Show this help");
                 std::process::exit(0);
+            }
+            "--generate-config" => {
+                print!("{}", config::generate_default_config());
+                std::process::exit(0);
+            }
+            "--generate-theme" => {
+                if i + 1 < args.len() {
+                    let name = &args[i + 1];
+                    if name == "list" {
+                        for t in config::Theme::builtin_names() {
+                            println!("{}", t);
+                        }
+                        std::process::exit(0);
+                    }
+                    match config::generate_theme(name) {
+                        Some(yaml) => {
+                            print!("{}", yaml);
+                            std::process::exit(0);
+                        }
+                        None => {
+                            eprintln!("Error: unknown theme '{}'\n\nAvailable themes:", name);
+                            for t in config::Theme::builtin_names() {
+                                eprintln!("  {}", t);
+                            }
+                            std::process::exit(1);
+                        }
+                    }
+                } else {
+                    eprintln!("Error: --generate-theme requires a theme name (or 'list')");
+                    std::process::exit(1);
+                }
+            }
+            arg if arg.starts_with("--generate-theme=") => {
+                let name = arg.trim_start_matches("--generate-theme=");
+                if name == "list" {
+                    for t in config::Theme::builtin_names() {
+                        println!("{}", t);
+                    }
+                    std::process::exit(0);
+                }
+                match config::generate_theme(name) {
+                    Some(yaml) => {
+                        print!("{}", yaml);
+                        std::process::exit(0);
+                    }
+                    None => {
+                        eprintln!("Error: unknown theme '{}'\n\nAvailable themes:", name);
+                        for t in config::Theme::builtin_names() {
+                            eprintln!("  {}", t);
+                        }
+                        std::process::exit(1);
+                    }
+                }
             }
             _ => {
                 file_args.push(args[i].clone());


### PR DESCRIPTION
## Summary

Add CLI commands for generating default config and theme files, making it easy for users to bootstrap customization.

### New CLI Flags
- `--generate-config` — output default config YAML with comments to stdout
- `--generate-theme <name>` — output a built-in theme as YAML to stdout
- `--generate-theme list` — list available built-in theme names

Both print and exit immediately without starting the TUI.

### Changes
- **`main.rs`**: Parse `--generate-config` and `--generate-theme` args
- **`config/mod.rs`**: Add `generate_default_config()` and `generate_theme()`
- **`config/theme.rs`**: Add `builtin_names()`
- **`config_tests.rs`**: 4 new tests (config validity, theme generation, unknown theme, builtin names)

### Test Plan
All 570 tests pass (4 new).

Closes #331