### PR TITLE
feat: add ExpandedField/ExpandedValue tree to LogRecord

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -1755,6 +1755,7 @@ mod tests {
             raw: message.to_string(),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 
@@ -1776,6 +1777,7 @@ mod tests {
             raw: format!("msg {}", id),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 
@@ -2420,6 +2422,7 @@ mod field_filter_v2_tests {
             raw: msg.to_string(),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 
@@ -2604,6 +2607,7 @@ mod column_follow_tests {
             raw: message.to_string(),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 
@@ -2805,6 +2809,7 @@ mod copy_tests {
             raw: msg.to_string(),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 
@@ -2968,6 +2973,7 @@ mod time_jump_tests {
             raw: format!("msg {}", id),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 
@@ -3106,6 +3112,7 @@ mod command_tests {
             raw: msg.to_string(),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
@@ -30,6 +30,7 @@ mod tests {
             raw: "2025-05-18 INFO orchagent hello world".into(),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
@@ -29,6 +29,7 @@ mod tests {
             raw: message.to_string(),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -28,6 +28,7 @@ mod tests {
             raw: format!("msg {}", id),
             metadata: None,
             loader_id: "test".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty/src/filter/engine_tests.rs
+++ b/crates/scouty/src/filter/engine_tests.rs
@@ -26,6 +26,7 @@ mod tests {
             raw: message.into(),
             metadata: None,
             loader_id: "test-loader".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty/src/filter/eval_tests.rs
+++ b/crates/scouty/src/filter/eval_tests.rs
@@ -26,6 +26,7 @@ mod tests {
             raw: message.into(),
             metadata: Some(metadata),
             loader_id: "loader-1".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty/src/integration_tests.rs
+++ b/crates/scouty/src/integration_tests.rs
@@ -400,6 +400,7 @@ random garbage
                 raw: format!("message {}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             });
         }
 

--- a/crates/scouty/src/parser/regex_parser.rs
+++ b/crates/scouty/src/parser/regex_parser.rs
@@ -274,6 +274,7 @@ impl RegexParser {
             raw: raw.to_string(),
             metadata,
             loader_id: Arc::clone(loader_id),
+            expanded: None,
         })
     }
 
@@ -368,6 +369,7 @@ impl RegexParser {
             raw,
             metadata,
             loader_id: Arc::clone(loader_id),
+            expanded: None,
         })
     }
 
@@ -441,6 +443,7 @@ impl RegexParser {
             raw: raw.to_string(),
             metadata,
             loader_id: Arc::clone(loader_id),
+            expanded: None,
         })
     }
 }

--- a/crates/scouty/src/parser/sairedis_parser.rs
+++ b/crates/scouty/src/parser/sairedis_parser.rs
@@ -215,6 +215,7 @@ impl SairedisParser {
             raw: String::new(), // Caller sets raw
             metadata: None,
             loader_id: Arc::clone(loader_id),
+            expanded: None,
         })
     }
 

--- a/crates/scouty/src/parser/swss_parser.rs
+++ b/crates/scouty/src/parser/swss_parser.rs
@@ -100,6 +100,7 @@ impl SwssParser {
                 raw: raw.to_string(),
                 metadata: None,
                 loader_id: Arc::clone(loader_id),
+                expanded: None,
             });
         }
 
@@ -126,6 +127,7 @@ impl SwssParser {
             raw: raw.to_string(),
             metadata: None,
             loader_id: Arc::clone(loader_id),
+            expanded: None,
         })
     }
 }

--- a/crates/scouty/src/parser/unified_syslog_parser.rs
+++ b/crates/scouty/src/parser/unified_syslog_parser.rs
@@ -427,6 +427,7 @@ fn build_record(
         raw: String::new(), // Caller should set raw to avoid double allocation
         metadata: None,
         loader_id: Arc::clone(loader_id),
+        expanded: None,
     }
 }
 

--- a/crates/scouty/src/processor_tests.rs
+++ b/crates/scouty/src/processor_tests.rs
@@ -26,6 +26,7 @@ mod tests {
             raw: message.into(),
             metadata: None,
             loader_id: "test-loader".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty/src/record.rs
+++ b/crates/scouty/src/record.rs
@@ -121,6 +121,30 @@ pub struct LogRecord {
     pub metadata: Option<HashMap<String, String>>,
     /// Which loader produced this record.
     pub loader_id: Arc<str>,
+    /// Parser-provided structured expansion for the detail panel.
+    /// `None` for simple/unstructured logs (zero allocation).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expanded: Option<Vec<ExpandedField>>,
+}
+
+/// A labelled expanded field produced by a parser.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExpandedField {
+    /// Display label (e.g. "Operation", "Attributes").
+    pub label: String,
+    /// The structured value.
+    pub value: ExpandedValue,
+}
+
+/// Recursive tree value for structured log expansion.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ExpandedValue {
+    /// Plain text leaf.
+    Text(String),
+    /// Ordered key-value pairs (preserves parser ordering).
+    KeyValue(Vec<(String, ExpandedValue)>),
+    /// Ordered list of values.
+    List(Vec<ExpandedValue>),
 }
 
 #[cfg(test)]

--- a/crates/scouty/src/record_tests.rs
+++ b/crates/scouty/src/record_tests.rs
@@ -24,6 +24,7 @@ mod tests {
             raw: message.into(),
             metadata: None,
             loader_id: "test-loader".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty/src/session_tests.rs
+++ b/crates/scouty/src/session_tests.rs
@@ -32,6 +32,7 @@ mod tests {
             raw: message.into(),
             metadata: None,
             loader_id: "test-loader".into(),
+            expanded: None,
         }
     }
 

--- a/crates/scouty/src/store_tests.rs
+++ b/crates/scouty/src/store_tests.rs
@@ -25,6 +25,7 @@ mod tests {
             raw: message.into(),
             metadata: None,
             loader_id: "test-loader".into(),
+            expanded: None,
         }
     }
 
@@ -46,6 +47,7 @@ mod tests {
             raw: format!("msg-{}", id),
             metadata: None,
             loader_id: "test-loader".into(),
+            expanded: None,
         }
     }
 
@@ -360,6 +362,7 @@ mod tests {
                 raw: format!("msg-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 
@@ -386,6 +389,7 @@ mod tests {
                 raw: format!("new-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 
@@ -425,6 +429,7 @@ mod tests {
                 raw: format!("msg-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 
@@ -450,6 +455,7 @@ mod tests {
                 raw: format!("interleaved-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 
@@ -495,6 +501,7 @@ mod tests {
                 raw: format!("msg-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             });
         }
 
@@ -525,6 +532,7 @@ mod tests {
                 raw: format!("msg-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 
@@ -563,6 +571,7 @@ mod tests {
                 raw: format!("msg-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 
@@ -599,6 +608,7 @@ mod tests {
                 raw: format!("msg-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 
@@ -639,6 +649,7 @@ mod tests {
                 raw: format!("msg-{}", i),
                 metadata: None,
                 loader_id: "bench".into(),
+                expanded: None,
             })
             .collect();
 

--- a/crates/scouty/src/view_tests.rs
+++ b/crates/scouty/src/view_tests.rs
@@ -30,6 +30,7 @@ mod tests {
             raw: message.to_string(),
             metadata: None,
             loader_id: "loader".into(),
+            expanded: None,
         }
     }
 


### PR DESCRIPTION
Add parser-driven structured expansion support to LogRecord.

## Changes
- **ExpandedField** struct: `{ label: String, value: ExpandedValue }`
- **ExpandedValue** enum: `Text(String)`, `KeyValue(Vec<(String, ExpandedValue)>)`, `List(Vec<ExpandedValue>)` — recursive nesting
- **LogRecord.expanded**: `Option<Vec<ExpandedField>>` — `None` default for simple logs (zero allocation)
- Serde Serialize/Deserialize + `skip_serializing_if` for None
- All existing parsers set `expanded: None` (no behavior change)

## Foundation for
- #337 (JSON parser fills expanded)
- #338 (SWSS parser fills expanded)
- #339 (Sairedis parser fills expanded)
- #340 (Detail panel renders expansion tree)

## Tests
All 570 tests pass (294 scouty + 276 scouty-tui)

Closes #336