### PR TITLE
fix: detail panel split layout per spec (MIN_SPLIT_WIDTH 80→40)

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
@@ -229,7 +229,7 @@ fn build_field_lines(record: &scouty::record::LogRecord, theme: &Theme) -> Vec<L
 pub struct DetailPanelWidget;
 
 /// Minimum total width to show split layout.
-const MIN_SPLIT_WIDTH: u16 = 80;
+const MIN_SPLIT_WIDTH: u16 = 40;
 /// Max value display length before truncation.
 const MAX_VALUE_LEN: usize = 60;
 

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_min_split_width_constant() {
-        assert_eq!(MIN_SPLIT_WIDTH, 80);
+        assert_eq!(MIN_SPLIT_WIDTH, 40);
     }
 
     // --- Tree flattening tests ---


### PR DESCRIPTION
## Summary

Fix detail panel to use left-right split layout for most terminal sizes, per spec.

### Root Cause
`MIN_SPLIT_WIDTH` was 80, causing any terminal under 80 columns to use single-column fallback (fields stacked vertically below content). Most users saw only the field table.

### Fix
Lower `MIN_SPLIT_WIDTH` from 80 to 40. The split layout (70% log content / 30% fields) now works for terminals >= 40 columns wide.

### Changes
- **`detail_panel_widget.rs`**: `MIN_SPLIT_WIDTH` 80 → 40
- **`detail_panel_widget_tests.rs`**: Updated constant assertion

### Test Plan
All 601 tests pass.

Closes #350