### PR TITLE
feat: sairedis parser expanded field with structured tree

### DIFF
--- a/crates/scouty/src/parser/sairedis_parser.rs
+++ b/crates/scouty/src/parser/sairedis_parser.rs
@@ -8,7 +8,7 @@
 #[path = "sairedis_parser_tests.rs"]
 mod sairedis_parser_tests;
 
-use crate::record::{LogLevel, LogRecord};
+use crate::record::{ExpandedField, ExpandedValue, LogLevel, LogRecord};
 use crate::traits::LogParser;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::cell::RefCell;
@@ -198,6 +198,9 @@ impl SairedisParser {
             _ => Some(LogLevel::Info),
         };
 
+        // Build expanded field
+        let expanded = build_expanded(op, &function, &component, &context, &message);
+
         Some(LogRecord {
             id,
             timestamp,
@@ -215,7 +218,7 @@ impl SairedisParser {
             raw: String::new(), // Caller sets raw
             metadata: None,
             loader_id: Arc::clone(loader_id),
-            expanded: None,
+            expanded,
         })
     }
 
@@ -382,6 +385,77 @@ impl SairedisParser {
             None => (str_from_bytes(detail), String::new()),
         }
     }
+}
+
+/// Build expanded field for sairedis entries.
+///
+/// Structure: Operation, Object Type, OID (if present), Attributes (if present),
+/// and Request Context for stateful G/Q responses.
+fn build_expanded(
+    op: u8,
+    function: &str,
+    component: &Option<String>,
+    context: &Option<String>,
+    message: &str,
+) -> Option<Vec<ExpandedField>> {
+    let mut fields = Vec::new();
+
+    // Operation (human-readable name)
+    fields.push(ExpandedField {
+        label: "Operation".to_string(),
+        value: ExpandedValue::Text(function.to_string()),
+    });
+
+    // Object Type (component_name)
+    if let Some(obj_type) = component {
+        fields.push(ExpandedField {
+            label: "Object Type".to_string(),
+            value: ExpandedValue::Text(obj_type.clone()),
+        });
+    }
+
+    // OID (context)
+    if let Some(oid) = context {
+        fields.push(ExpandedField {
+            label: "OID".to_string(),
+            value: ExpandedValue::Text(oid.clone()),
+        });
+    }
+
+    // Attributes from message (pipe-delimited "key=value" pairs)
+    if !message.is_empty() {
+        let pairs: Vec<(String, ExpandedValue)> = message
+            .split('|')
+            .filter(|s| !s.is_empty())
+            .map(|attr| {
+                if let Some(pos) = attr.find('=') {
+                    let k = &attr[..pos];
+                    let v = &attr[pos + 1..];
+                    (k.to_string(), ExpandedValue::Text(v.to_string()))
+                } else {
+                    (attr.to_string(), ExpandedValue::Text(String::new()))
+                }
+            })
+            .collect();
+
+        if !pairs.is_empty() {
+            fields.push(ExpandedField {
+                label: "Attributes".to_string(),
+                value: ExpandedValue::KeyValue(pairs),
+            });
+        }
+    }
+
+    // For G/Q responses, label includes request context already in function name
+    // Mark stateful ops
+    if matches!(op, b'G' | b'Q') && context.is_some() {
+        fields.push(ExpandedField {
+            label: "Request Context".to_string(),
+            value: ExpandedValue::Text(context.as_ref().unwrap().clone()),
+        });
+    }
+
+    Some(fields)
 }
 
 impl LogParser for SairedisParser {

--- a/crates/scouty/src/parser/sairedis_parser_tests.rs
+++ b/crates/scouty/src/parser/sairedis_parser_tests.rs
@@ -347,4 +347,113 @@ mod tests {
             assert!(rate > 500_000.0, "Too slow: {:.0} rec/sec", rate);
         }
     }
+
+    #[test]
+    fn test_expanded_create_op() {
+        let p = SairedisParser::new();
+        let r = p
+            .parse(
+                "2025-01-15.10:30:45.123456|c|SAI_OBJECT_TYPE_ROUTE_ENTRY:oid:0x1234|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x5678",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        let expanded = r.expanded.as_ref().unwrap();
+        assert_eq!(expanded[0].label, "Operation");
+        assert_eq!(
+            expanded[0].value,
+            crate::record::ExpandedValue::Text("Create".to_string())
+        );
+        assert_eq!(expanded[1].label, "Object Type");
+        assert_eq!(
+            expanded[1].value,
+            crate::record::ExpandedValue::Text("SAI_OBJECT_TYPE_ROUTE_ENTRY".to_string())
+        );
+        assert_eq!(expanded[2].label, "OID");
+        assert_eq!(
+            expanded[2].value,
+            crate::record::ExpandedValue::Text("oid:0x1234".to_string())
+        );
+        assert_eq!(expanded[3].label, "Attributes");
+        if let crate::record::ExpandedValue::KeyValue(pairs) = &expanded[3].value {
+            assert_eq!(pairs[0].0, "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID");
+            assert_eq!(
+                pairs[0].1,
+                crate::record::ExpandedValue::Text("oid:0x5678".to_string())
+            );
+        } else {
+            panic!("expected KeyValue for Attributes");
+        }
+    }
+
+    #[test]
+    fn test_expanded_remove_no_attrs() {
+        let p = SairedisParser::new();
+        let r = p
+            .parse(
+                "2025-01-15.10:30:45.123456|r|SAI_OBJECT_TYPE_ROUTE_ENTRY:oid:0x1234",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        let expanded = r.expanded.as_ref().unwrap();
+        assert_eq!(expanded[0].label, "Operation");
+        assert_eq!(expanded[1].label, "Object Type");
+        assert_eq!(expanded[2].label, "OID");
+        // No Attributes field
+        assert_eq!(expanded.len(), 3);
+    }
+
+    #[test]
+    fn test_expanded_get_response_stateful() {
+        let p = SairedisParser::new();
+        // First parse a 'g' to set context
+        p.parse(
+            "2025-01-15.10:30:45.123456|g|SAI_OBJECT_TYPE_SWITCH:oid:0xABCD|SAI_SWITCH_ATTR_SRC_MAC_ADDRESS=",
+            "test",
+            "loader",
+            1,
+        );
+        // Then parse 'G' response
+        let r = p
+            .parse(
+                "2025-01-15.10:30:45.123457|G|SAI_STATUS_SUCCESS|SAI_SWITCH_ATTR_SRC_MAC_ADDRESS=00:11:22:33:44:55",
+                "test",
+                "loader",
+                2,
+            )
+            .unwrap();
+        let expanded = r.expanded.as_ref().unwrap();
+        assert_eq!(expanded[0].label, "Operation");
+        assert_eq!(
+            expanded[0].value,
+            crate::record::ExpandedValue::Text("GetResponse".to_string())
+        );
+        // Should have OID from stateful context
+        let has_oid = expanded.iter().any(|f| f.label == "OID");
+        assert!(has_oid);
+        // Should have Request Context
+        let has_request_ctx = expanded.iter().any(|f| f.label == "Request Context");
+        assert!(has_request_ctx);
+    }
+
+    #[test]
+    fn test_expanded_notification() {
+        let p = SairedisParser::new();
+        let r = p
+            .parse(
+                "2025-01-15.10:30:45.123456|n|fdb_event|[{\"fdb_entry\":\"{}\",\"fdb_event\":\"SAI_FDB_EVENT_LEARNED\"}]|",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        let expanded = r.expanded.as_ref().unwrap();
+        assert_eq!(expanded[0].label, "Operation");
+        assert!(expanded[0].value.eq(&crate::record::ExpandedValue::Text(
+            "Notification: fdb_event".to_string()
+        )));
+    }
 }


### PR DESCRIPTION
## Summary

Populate `LogRecord.expanded` in the sairedis parser with structured expansion.

### Expansion Structure
- **Operation**: Human-readable op name (Create, Set, Remove, Get, GetResponse, etc.)
- **Object Type**: SAI object type (e.g., SAI_OBJECT_TYPE_ROUTE_ENTRY)
- **OID**: Object identifier
- **Attributes**: Key=value pairs as `ExpandedValue::KeyValue`
- **Request Context**: For stateful G/Q responses, the correlated request context

### Changes
- **`sairedis_parser.rs`**: Add `build_expanded()` function, populate expanded in `parse_inner()`
- **`sairedis_parser_tests.rs`**: 4 new tests (create op, remove, stateful G response, notification)

### Test Plan
All 592 tests pass (4 new).

Closes #339