### PR TITLE
fix: text input end-of-line cursor appearance

### DIFF
--- a/crates/scouty-tui/src/text_input.rs
+++ b/crates/scouty-tui/src/text_input.rs
@@ -184,7 +184,7 @@ impl TextInput {
             let after_pos = byte_pos + ch.len_utf8();
             (before, ch.to_string(), &self.text[after_pos..])
         } else {
-            (before, "█".to_string(), "")
+            (before, " ".to_string(), "")
         }
     }
 }

--- a/crates/scouty-tui/src/text_input_tests.rs
+++ b/crates/scouty-tui/src/text_input_tests.rs
@@ -114,7 +114,7 @@ mod tests {
         let ti = TextInput::with_text("abc");
         let (before, cursor, after) = ti.render_parts();
         assert_eq!(before, "abc");
-        assert_eq!(cursor, "█");
+        assert_eq!(cursor, " ");
         assert_eq!(after, "");
     }
 


### PR DESCRIPTION
## Bug

Cursor at end of text input rendered as `█` with REVERSED style, which appeared as an underscore in some terminals — looked like an extra character in the path.

## Fix

Use a space ` ` instead of `█` for the end-of-string cursor placeholder. With REVERSED style, this renders as a clean block cursor that's visually distinct from text content.

## Test Plan

All 570 tests pass (updated render_parts test).

Closes #332