### PR TITLE
fix: detail panel missing log content section

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
@@ -428,11 +428,38 @@ impl DetailPanelWidget {
     ) {
         let mut lines = build_field_lines(record, theme);
         lines.push(Line::from(""));
-        lines.push(Line::styled(
-            "Message:",
-            theme.detail_panel.section_header.to_style(),
-        ));
-        lines.push(Line::from(record.message.clone()));
+
+        // Show log content section
+        let has_expanded = record.expanded.as_ref().is_some_and(|e| !e.is_empty());
+        if has_expanded {
+            lines.push(Line::styled(
+                "Expanded:",
+                theme.detail_panel.section_header.to_style(),
+            ));
+            // Show a flat summary of expanded fields
+            if let Some(expanded) = &record.expanded {
+                for field in expanded {
+                    let summary = match &field.value {
+                        scouty::record::ExpandedValue::Text(t) => {
+                            format!("  {}: {}", field.label, t)
+                        }
+                        _ => format!("  {} (…)", field.label),
+                    };
+                    lines.push(Line::from(summary));
+                }
+            }
+        } else {
+            lines.push(Line::styled(
+                "Log Content:",
+                theme.detail_panel.section_header.to_style(),
+            ));
+            let content = if record.raw.is_empty() {
+                &record.message
+            } else {
+                &record.raw
+            };
+            lines.push(Line::from(content.clone()));
+        }
 
         let detail = Paragraph::new(lines).wrap(Wrap { trim: false });
         frame.render_widget(detail, area);

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -21,11 +21,20 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         let detail_height = if let Some(record) = app.selected_record() {
             use crate::ui::widgets::detail_panel_widget::field_count;
             let fc = field_count(record);
-            // +1 for top border, min 4
-            let raw_height = (fc.min(u16::MAX as usize) as u16).saturating_add(1).max(4);
+            // For split layout, ensure enough height for left-side content
+            // (raw text or expanded tree). Minimum 8 rows for usable detail.
+            let left_min = if record.expanded.is_some() || !record.raw.is_empty() {
+                8
+            } else {
+                4
+            };
+            // +1 for top border
+            let raw_height = (fc.min(u16::MAX as usize) as u16)
+                .saturating_add(1)
+                .max(left_min);
             // Cap detail panel height using the configurable ratio
             let max_detail = (main_chunks[0].height as f64 * app.detail_panel_ratio) as u16;
-            raw_height.min(max_detail).max(4)
+            raw_height.min(max_detail).max(left_min)
         } else {
             4 // "No record selected" + border
         };


### PR DESCRIPTION
## Summary

Fix detail panel not showing log content — only field table was visible.

### Issues Fixed

1. **Single-column layout** (`render_single_column`, terminal width < 80): Only showed field pairs + message. Now includes a 'Log Content' section (raw text) or 'Expanded' summary (structured logs).

2. **Detail panel height too short**: Height was based on right-side field count (min 4 rows). For records with raw/expanded content, minimum is now 8 rows for a usable split view.

### Changes
- **`detail_panel_widget.rs`**: `render_single_column` now includes raw text or expanded summary
- **`ui_legacy.rs`**: Detail panel height minimum increased to 8 for records with content

### Test Plan
All 601 tests pass.

Closes #348