### PR TITLE
[PM Spec] Structured log expansion framework + JSON parser

### DIFF
--- a/crates/scouty-tui/spec/detail-panel.md
+++ b/crates/scouty-tui/spec/detail-panel.md
@@ -2,17 +2,61 @@
 
 ## Overview
 
-The detail panel displays the full content of the currently selected log record in a left-right split layout: log content on the left, structured fields on the right.
+The detail panel displays the full content of the currently selected log record in a left-right split layout: log content on the left, structured fields on the right. When the log record has parser-provided structured expansion, the left side renders an interactive tree view.
 
 
 ## Design
 
 ### Layout
 
-- **Left side (~70% width)**: Full log content (`raw` field), with word wrap. Scrollable if content exceeds panel height.
+- **Left side (~70% width)**: Structured expansion tree (if `expanded` is present) or full log content (`raw` field) with word wrap. Scrollable.
 - **Right side (~30% width)**: Structured field table (Field | Value), fixed-width field column, value fills remaining space. Truncated (no wrap) for long values.
 - Vertical separator between left and right areas.
-- Left title: "Log Content"; Right title: "Fields"
+- Left title: "Expanded" (when tree) or "Log Content" (when raw); Right title: "Fields"
+
+### Structured Expansion Tree (Left Side)
+
+When `LogRecord.expanded` is populated by the parser, the left side renders an interactive tree:
+
+```
+▼ Operation: SET
+▼ Table: ROUTE_TABLE
+▼ Key: Vrf1:10.0.0.0/24
+▼ Attributes
+    nexthop: 10.1.1.1
+    ifname: Ethernet0
+```
+
+JSON example:
+```
+▼ Payload
+    service: auth
+    msg: login failed
+  ▼ details
+      user: alice
+      ip: 10.0.0.1
+```
+
+**Tree behavior:**
+- `▼` / `▶` indicators for collapsible nodes (KeyValue and List types)
+- `j`/`k` to navigate tree nodes
+- `Enter` or `l` to expand/collapse a node
+- `h` to collapse current node (or go to parent if already collapsed)
+- `H` to collapse all; `L` to expand all
+- Indentation: 2 spaces per nesting level
+- Leaf nodes (Text values): `label: value` on one line
+- Long values: truncated with `…`, full value shown on hover/select
+- When `expanded` is not populated: falls back to raw text display (current behavior)
+
+### Quick Filter from Expanded Fields
+
+When navigating the tree, press `f` on a leaf node to create a filter from that field:
+
+- **KeyValue leaf**: creates filter `key == "value"` (using the field's key path)
+- Status bar shows: `Filter added: details.user == "alice"`
+- Works with existing filter system (additive)
+
+This gives users a fast path from browsing structured logs to filtering by any field.
 
 ### Fields Displayed (Right Side)
 
@@ -22,10 +66,12 @@ Level shows `-` when empty. Source always shown even if hidden in table columns.
 
 ### Behavior
 
-- `Enter` toggles panel open/close
+- `Enter` toggles panel open/close (when panel is closed)
+- When panel is open and expanded tree is shown, `Enter` toggles tree nodes
 - Panel follows cursor — updates when selected row changes
 - Panel height adapts to field count + border (not fixed percentage)
 - Narrow window (< 80 cols): right side collapses or switches to single-column
+- `Tab` switches focus between left (tree/content) and right (fields) sides
 
 ## Change Log
 
@@ -33,3 +79,4 @@ Level shows `-` when empty. Source always shown even if hidden in table columns.
 |------|--------|
 | 2026-02-20 | Initial detail panel (single column) |
 | 2026-02-22 | Left-right split layout redesign |
+| 2026-02-24 | Structured expansion tree rendering with interactive navigation and quick filter |

--- a/crates/scouty/spec/log-record.md
+++ b/crates/scouty/spec/log-record.md
@@ -26,6 +26,69 @@
 | `raw` | `String` | Original raw log text |
 | `metadata` | `Option<HashMap<String, String>>` | Extensible key-value metadata (None when empty to avoid allocation) |
 | `loader_id` | `Arc<str>` | Source loader identifier (shared) |
+| `expanded` | `Option<Vec<ExpandedField>>` | Parser-provided structured expansion of the log content (None when not applicable) |
+
+### ExpandedField
+
+A recursive tree structure for representing parsed/expanded log content:
+
+```rust
+enum ExpandedValue {
+    Text(String),                          // Simple text value
+    KeyValue(Vec<(String, ExpandedValue)>),  // Ordered key-value pairs (preserves order)
+    List(Vec<ExpandedValue>),              // Ordered list of values
+}
+
+struct ExpandedField {
+    label: String,           // Display label (e.g., "TABLE", "Attributes", "Payload")
+    value: ExpandedValue,    // The structured content
+}
+```
+
+**Design rationale:**
+- Each parser knows its own log format best — parsers provide the expansion, not the UI
+- `ExpandedValue` is recursive, supporting nested JSON objects, SWSS table→key→attrs, sairedis op→oid→attrs
+- `Option<Vec>` avoids allocation for simple log lines that don't need expansion
+- Ordering is preserved (important for readability — parsers control display order)
+
+**Examples by parser:**
+
+SWSS log `2025-01-15.10:30:45.123456|ROUTE_TABLE|Vrf1:10.0.0.0/24|SET|nexthop:10.1.1.1|ifname:Ethernet0`:
+```
+expanded:
+  - label: "Operation"
+    value: Text("SET")
+  - label: "Table"
+    value: Text("ROUTE_TABLE")
+  - label: "Key"
+    value: Text("Vrf1:10.0.0.0/24")
+  - label: "Attributes"
+    value: KeyValue([("nexthop", Text("10.1.1.1")), ("ifname", Text("Ethernet0"))])
+```
+
+Sairedis log `2025-01-15.10:30:45.123456|c|SAI_OBJECT_TYPE_ROUTE_ENTRY:...`:
+```
+expanded:
+  - label: "Operation"
+    value: Text("Create")
+  - label: "Object Type"
+    value: Text("SAI_OBJECT_TYPE_ROUTE_ENTRY")
+  - label: "OID"
+    value: Text("oid:0x5000000000612")
+  - label: "Attributes"
+    value: KeyValue([("SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID", Text("oid:0x4000...")), ...])
+```
+
+JSON log `{"timestamp":"...","level":"ERROR","service":"auth","msg":"login failed","details":{"user":"alice","ip":"10.0.0.1"}}`:
+```
+expanded:
+  - label: "Payload"
+    value: KeyValue([
+      ("service", Text("auth")),
+      ("msg", Text("login failed")),
+      ("details", KeyValue([("user", Text("alice")), ("ip", Text("10.0.0.1"))]))
+    ])
+```
 
 ### LogLevel Enum
 
@@ -49,3 +112,4 @@ All fields (including `hostname`, `container`, `context`, `function`, and metada
 | 2026-02-20 | Added `hostname` and `container` as first-class fields |
 | 2026-02-21 | Added `context` and `function` for SWSS/sairedis support |
 | 2026-02-19 | Optimized `source`/`loader_id` to `Arc<str>`, metadata to `Option<HashMap>` |
+| 2026-02-24 | Added `expanded` field with ExpandedField/ExpandedValue tree for parser-provided structured expansion |

--- a/crates/scouty/spec/parsers.md
+++ b/crates/scouty/spec/parsers.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Scouty parsers transform raw log lines into `LogRecord` structs. The system supports multiple parser types: a unified hand-written syslog parser (zero-regex), SONiC SWSS parser, sairedis parser, and user-defined regex parsers.
+Scouty parsers transform raw log lines into `LogRecord` structs. The system supports multiple parser types: a unified hand-written syslog parser (zero-regex), SONiC SWSS parser, sairedis parser, JSON log parser, and user-defined regex parsers.
+
+All parsers may optionally populate the `expanded` field on `LogRecord` to provide structured expansion of log content for the detail panel (see log-record spec for `ExpandedField` structure).
 
 
 ## Design
@@ -55,6 +57,8 @@ Parses `|`-delimited SWSS logs: `YYYY-MM-DD.HH:MM:SS.ffffff|<content...>`
 | OP (SET/DEL) | `function` |
 | KV pairs | `message` |
 
+**Structured expansion:** Populates `expanded` with Operation, Table, Key, and Attributes (KV pairs as ordered key-value tree).
+
 **Parsing logic:** Split by `|`, locate SET/DEL position, determine TABLE:Key vs TABLE|SubKey format. Key may contain `:` (e.g., IPv6), so only split at first `:`.
 
 ### SONiC Sairedis Log Parser
@@ -68,6 +72,37 @@ Parses SAI Redis operation logs: `YYYY-MM-DD.HH:MM:SS.ffffff|<op>|<detail...>`
 - Bulk operations stored as single record (not split into multiple)
 - Auto-detection: second `|`-segment is single char op code (vs SWSS multi-char TABLE_NAME)
 - Unknown op codes gracefully fall back (op as function, detail as message)
+
+**Structured expansion:** Populates `expanded` with Operation (human-readable name), Object Type, OID, and Attributes. For stateful `G`/`Q` responses, expansion includes the correlated request context.
+
+### JSON Log Parser
+
+Parses log lines that are complete JSON objects (one object per line, i.e., NDJSON/JSON Lines).
+
+**Auto-detection:** Line starts with `{` and is valid JSON.
+
+**Field mapping (well-known keys):**
+
+| JSON key (case-insensitive) | LogRecord field |
+|----|-----|
+| `timestamp`, `time`, `ts`, `@timestamp` | `timestamp` |
+| `level`, `severity`, `loglevel` | `level` |
+| `message`, `msg`, `log` | `message` |
+| `hostname`, `host` | `hostname` |
+| `service`, `component`, `logger`, `name` | `component_name` |
+| `pid` | `pid` |
+| `tid`, `thread` | `tid` |
+
+All other keys go to `metadata`.
+
+**Structured expansion:** Populates `expanded` with a "Payload" `KeyValue` tree, recursively expanding nested objects and arrays. Well-known fields already mapped to LogRecord top-level fields are excluded from expansion to avoid duplication. Nested objects become nested `KeyValue`, arrays become `List`.
+
+**Key decisions:**
+- Well-known field names are case-insensitive for broad compatibility
+- Numeric/boolean JSON values converted to string for `metadata`
+- Nested JSON preserved in structured expansion (not flattened)
+- Very deep nesting (>10 levels): truncated with `...` marker
+- Invalid JSON lines: fall through to next parser in the group
 
 ### Regex Parser Optimization
 
@@ -84,6 +119,7 @@ Parses SAI Redis operation logs: `YYYY-MM-DD.HH:MM:SS.ffffff|<op>|<detail...>`
 | UnifiedSyslogParser (all 3 formats) | ≥ 10M rec/sec | Zero-regex, byte-level |
 | SWSS Parser | ≥ 1M rec/sec | Hand-written |
 | Sairedis Parser | ≥ 1M rec/sec | Hand-written |
+| JSON Parser | ≥ 500K rec/sec | `serde_json` + field mapping |
 | Regex Parser (syslog) | ≥ 1M rec/sec | Optimized regex |
 
 ## Change Log
@@ -95,3 +131,5 @@ Parses SAI Redis operation logs: `YYYY-MM-DD.HH:MM:SS.ffffff|<op>|<detail...>`
 | 2026-02-21 | UnifiedSyslogParser consolidating 4 parsers |
 | 2026-02-21 | SONiC SWSS log parser with context/function fields |
 | 2026-02-22 | SONiC sairedis log parser with stateful G/Q context |
+| 2026-02-24 | JSON log parser with well-known field mapping |
+| 2026-02-24 | Structured expansion (expanded field) for SWSS, sairedis, and JSON parsers |


### PR DESCRIPTION
**Core idea:** Parsers know their log format best → parsers provide structured expansion, UI just renders the tree.

### LogRecord changes
- New `expanded: Option<Vec<ExpandedField>>` field
- `ExpandedValue` enum: `Text` / `KeyValue` (ordered pairs) / `List` — recursive tree

### New: JSON Log Parser
- Auto-detects JSON lines (starts with `{`)
- Well-known field mapping: `timestamp`/`level`/`message`/`hostname`/`service` etc.
- Nested objects → recursive `KeyValue` expansion
- All unmapped keys go to `metadata`

### Existing parsers updated
- **SWSS**: populates `expanded` with Operation/Table/Key/Attributes
- **Sairedis**: populates `expanded` with Operation/ObjectType/OID/Attributes

### Detail panel
- Left side: interactive tree view when `expanded` is present (▼/▶ collapse, j/k nav, h/l expand)
- Quick filter: press `f` on any tree leaf → creates `key == "value"` filter
- Falls back to raw text when no expansion

**This is extensible** — any future parser (custom format, protobuf logs, etc.) just needs to populate `expanded`.