### PR TITLE
feat: pipe output mode for non-interactive use

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -4,6 +4,7 @@ mod app;
 pub mod config;
 mod density;
 pub mod keybinding;
+mod pipe;
 pub mod text_input;
 mod ui;
 
@@ -64,6 +65,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut theme_override: Option<String> = None;
     let mut config_override: Option<String> = None;
     let mut file_args: Vec<String> = Vec::new();
+    let mut no_tui = false;
+    let mut pipe_filters: Vec<String> = Vec::new();
+    let mut pipe_level: Option<String> = None;
+    let mut pipe_format: Option<String> = None;
+    let mut pipe_fields: Option<String> = None;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
@@ -108,6 +114,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!(
                     "  --generate-theme <name>    Generate built-in theme to stdout (or 'list')"
                 );
+                eprintln!();
+                eprintln!("Pipe mode (auto when stdout is not a TTY):");
+                eprintln!("  --no-tui                   Force pipe mode (no TUI)");
+                eprintln!("  --filter <expr>            Filter expression (repeatable, AND logic)");
+                eprintln!("  --level <level>            Minimum level (trace/debug/info/notice/warn/error/fatal)");
+                eprintln!(
+                    "  --format <fmt>             Output format: raw (default), json, yaml, csv"
+                );
+                eprintln!("  --fields <list>            Comma-separated fields (default: all)");
+                eprintln!();
                 eprintln!("  -h, --help        Show this help");
                 std::process::exit(0);
             }
@@ -164,6 +180,62 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             }
+            "--no-tui" => {
+                no_tui = true;
+                i += 1;
+            }
+            "--filter" => {
+                if i + 1 < args.len() {
+                    pipe_filters.push(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --filter requires a value");
+                    std::process::exit(1);
+                }
+            }
+            arg if arg.starts_with("--filter=") => {
+                pipe_filters.push(arg.trim_start_matches("--filter=").to_string());
+                i += 1;
+            }
+            "--level" => {
+                if i + 1 < args.len() {
+                    pipe_level = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --level requires a value");
+                    std::process::exit(1);
+                }
+            }
+            arg if arg.starts_with("--level=") => {
+                pipe_level = Some(arg.trim_start_matches("--level=").to_string());
+                i += 1;
+            }
+            "--format" => {
+                if i + 1 < args.len() {
+                    pipe_format = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --format requires a value");
+                    std::process::exit(1);
+                }
+            }
+            arg if arg.starts_with("--format=") => {
+                pipe_format = Some(arg.trim_start_matches("--format=").to_string());
+                i += 1;
+            }
+            "--fields" => {
+                if i + 1 < args.len() {
+                    pipe_fields = Some(args[i + 1].clone());
+                    i += 2;
+                } else {
+                    eprintln!("Error: --fields requires a value");
+                    std::process::exit(1);
+                }
+            }
+            arg if arg.starts_with("--fields=") => {
+                pipe_fields = Some(arg.trim_start_matches("--fields=").to_string());
+                i += 1;
+            }
             _ => {
                 file_args.push(args[i].clone());
                 i += 1;
@@ -171,8 +243,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // pipe + file args are mutually exclusive
-    if piped && !file_args.is_empty() {
+    // Determine if we should run in pipe mode
+    let stdout_is_tty = std::io::stdout().is_terminal();
+    let pipe_mode = no_tui || !stdout_is_tty;
+
+    // pipe + file args are mutually exclusive (in TUI mode, stdin is consumed for terminal)
+    if !pipe_mode && piped && !file_args.is_empty() {
         eprintln!("Error: Cannot combine piped stdin with file arguments.");
         eprintln!("Use either: command | scouty-tui  OR  scouty-tui <files>");
         std::process::exit(1);
@@ -182,10 +258,70 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cfg = config::load_config_layered(config_override.as_deref());
 
     let files: Vec<String> = if !piped && file_args.is_empty() {
+        if pipe_mode {
+            // In pipe mode without files or stdin, error
+            eprintln!("Error: No input. Provide files or pipe stdin.");
+            std::process::exit(1);
+        }
         resolve_default_files(&cfg)?
     } else {
         file_args
     };
+
+    // ── Pipe mode: parse/filter/output without TUI ──
+    if pipe_mode {
+        let format = pipe_format
+            .as_deref()
+            .map(|f| {
+                pipe::OutputFormat::from_str(f).unwrap_or_else(|| {
+                    eprintln!("Error: unknown format '{}'. Use: raw, json, yaml, csv", f);
+                    std::process::exit(1);
+                })
+            })
+            .unwrap_or(pipe::OutputFormat::Raw);
+
+        let level = pipe_level.as_deref().map(|l| {
+            scouty::record::LogLevel::from_str_loose(l).unwrap_or_else(|| {
+                eprintln!(
+                    "Error: unknown level '{}'. Use: trace, debug, info, notice, warn, error, fatal",
+                    l
+                );
+                std::process::exit(1);
+            })
+        });
+
+        let fields: Vec<String> = pipe_fields
+            .map(|f| f.split(',').map(|s| s.trim().to_string()).collect())
+            .unwrap_or_default();
+
+        // Read stdin if piped
+        let stdin_lines: Option<Vec<String>> = if piped {
+            use std::io::BufRead;
+            let stdin = std::io::stdin();
+            let lines: Vec<String> = stdin
+                .lock()
+                .lines()
+                .collect::<std::result::Result<_, _>>()?;
+            Some(lines)
+        } else {
+            None
+        };
+
+        let pipe_config = pipe::PipeConfig {
+            filters: pipe_filters,
+            level,
+            format,
+            fields,
+        };
+
+        return pipe::run_pipe_mode(
+            files,
+            stdin_lines,
+            pipe_config,
+            cfg.ssh.connect_timeout,
+            cfg.ssh.keepalive_interval,
+        );
+    }
 
     // If piped, read all stdin lines before entering TUI (stdin will be consumed).
     //

--- a/crates/scouty-tui/src/pipe.rs
+++ b/crates/scouty-tui/src/pipe.rs
@@ -1,0 +1,305 @@
+//! Pipe output mode — non-interactive parse/filter/output to stdout.
+
+#[cfg(test)]
+#[path = "pipe_tests.rs"]
+mod pipe_tests;
+
+use scouty::loader::file::FileLoader;
+use scouty::loader::ssh::{is_ssh_url, SshLoader, SshUrl};
+use scouty::parser::factory::ParserFactory;
+use scouty::record::{LogLevel, LogRecord};
+use scouty::traits::{LoaderInfo, LogLoader};
+use std::io::{self, BufWriter, Write};
+
+/// Output format for pipe mode.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OutputFormat {
+    Raw,
+    Json,
+    Yaml,
+    Csv,
+}
+
+impl OutputFormat {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "raw" => Some(Self::Raw),
+            "json" => Some(Self::Json),
+            "yaml" => Some(Self::Yaml),
+            "csv" => Some(Self::Csv),
+            _ => None,
+        }
+    }
+}
+
+/// Pipe mode configuration.
+pub struct PipeConfig {
+    pub filters: Vec<String>,
+    pub level: Option<LogLevel>,
+    pub format: OutputFormat,
+    pub fields: Vec<String>,
+}
+
+/// Run pipe mode: parse input, apply filters, output to stdout.
+pub fn run_pipe_mode(
+    files: Vec<String>,
+    stdin_lines: Option<Vec<String>>,
+    config: PipeConfig,
+    ssh_connect_timeout: u32,
+    ssh_keepalive_interval: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let stdout = io::stdout();
+    let mut writer = BufWriter::new(stdout.lock());
+
+    // Compile filter expressions into a single FilterEngine
+    let mut filter_engine = scouty::filter::engine::FilterEngine::new();
+    for expr in &config.filters {
+        if let Err(e) =
+            filter_engine.add_expr_filter(scouty::filter::engine::FilterAction::Include, expr)
+        {
+            eprintln!("Warning: invalid filter '{}': {}", expr, e);
+        }
+    }
+
+    let use_all_fields =
+        config.fields.is_empty() || (config.fields.len() == 1 && config.fields[0] == "all");
+
+    // CSV header
+    if config.format == OutputFormat::Csv {
+        let fields = if use_all_fields {
+            default_fields()
+        } else {
+            config.fields.clone()
+        };
+        writeln!(writer, "{}", fields.join(","))?;
+    }
+
+    let mut record_id: u64 = 0;
+
+    // Process stdin lines
+    if let Some(lines) = stdin_lines {
+        let loader = scouty::loader::stdin::StdinLoader::new();
+        let mut info = loader.info().clone();
+        info.sample_lines = lines.iter().take(10).cloned().collect();
+        process_lines(
+            &mut writer,
+            lines,
+            &info,
+            &mut record_id,
+            &config,
+            &filter_engine,
+            use_all_fields,
+        )?;
+    }
+
+    // Process files
+    for path in &files {
+        if is_ssh_url(path) {
+            let url = SshUrl::parse(path).map_err(|e| {
+                Box::<dyn std::error::Error>::from(format!("Invalid SSH URL '{}': {}", path, e))
+            })?;
+            let mut loader = SshLoader::new(url, ssh_connect_timeout, ssh_keepalive_interval);
+            let lines = loader.load()?;
+            let info = loader.info().clone();
+            process_lines(
+                &mut writer,
+                lines,
+                &info,
+                &mut record_id,
+                &config,
+                &filter_engine,
+                use_all_fields,
+            )?;
+        } else {
+            let mut loader = FileLoader::new(path, false);
+            let lines = loader.load()?;
+            let info = loader.info().clone();
+            process_lines(
+                &mut writer,
+                lines,
+                &info,
+                &mut record_id,
+                &config,
+                &filter_engine,
+                use_all_fields,
+            )?;
+        }
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+fn process_lines(
+    writer: &mut impl Write,
+    lines: Vec<String>,
+    info: &LoaderInfo,
+    record_id: &mut u64,
+    config: &PipeConfig,
+    filter_engine: &scouty::filter::engine::FilterEngine,
+    use_all_fields: bool,
+) -> io::Result<()> {
+    let group = ParserFactory::create_parser_group(info);
+
+    for line in lines {
+        if let Some(record) = group.parse(&line, &info.id, &info.id, *record_id) {
+            *record_id += 1;
+
+            // Level filter
+            if let Some(min_level) = &config.level {
+                if let Some(rec_level) = &record.level {
+                    if !level_passes(*rec_level, *min_level) {
+                        continue;
+                    }
+                }
+            }
+
+            // Expression filters (AND)
+            if !filter_engine.matches(&record) {
+                continue;
+            }
+
+            // Output
+            match config.format {
+                OutputFormat::Raw => {
+                    if record.raw.is_empty() {
+                        writeln!(writer, "{}", line)?;
+                    } else {
+                        writeln!(writer, "{}", record.raw)?;
+                    }
+                }
+                OutputFormat::Json => {
+                    write_json(writer, &record, &config.fields, use_all_fields)?;
+                }
+                OutputFormat::Yaml => {
+                    write_yaml(writer, &record, &config.fields, use_all_fields)?;
+                }
+                OutputFormat::Csv => {
+                    write_csv(writer, &record, &config.fields, use_all_fields)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Check if a record level passes the minimum level filter.
+fn level_passes(record_level: LogLevel, min_level: LogLevel) -> bool {
+    level_rank(record_level) >= level_rank(min_level)
+}
+
+fn level_rank(level: LogLevel) -> u8 {
+    match level {
+        LogLevel::Trace => 0,
+        LogLevel::Debug => 1,
+        LogLevel::Info => 2,
+        LogLevel::Notice => 3,
+        LogLevel::Warn => 4,
+        LogLevel::Error => 5,
+        LogLevel::Fatal => 6,
+    }
+}
+
+fn default_fields() -> Vec<String> {
+    vec![
+        "timestamp".to_string(),
+        "level".to_string(),
+        "hostname".to_string(),
+        "component".to_string(),
+        "pid".to_string(),
+        "message".to_string(),
+    ]
+}
+
+fn record_field(record: &LogRecord, field: &str) -> String {
+    match field.to_lowercase().as_str() {
+        "timestamp" | "time" | "ts" => record.timestamp.to_rfc3339(),
+        "level" | "severity" => record.level.map(|l| format!("{:?}", l)).unwrap_or_default(),
+        "message" | "msg" => record.message.clone(),
+        "hostname" | "host" => record.hostname.clone().unwrap_or_default(),
+        "component" | "service" | "logger" => record.component_name.clone().unwrap_or_default(),
+        "process" | "process_name" => record.process_name.clone().unwrap_or_default(),
+        "pid" => record.pid.map(|p| p.to_string()).unwrap_or_default(),
+        "tid" | "thread" => record.tid.map(|t| t.to_string()).unwrap_or_default(),
+        "container" => record.container.clone().unwrap_or_default(),
+        "context" => record.context.clone().unwrap_or_default(),
+        "function" => record.function.clone().unwrap_or_default(),
+        "source" => record.source.to_string(),
+        "raw" => record.raw.clone(),
+        _ => {
+            // Check metadata
+            record
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get(field).cloned())
+                .unwrap_or_default()
+        }
+    }
+}
+
+fn write_json(
+    writer: &mut impl Write,
+    record: &LogRecord,
+    fields: &[String],
+    use_all: bool,
+) -> io::Result<()> {
+    let fields_list = if use_all {
+        default_fields()
+    } else {
+        fields.to_vec()
+    };
+
+    let mut map = serde_json::Map::new();
+    for f in &fields_list {
+        let val = record_field(record, f);
+        map.insert(f.clone(), serde_json::Value::String(val));
+    }
+    let json = serde_json::Value::Object(map);
+    writeln!(writer, "{}", json)
+}
+
+fn write_yaml(
+    writer: &mut impl Write,
+    record: &LogRecord,
+    fields: &[String],
+    use_all: bool,
+) -> io::Result<()> {
+    let fields_list = if use_all {
+        default_fields()
+    } else {
+        fields.to_vec()
+    };
+
+    writeln!(writer, "---")?;
+    for f in &fields_list {
+        let val = record_field(record, f);
+        writeln!(writer, "{}: \"{}\"", f, val.replace('"', "\\\""))?;
+    }
+    Ok(())
+}
+
+fn write_csv(
+    writer: &mut impl Write,
+    record: &LogRecord,
+    fields: &[String],
+    use_all: bool,
+) -> io::Result<()> {
+    let fields_list = if use_all {
+        default_fields()
+    } else {
+        fields.to_vec()
+    };
+
+    let values: Vec<String> = fields_list
+        .iter()
+        .map(|f| {
+            let val = record_field(record, f);
+            if val.contains(',') || val.contains('"') || val.contains('\n') {
+                format!("\"{}\"", val.replace('"', "\"\""))
+            } else {
+                val
+            }
+        })
+        .collect();
+    writeln!(writer, "{}", values.join(","))
+}

--- a/crates/scouty-tui/src/pipe_tests.rs
+++ b/crates/scouty-tui/src/pipe_tests.rs
@@ -1,0 +1,137 @@
+#[cfg(test)]
+mod tests {
+    use crate::pipe::*;
+    use scouty::record::{LogLevel, LogRecord};
+
+    #[test]
+    fn test_output_format_from_str() {
+        assert_eq!(OutputFormat::from_str("raw"), Some(OutputFormat::Raw));
+        assert_eq!(OutputFormat::from_str("json"), Some(OutputFormat::Json));
+        assert_eq!(OutputFormat::from_str("yaml"), Some(OutputFormat::Yaml));
+        assert_eq!(OutputFormat::from_str("csv"), Some(OutputFormat::Csv));
+        assert_eq!(OutputFormat::from_str("JSON"), Some(OutputFormat::Json));
+        assert_eq!(OutputFormat::from_str("unknown"), None);
+    }
+
+    #[test]
+    fn test_level_passes() {
+        assert!(level_passes(LogLevel::Error, LogLevel::Warn));
+        assert!(level_passes(LogLevel::Warn, LogLevel::Warn));
+        assert!(!level_passes(LogLevel::Info, LogLevel::Warn));
+        assert!(level_passes(LogLevel::Fatal, LogLevel::Trace));
+    }
+
+    #[test]
+    fn test_level_rank_ordering() {
+        assert!(level_rank(LogLevel::Trace) < level_rank(LogLevel::Debug));
+        assert!(level_rank(LogLevel::Debug) < level_rank(LogLevel::Info));
+        assert!(level_rank(LogLevel::Info) < level_rank(LogLevel::Notice));
+        assert!(level_rank(LogLevel::Notice) < level_rank(LogLevel::Warn));
+        assert!(level_rank(LogLevel::Warn) < level_rank(LogLevel::Error));
+        assert!(level_rank(LogLevel::Error) < level_rank(LogLevel::Fatal));
+    }
+
+    #[test]
+    fn test_record_field_extraction() {
+        let record = LogRecord {
+            id: 1,
+            timestamp: chrono::Utc::now(),
+            level: Some(LogLevel::Error),
+            source: std::sync::Arc::from("test.log"),
+            pid: Some(1234),
+            tid: None,
+            component_name: Some("myservice".to_string()),
+            process_name: None,
+            hostname: Some("host01".to_string()),
+            container: None,
+            context: None,
+            function: None,
+            message: "test message".to_string(),
+            raw: "raw line".to_string(),
+            metadata: None,
+            loader_id: std::sync::Arc::from("loader"),
+            expanded: None,
+        };
+
+        assert_eq!(record_field(&record, "message"), "test message");
+        assert_eq!(record_field(&record, "hostname"), "host01");
+        assert_eq!(record_field(&record, "component"), "myservice");
+        assert_eq!(record_field(&record, "pid"), "1234");
+        assert_eq!(record_field(&record, "level"), "Error");
+        assert_eq!(record_field(&record, "raw"), "raw line");
+        assert_eq!(record_field(&record, "tid"), "");
+        assert_eq!(record_field(&record, "unknown_field"), "");
+    }
+
+    #[test]
+    fn test_write_json() {
+        let record = LogRecord {
+            id: 1,
+            timestamp: chrono::DateTime::parse_from_rfc3339("2026-01-15T10:30:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+            level: Some(LogLevel::Info),
+            source: std::sync::Arc::from("test.log"),
+            pid: None,
+            tid: None,
+            component_name: None,
+            process_name: None,
+            hostname: None,
+            container: None,
+            context: None,
+            function: None,
+            message: "hello".to_string(),
+            raw: String::new(),
+            metadata: None,
+            loader_id: std::sync::Arc::from("loader"),
+            expanded: None,
+        };
+
+        let mut buf = Vec::new();
+        write_json(&mut buf, &record, &[], true).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        assert_eq!(parsed["message"], "hello");
+        assert_eq!(parsed["level"], "Info");
+    }
+
+    #[test]
+    fn test_write_csv_escaping() {
+        let record = LogRecord {
+            id: 1,
+            timestamp: chrono::Utc::now(),
+            level: None,
+            source: std::sync::Arc::from("test.log"),
+            pid: None,
+            tid: None,
+            component_name: None,
+            process_name: None,
+            hostname: None,
+            container: None,
+            context: None,
+            function: None,
+            message: "hello, world".to_string(),
+            raw: String::new(),
+            metadata: None,
+            loader_id: std::sync::Arc::from("loader"),
+            expanded: None,
+        };
+
+        let mut buf = Vec::new();
+        let fields = vec!["message".to_string()];
+        write_csv(&mut buf, &record, &fields, false).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.contains("\"hello, world\""),
+            "CSV should quote fields with commas"
+        );
+    }
+
+    #[test]
+    fn test_default_fields() {
+        let fields = default_fields();
+        assert!(fields.contains(&"timestamp".to_string()));
+        assert!(fields.contains(&"level".to_string()));
+        assert!(fields.contains(&"message".to_string()));
+    }
+}


### PR DESCRIPTION
## Summary

Add pipe output mode for scripting: when stdout is not a TTY (or `--no-tui` is set), skip the TUI and stream parsed/filtered results to stdout.

### New CLI Flags
- `--no-tui` — force pipe mode even with TTY stdout
- `--filter <expr>` — filter expression (repeatable, AND logic)
- `--level <level>` — minimum level filter (trace/debug/info/notice/warn/error/fatal)
- `--format <fmt>` — output format: raw (default), json, yaml, csv
- `--fields <list>` — comma-separated fields for structured output

### Auto-detection
- `!isatty(stdout)` → pipe mode (no TUI)
- Works with file args, stdin pipe, and ssh:// remote

### Output Formats
- **raw**: original log line
- **json**: NDJSON (one object per line)
- **yaml**: YAML document per record (`---` separated)
- **csv**: header + data rows with proper escaping

### Changes
- **`pipe.rs`**: New module with pipe mode logic
- **`pipe_tests.rs`**: 7 tests (format parsing, level filtering, field extraction, JSON/CSV output)
- **`main.rs`**: CLI flag parsing, pipe mode detection and dispatch

### Test Plan
All 608 tests pass (7 new).

Closes #355