### PR TITLE
feat: JSON log parser with field mapping + expansion

### DIFF
--- a/crates/scouty/src/parser/factory.rs
+++ b/crates/scouty/src/parser/factory.rs
@@ -5,6 +5,7 @@
 mod factory_tests;
 
 use crate::parser::group::ParserGroup;
+use crate::parser::json_parser::{looks_like_json, JsonParser};
 use crate::parser::regex_parser::RegexParser;
 use crate::parser::sairedis_parser::{looks_like_sairedis, SairedisParser};
 use crate::parser::swss_parser::SwssParser;
@@ -39,6 +40,8 @@ impl ParserFactory {
                     Self::add_swss_parsers(&mut group);
                 } else if Self::looks_like_syslog(&info.sample_lines) {
                     Self::add_unified_syslog_parser(&mut group);
+                } else if Self::looks_like_json(&info.sample_lines) {
+                    Self::add_json_parser(&mut group);
                 }
                 // Add common log format parsers
                 Self::add_common_parsers(&mut group);
@@ -106,6 +109,10 @@ impl ParserFactory {
         Self::majority_match(sample_lines, |l| re.is_match(l))
     }
 
+    fn looks_like_json(sample_lines: &[String]) -> bool {
+        Self::majority_match(sample_lines, looks_like_json)
+    }
+
     /// Returns true if the majority of non-empty sample lines (up to 5) match the predicate.
     fn majority_match(sample_lines: &[String], pred: impl Fn(&str) -> bool) -> bool {
         let lines: Vec<&str> = sample_lines
@@ -127,6 +134,10 @@ impl ParserFactory {
 
     fn add_swss_parsers(group: &mut ParserGroup) {
         group.add_parser(Box::new(SwssParser::new()));
+    }
+
+    fn add_json_parser(group: &mut ParserGroup) {
+        group.add_parser(Box::new(JsonParser::new()));
     }
 
     fn add_unified_syslog_parser(group: &mut ParserGroup) {

--- a/crates/scouty/src/parser/json_parser.rs
+++ b/crates/scouty/src/parser/json_parser.rs
@@ -1,0 +1,218 @@
+//! JSON log parser — parses NDJSON/JSON Lines log entries.
+//!
+//! Auto-detects lines starting with `{`, maps well-known fields to LogRecord,
+//! and populates `expanded` with the full JSON tree.
+
+#[cfg(test)]
+#[path = "json_parser_tests.rs"]
+mod json_parser_tests;
+
+use crate::record::{ExpandedField, ExpandedValue, LogLevel, LogRecord};
+use crate::traits::LogParser;
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Parser for JSON log lines (one JSON object per line).
+#[derive(Debug, Default)]
+pub struct JsonParser;
+
+impl JsonParser {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl LogParser for JsonParser {
+    fn parse(&self, raw: &str, source: &str, loader_id: &str, id: u64) -> Option<LogRecord> {
+        let trimmed = raw.trim();
+        if !trimmed.starts_with('{') {
+            return None;
+        }
+
+        let obj: serde_json::Map<String, Value> = serde_json::from_str(trimmed).ok()?;
+
+        let source_arc = Arc::from(source);
+        let loader_arc = Arc::from(loader_id);
+
+        let mut timestamp = Utc::now();
+        let mut level: Option<LogLevel> = None;
+        let mut message = String::new();
+        let mut hostname: Option<String> = None;
+        let mut component_name: Option<String> = None;
+        let mut pid: Option<u32> = None;
+        let mut tid: Option<u32> = None;
+        let mut metadata: HashMap<String, String> = HashMap::new();
+        let mut mapped_keys: Vec<String> = Vec::new();
+
+        for (key, value) in &obj {
+            let lower = key.to_ascii_lowercase();
+            match lower.as_str() {
+                "timestamp" | "time" | "ts" | "@timestamp" => {
+                    if let Some(ts) = parse_timestamp(value) {
+                        timestamp = ts;
+                        mapped_keys.push(key.clone());
+                    }
+                }
+                "level" | "severity" | "loglevel" => {
+                    if let Some(s) = value.as_str() {
+                        level = LogLevel::from_str_loose(s);
+                        mapped_keys.push(key.clone());
+                    }
+                }
+                "message" | "msg" | "log" => {
+                    if let Some(s) = value.as_str() {
+                        message = s.to_string();
+                    } else {
+                        message = value.to_string();
+                    }
+                    mapped_keys.push(key.clone());
+                }
+                "hostname" | "host" => {
+                    hostname = Some(value_to_string(value));
+                    mapped_keys.push(key.clone());
+                }
+                "service" | "component" | "logger" | "name" => {
+                    component_name = Some(value_to_string(value));
+                    mapped_keys.push(key.clone());
+                }
+                "pid" => {
+                    pid = value
+                        .as_u64()
+                        .map(|v| v as u32)
+                        .or_else(|| value.as_str().and_then(|s| s.parse().ok()));
+                    mapped_keys.push(key.clone());
+                }
+                "tid" | "thread" => {
+                    tid = value
+                        .as_u64()
+                        .map(|v| v as u32)
+                        .or_else(|| value.as_str().and_then(|s| s.parse().ok()));
+                    mapped_keys.push(key.clone());
+                }
+                _ => {
+                    metadata.insert(key.clone(), value_to_string(value));
+                }
+            }
+        }
+
+        // Build expanded tree excluding already-mapped well-known fields
+        let expanded_pairs: Vec<(String, ExpandedValue)> = obj
+            .iter()
+            .filter(|(k, _)| !mapped_keys.contains(k))
+            .map(|(k, v)| (k.clone(), json_to_expanded(v, 0)))
+            .collect();
+
+        let expanded = if expanded_pairs.is_empty() {
+            None
+        } else {
+            Some(vec![ExpandedField {
+                label: "Payload".to_string(),
+                value: ExpandedValue::KeyValue(expanded_pairs),
+            }])
+        };
+
+        Some(LogRecord {
+            id,
+            timestamp,
+            level,
+            source: source_arc,
+            pid,
+            tid,
+            component_name,
+            process_name: None,
+            hostname,
+            container: None,
+            context: None,
+            function: None,
+            message,
+            raw: raw.to_string(),
+            metadata: if metadata.is_empty() {
+                None
+            } else {
+                Some(metadata)
+            },
+            loader_id: loader_arc,
+            expanded,
+        })
+    }
+
+    fn name(&self) -> &str {
+        "json"
+    }
+}
+
+/// Convert a JSON value to a string for metadata.
+fn value_to_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Parse a timestamp from a JSON value (string or number).
+fn parse_timestamp(v: &Value) -> Option<DateTime<Utc>> {
+    match v {
+        Value::String(s) => {
+            // Try RFC 3339 / ISO 8601
+            if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+                return Some(dt.with_timezone(&Utc));
+            }
+            // Try "YYYY-MM-DD HH:MM:SS" with optional fractional seconds
+            if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.f") {
+                return Some(dt.and_utc());
+            }
+            if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S") {
+                return Some(dt.and_utc());
+            }
+            None
+        }
+        Value::Number(n) => {
+            // Unix timestamp (seconds or milliseconds)
+            let ts = n.as_f64()?;
+            if ts > 1e12 {
+                // Likely milliseconds
+                DateTime::from_timestamp_millis(ts as i64)
+            } else {
+                DateTime::from_timestamp(ts as i64, ((ts.fract()) * 1_000_000_000.0) as u32)
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Recursively convert a JSON value to ExpandedValue.
+/// Depth limited to 10 levels.
+fn json_to_expanded(v: &Value, depth: usize) -> ExpandedValue {
+    if depth > 10 {
+        return ExpandedValue::Text("...".to_string());
+    }
+    match v {
+        Value::Object(map) => {
+            let pairs = map
+                .iter()
+                .map(|(k, val)| (k.clone(), json_to_expanded(val, depth + 1)))
+                .collect();
+            ExpandedValue::KeyValue(pairs)
+        }
+        Value::Array(arr) => {
+            let items = arr
+                .iter()
+                .map(|val| json_to_expanded(val, depth + 1))
+                .collect();
+            ExpandedValue::List(items)
+        }
+        Value::String(s) => ExpandedValue::Text(s.clone()),
+        Value::Number(n) => ExpandedValue::Text(n.to_string()),
+        Value::Bool(b) => ExpandedValue::Text(b.to_string()),
+        Value::Null => ExpandedValue::Text("null".to_string()),
+    }
+}
+
+/// Quick check: does this line look like a JSON log line?
+pub fn looks_like_json(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('{') && trimmed.ends_with('}')
+}

--- a/crates/scouty/src/parser/json_parser_tests.rs
+++ b/crates/scouty/src/parser/json_parser_tests.rs
@@ -1,0 +1,149 @@
+#[cfg(test)]
+mod tests {
+    use crate::parser::json_parser::JsonParser;
+    use crate::record::{ExpandedField, ExpandedValue, LogLevel};
+    use crate::traits::LogParser;
+
+    fn parse(line: &str) -> Option<crate::record::LogRecord> {
+        let parser = JsonParser::new();
+        parser.parse(line, "test.log", "loader-1", 1)
+    }
+
+    #[test]
+    fn test_basic_json_log() {
+        let line = r#"{"timestamp":"2026-01-15T10:30:00Z","level":"INFO","message":"hello world"}"#;
+        let rec = parse(line).unwrap();
+        assert_eq!(rec.level, Some(LogLevel::Info));
+        assert_eq!(rec.message, "hello world");
+        assert_eq!(rec.timestamp.to_rfc3339(), "2026-01-15T10:30:00+00:00");
+    }
+
+    #[test]
+    fn test_well_known_field_variants() {
+        let line = r#"{"ts":"2026-01-15T10:30:00Z","severity":"ERROR","msg":"fail","host":"web01","service":"api","pid":1234,"tid":5678}"#;
+        let rec = parse(line).unwrap();
+        assert_eq!(rec.level, Some(LogLevel::Error));
+        assert_eq!(rec.message, "fail");
+        assert_eq!(rec.hostname.as_deref(), Some("web01"));
+        assert_eq!(rec.component_name.as_deref(), Some("api"));
+        assert_eq!(rec.pid, Some(1234));
+        assert_eq!(rec.tid, Some(5678));
+    }
+
+    #[test]
+    fn test_non_json_returns_none() {
+        assert!(parse("Nov 24 10:30:00 host proc: msg").is_none());
+        assert!(parse("just plain text").is_none());
+        assert!(parse("").is_none());
+    }
+
+    #[test]
+    fn test_invalid_json_returns_none() {
+        assert!(parse("{invalid json}").is_none());
+        assert!(parse(r#"{"key": }"#).is_none());
+    }
+
+    #[test]
+    fn test_expanded_excludes_mapped_fields() {
+        let line = r#"{"timestamp":"2026-01-15T10:30:00Z","level":"INFO","message":"hi","extra":"data","nested":{"a":1}}"#;
+        let rec = parse(line).unwrap();
+        let expanded = rec.expanded.as_ref().unwrap();
+        assert_eq!(expanded.len(), 1);
+        assert_eq!(expanded[0].label, "Payload");
+        if let ExpandedValue::KeyValue(pairs) = &expanded[0].value {
+            let keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_str()).collect();
+            assert!(keys.contains(&"extra"));
+            assert!(keys.contains(&"nested"));
+            // Well-known fields should NOT be in expanded
+            assert!(!keys.contains(&"timestamp"));
+            assert!(!keys.contains(&"level"));
+            assert!(!keys.contains(&"message"));
+        } else {
+            panic!("expected KeyValue");
+        }
+    }
+
+    #[test]
+    fn test_nested_objects_and_arrays() {
+        let line = r#"{"message":"test","data":{"items":[1,2,3],"flag":true}}"#;
+        let rec = parse(line).unwrap();
+        let expanded = rec.expanded.as_ref().unwrap();
+        if let ExpandedValue::KeyValue(pairs) = &expanded[0].value {
+            assert_eq!(pairs[0].0, "data");
+            if let ExpandedValue::KeyValue(inner) = &pairs[0].1 {
+                // BTreeMap sorts alphabetically: flag before items
+                let keys: Vec<&str> = inner.iter().map(|(k, _)| k.as_str()).collect();
+                assert!(keys.contains(&"items"));
+                assert!(keys.contains(&"flag"));
+                let items_val = &inner.iter().find(|(k, _)| k == "items").unwrap().1;
+                assert!(matches!(items_val, ExpandedValue::List(_)));
+                let flag_val = &inner.iter().find(|(k, _)| k == "flag").unwrap().1;
+                assert_eq!(*flag_val, ExpandedValue::Text("true".to_string()));
+            } else {
+                panic!("expected nested KeyValue");
+            }
+        } else {
+            panic!("expected KeyValue");
+        }
+    }
+
+    #[test]
+    fn test_unix_timestamp_seconds() {
+        let line = r#"{"timestamp":1737000000,"message":"unix"}"#;
+        let rec = parse(line).unwrap();
+        assert_eq!(rec.timestamp.timestamp(), 1737000000);
+    }
+
+    #[test]
+    fn test_unix_timestamp_millis() {
+        let line = r#"{"timestamp":1737000000000,"message":"unix ms"}"#;
+        let rec = parse(line).unwrap();
+        assert_eq!(rec.timestamp.timestamp(), 1737000000);
+    }
+
+    #[test]
+    fn test_metadata_for_unknown_fields() {
+        let line = r#"{"message":"hi","custom_field":"value","count":42}"#;
+        let rec = parse(line).unwrap();
+        let meta = rec.metadata.as_ref().unwrap();
+        assert_eq!(meta.get("custom_field").unwrap(), "value");
+        assert_eq!(meta.get("count").unwrap(), "42");
+    }
+
+    #[test]
+    fn test_no_expanded_when_only_mapped_fields() {
+        let line = r#"{"timestamp":"2026-01-15T10:30:00Z","level":"INFO","message":"hi"}"#;
+        let rec = parse(line).unwrap();
+        assert!(rec.expanded.is_none());
+    }
+
+    #[test]
+    fn test_parser_name() {
+        let parser = JsonParser::new();
+        assert_eq!(parser.name(), "json");
+    }
+
+    #[test]
+    fn test_case_insensitive_field_names() {
+        let line = r#"{"Timestamp":"2026-01-15T10:30:00Z","Level":"WARN","Message":"warning"}"#;
+        let rec = parse(line).unwrap();
+        assert_eq!(rec.level, Some(LogLevel::Warn));
+        assert_eq!(rec.message, "warning");
+    }
+
+    #[test]
+    fn test_at_timestamp() {
+        let line = r#"{"@timestamp":"2026-01-15T10:30:00Z","message":"elk style"}"#;
+        let rec = parse(line).unwrap();
+        assert_eq!(rec.timestamp.to_rfc3339(), "2026-01-15T10:30:00+00:00");
+    }
+
+    #[test]
+    fn test_looks_like_json() {
+        use crate::parser::json_parser::looks_like_json;
+        assert!(looks_like_json(r#"{"key":"value"}"#));
+        assert!(!looks_like_json("plain text"));
+        assert!(!looks_like_json("{unclosed"));
+        assert!(looks_like_json(r#"  {"key":"value"}  "#));
+    }
+}

--- a/crates/scouty/src/parser/mod.rs
+++ b/crates/scouty/src/parser/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod factory;
 pub mod group;
+pub mod json_parser;
 pub mod multiline;
 pub mod regex_parser;
 pub mod sairedis_parser;


### PR DESCRIPTION
## Summary

New JSON log parser that detects NDJSON/JSON Lines log entries and maps well-known fields to LogRecord, with full structured expansion.

### Features
- **Auto-detection**: Lines starting with `{` that are valid JSON
- **Well-known field mapping** (case-insensitive): timestamp/time/ts/@timestamp, level/severity/loglevel, message/msg/log, hostname/host, service/component/logger/name, pid, tid/thread
- **Structured expansion**: Full JSON tree as `ExpandedValue` (objects → `KeyValue`, arrays → `List`, primitives → `Text`), excluding already-mapped fields
- **Timestamp formats**: RFC 3339, `YYYY-MM-DD HH:MM:SS`, Unix seconds, Unix milliseconds
- **Depth limit**: 10 levels (truncated with `...`)
- **Factory integration**: Auto-detected from sample lines

### Changes
- **`json_parser.rs`**: Parser implementation
- **`json_parser_tests.rs`**: 14 tests covering field mapping, nesting, timestamps, edge cases
- **`factory.rs`**: Register JSON parser with auto-detection
- **`mod.rs`**: Export json_parser module

### Test Plan
All 584 tests pass (14 new).

Closes #337