### PR TITLE
feat: region config loading and data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "criterion",
+ "dirs",
  "flate2",
  "memchr",
  "memmap2",

--- a/crates/scouty/Cargo.toml
+++ b/crates/scouty/Cargo.toml
@@ -10,6 +10,7 @@ description = "Log parsing, filtering, and analysis library"
 memchr = "2"
 memmap2 = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
+dirs = "5"
 flate2 = "1"
 regex = "1"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/scouty/src/lib.rs
+++ b/crates/scouty/src/lib.rs
@@ -3,6 +3,7 @@ pub mod loader;
 pub mod parser;
 pub mod processor;
 pub mod record;
+pub mod region;
 pub mod session;
 pub mod store;
 pub mod traits;

--- a/crates/scouty/src/region/config.rs
+++ b/crates/scouty/src/region/config.rs
@@ -1,0 +1,230 @@
+//! Region configuration loading and data structures.
+
+use crate::filter::expr::{self, Expr};
+use regex::Regex;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// A compiled region definition ready for matching.
+#[derive(Debug, Clone)]
+pub struct RegionDefinition {
+    /// Unique name for this region type.
+    pub name: String,
+    /// Human-readable description.
+    pub description: Option<String>,
+    /// Compiled start point matchers.
+    pub start_points: Vec<CompiledMatchPoint>,
+    /// Compiled end point matchers.
+    pub end_points: Vec<CompiledMatchPoint>,
+    /// Metadata field names that must match between start and end.
+    pub correlate: Vec<String>,
+    /// Template for region name.
+    pub name_template: String,
+    /// Template for region description.
+    pub description_template: Option<String>,
+    /// Max duration between start and end (None = unlimited).
+    pub timeout: Option<Duration>,
+}
+
+/// A compiled match point (filter + optional regex).
+#[derive(Debug, Clone)]
+pub struct CompiledMatchPoint {
+    /// Compiled filter expression.
+    pub filter: Expr,
+    /// Original filter string (for display).
+    pub filter_str: String,
+    /// Compiled regex for metadata extraction (applied to message field).
+    pub regex: Option<Regex>,
+}
+
+// --- Raw YAML structures for deserialization ---
+
+#[derive(Debug, Deserialize)]
+pub struct RegionConfigFile {
+    pub regions: Vec<RawRegionDef>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawRegionDef {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub start_points: Vec<RawMatchPoint>,
+    pub end_points: Vec<RawMatchPoint>,
+    pub correlate: Vec<String>,
+    pub template: RawTemplate,
+    #[serde(default)]
+    pub timeout: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawMatchPoint {
+    pub filter: String,
+    #[serde(default)]
+    pub regex: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawTemplate {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// Parse a timeout string like "30s", "5m", "1h".
+pub(crate) fn parse_timeout(s: &str) -> Result<Duration, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("empty timeout".into());
+    }
+
+    let (num_str, unit) = if let Some(n) = s.strip_suffix('s') {
+        (n, 1u64)
+    } else if let Some(n) = s.strip_suffix('m') {
+        (n, 60)
+    } else if let Some(n) = s.strip_suffix('h') {
+        (n, 3600)
+    } else {
+        return Err(format!("invalid timeout unit in '{}' (use s/m/h)", s));
+    };
+
+    let num: u64 = num_str
+        .trim()
+        .parse()
+        .map_err(|_| format!("invalid timeout number in '{}'", s))?;
+    Ok(Duration::from_secs(num * unit))
+}
+
+/// Compile a raw match point into a compiled one.
+fn compile_match_point(raw: &RawMatchPoint) -> Result<CompiledMatchPoint, String> {
+    let filter = expr::parse(&raw.filter).map_err(|e| format!("filter '{}': {}", raw.filter, e))?;
+    let regex = match &raw.regex {
+        Some(pattern) => {
+            let re = Regex::new(pattern).map_err(|e| format!("regex '{}': {}", pattern, e))?;
+            Some(re)
+        }
+        None => None,
+    };
+    Ok(CompiledMatchPoint {
+        filter,
+        filter_str: raw.filter.clone(),
+        regex,
+    })
+}
+
+/// Compile a raw region definition.
+fn compile_definition(raw: &RawRegionDef) -> Result<RegionDefinition, String> {
+    let start_points: Vec<CompiledMatchPoint> = raw
+        .start_points
+        .iter()
+        .map(compile_match_point)
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("region '{}' start_point: {}", raw.name, e))?;
+
+    let end_points: Vec<CompiledMatchPoint> = raw
+        .end_points
+        .iter()
+        .map(compile_match_point)
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("region '{}' end_point: {}", raw.name, e))?;
+
+    let timeout = match &raw.timeout {
+        Some(s) => {
+            Some(parse_timeout(s).map_err(|e| format!("region '{}' timeout: {}", raw.name, e))?)
+        }
+        None => None,
+    };
+
+    Ok(RegionDefinition {
+        name: raw.name.clone(),
+        description: raw.description.clone(),
+        start_points,
+        end_points,
+        correlate: raw.correlate.clone(),
+        name_template: raw.template.name.clone(),
+        description_template: raw.template.description.clone(),
+        timeout,
+    })
+}
+
+/// Load region definitions from a YAML string.
+pub fn load_from_str(yaml: &str) -> Result<Vec<RegionDefinition>, String> {
+    let config: RegionConfigFile =
+        serde_yaml::from_str(yaml).map_err(|e| format!("YAML parse error: {}", e))?;
+    config.regions.iter().map(compile_definition).collect()
+}
+
+/// Load region definitions from a single YAML file.
+pub fn load_from_file(path: &Path) -> Result<Vec<RegionDefinition>, String> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| format!("{}: {}", path.display(), e))?;
+    load_from_str(&content).map_err(|e| format!("{}: {}", path.display(), e))
+}
+
+/// Load region definitions from a directory of YAML files.
+pub fn load_from_dir(dir: &Path) -> Result<Vec<RegionDefinition>, String> {
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+
+    let mut defs = Vec::new();
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map_err(|e| format!("{}: {}", dir.display(), e))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension()
+                .map(|ext| ext == "yaml" || ext == "yml")
+                .unwrap_or(false)
+        })
+        .collect();
+    entries.sort();
+
+    for path in &entries {
+        match load_from_file(path) {
+            Ok(mut file_defs) => defs.append(&mut file_defs),
+            Err(e) => {
+                eprintln!("Warning: skipping region config {}: {}", path.display(), e);
+            }
+        }
+    }
+
+    Ok(defs)
+}
+
+/// Load all region definitions from standard config locations.
+/// System (/etc/scouty/regions/) → User (~/.scouty/regions/) → Project (./scouty-regions/).
+pub fn load_all() -> Vec<RegionDefinition> {
+    let mut defs = Vec::new();
+
+    let dirs = [
+        PathBuf::from("/etc/scouty/regions"),
+        dirs::home_dir()
+            .map(|h| h.join(".scouty/regions"))
+            .unwrap_or_default(),
+        PathBuf::from("./scouty-regions"),
+    ];
+
+    for dir in &dirs {
+        if dir.as_os_str().is_empty() {
+            continue;
+        }
+        if let Ok(mut d) = load_from_dir(dir) {
+            defs.append(&mut d);
+        }
+    }
+
+    defs
+}
+
+/// Render a template string with metadata values.
+/// `{field}` is replaced with the value from metadata, or left as-is if missing.
+pub fn render_template(template: &str, metadata: &HashMap<String, String>) -> String {
+    let mut result = template.to_string();
+    for (key, value) in metadata {
+        result = result.replace(&format!("{{{}}}", key), value);
+    }
+    result
+}

--- a/crates/scouty/src/region/mod.rs
+++ b/crates/scouty/src/region/mod.rs
@@ -1,0 +1,26 @@
+//! Region parsing — configurable start/end matching with correlation.
+
+#[cfg(test)]
+#[path = "region_tests.rs"]
+mod region_tests;
+
+pub mod config;
+
+use std::collections::HashMap;
+
+/// A detected region span linking a start and end log record.
+#[derive(Debug, Clone)]
+pub struct Region {
+    /// Region definition name (e.g., "port_startup").
+    pub definition_name: String,
+    /// Rendered region name from template (e.g., "Port Startup Ethernet0").
+    pub name: String,
+    /// Rendered description from template.
+    pub description: Option<String>,
+    /// LogStore index of the start record.
+    pub start_index: usize,
+    /// LogStore index of the end record.
+    pub end_index: usize,
+    /// Merged metadata from start + end.
+    pub metadata: HashMap<String, String>,
+}

--- a/crates/scouty/src/region/region_tests.rs
+++ b/crates/scouty/src/region/region_tests.rs
@@ -1,0 +1,192 @@
+//! Tests for region config loading.
+
+mod tests {
+    use crate::region::config::*;
+    use std::collections::HashMap;
+
+    const SAMPLE_CONFIG: &str = r#"
+regions:
+  - name: "port_startup"
+    description: "Port initialization to oper up"
+    start_points:
+      - filter: 'message contains "addPort"'
+        regex: '(?P<port>Ethernet\d+)'
+    end_points:
+      - filter: 'message contains "oper_status.*up"'
+        regex: '(?P<port>Ethernet\d+).*oper_status.*(?P<status>up|down)'
+    correlate:
+      - "port"
+    template:
+      name: "Port Startup {port}"
+      description: "{port} startup → {status}"
+    timeout: "30s"
+
+  - name: "http_request"
+    start_points:
+      - filter: 'message contains "request started"'
+        regex: 'request_id=(?P<req_id>[a-f0-9-]+)'
+    end_points:
+      - filter: 'message contains "request completed"'
+        regex: 'request_id=(?P<req_id>[a-f0-9-]+).*status=(?P<status>\d+)'
+    correlate:
+      - "req_id"
+    template:
+      name: "{req_id}"
+"#;
+
+    #[test]
+    fn test_load_basic_config() {
+        let defs = load_from_str(SAMPLE_CONFIG).unwrap();
+        assert_eq!(defs.len(), 2);
+
+        assert_eq!(defs[0].name, "port_startup");
+        assert_eq!(
+            defs[0].description.as_deref(),
+            Some("Port initialization to oper up")
+        );
+        assert_eq!(defs[0].start_points.len(), 1);
+        assert_eq!(defs[0].end_points.len(), 1);
+        assert_eq!(defs[0].correlate, vec!["port"]);
+        assert_eq!(defs[0].name_template, "Port Startup {port}");
+        assert_eq!(defs[0].timeout.unwrap(), std::time::Duration::from_secs(30));
+
+        assert_eq!(defs[1].name, "http_request");
+        assert!(defs[1].description.is_none());
+        assert!(defs[1].timeout.is_none());
+    }
+
+    #[test]
+    fn test_filter_compiled() {
+        let defs = load_from_str(SAMPLE_CONFIG).unwrap();
+        // Should not panic — filters are compiled at load time
+        assert_eq!(
+            defs[0].start_points[0].filter_str,
+            "message contains \"addPort\""
+        );
+    }
+
+    #[test]
+    fn test_regex_compiled() {
+        let defs = load_from_str(SAMPLE_CONFIG).unwrap();
+        let re = defs[0].start_points[0].regex.as_ref().unwrap();
+        let caps = re.captures("addPort Ethernet0 speed 100G").unwrap();
+        assert_eq!(&caps["port"], "Ethernet0");
+    }
+
+    #[test]
+    fn test_no_regex() {
+        let yaml = r#"
+regions:
+  - name: "simple"
+    start_points:
+      - filter: 'level == "ERROR"'
+    end_points:
+      - filter: 'level == "INFO"'
+    correlate: []
+    template:
+      name: "Error Block"
+"#;
+        let defs = load_from_str(yaml).unwrap();
+        assert!(defs[0].start_points[0].regex.is_none());
+    }
+
+    #[test]
+    fn test_invalid_filter() {
+        let yaml = r#"
+regions:
+  - name: "bad"
+    start_points:
+      - filter: 'invalid $$$ filter'
+    end_points:
+      - filter: 'level == "INFO"'
+    correlate: []
+    template:
+      name: "Bad"
+"#;
+        let result = load_from_str(yaml);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("start_point"));
+    }
+
+    #[test]
+    fn test_invalid_regex() {
+        let yaml = r#"
+regions:
+  - name: "bad_regex"
+    start_points:
+      - filter: 'level == "ERROR"'
+        regex: '(?P<unclosed'
+    end_points:
+      - filter: 'level == "INFO"'
+    correlate: []
+    template:
+      name: "Bad"
+"#;
+        let result = load_from_str(yaml);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("regex"));
+    }
+
+    #[test]
+    fn test_parse_timeout() {
+        use std::time::Duration;
+        assert_eq!(parse_timeout("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_timeout("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_timeout("1h").unwrap(), Duration::from_secs(3600));
+        assert!(parse_timeout("").is_err());
+        assert!(parse_timeout("10x").is_err());
+        assert!(parse_timeout("abc").is_err());
+    }
+
+    #[test]
+    fn test_render_template() {
+        let mut meta = HashMap::new();
+        meta.insert("port".into(), "Ethernet0".into());
+        meta.insert("status".into(), "up".into());
+
+        assert_eq!(
+            render_template("Port Startup {port}", &meta),
+            "Port Startup Ethernet0"
+        );
+        assert_eq!(
+            render_template("{port} → {status}", &meta),
+            "Ethernet0 → up"
+        );
+        // Missing field left as-is
+        assert_eq!(
+            render_template("{unknown} {port}", &meta),
+            "{unknown} Ethernet0"
+        );
+    }
+
+    #[test]
+    fn test_load_from_nonexistent_dir() {
+        let result = load_from_dir(std::path::Path::new("/nonexistent/path"));
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_multiple_start_end_points() {
+        let yaml = r#"
+regions:
+  - name: "multi"
+    start_points:
+      - filter: 'message contains "start1"'
+        regex: '(?P<id>\d+)'
+      - filter: 'message contains "start2"'
+        regex: '(?P<id>\d+)'
+    end_points:
+      - filter: 'message contains "end1"'
+        regex: '(?P<id>\d+)'
+      - filter: 'message contains "end2"'
+        regex: '(?P<id>\d+)'
+    correlate:
+      - "id"
+    template:
+      name: "Region {id}"
+"#;
+        let defs = load_from_str(yaml).unwrap();
+        assert_eq!(defs[0].start_points.len(), 2);
+        assert_eq!(defs[0].end_points.len(), 2);
+    }
+}


### PR DESCRIPTION
Add region parsing configuration system for detecting logical spans in log streams.

## Changes
- **`Region`** struct: detected span with start/end indices, name, metadata
- **`RegionDefinition`**: compiled config with start/end match points, correlation, templates, timeout
- **`CompiledMatchPoint`**: filter expression (Expr) + optional regex, compiled at load time
- **YAML deserialization**: `RegionConfigFile` → `RawRegionDef` → compile to `RegionDefinition`
- **Multi-dir loading**: `/etc/scouty/regions/`, `~/.scouty/regions/`, `./scouty-regions/`
- **Timeout parsing**: `30s`, `5m`, `1h` → `Duration`
- **Template rendering**: `{field}` substitution in region names/descriptions

## Tests
10 new tests:
- Config loading (basic, multi-point, no-regex)
- Filter/regex compilation validation
- Error handling (invalid filter, invalid regex)
- Timeout parsing
- Template rendering
- Nonexistent directory handling

All 618 tests pass (327 scouty + 291 scouty-tui)

Closes #359