### PR TITLE
feat: region processor with correlation logic

### DIFF
--- a/crates/scouty/src/region/config.rs
+++ b/crates/scouty/src/region/config.rs
@@ -37,6 +37,8 @@ pub struct CompiledMatchPoint {
     pub filter_str: String,
     /// Compiled regex for metadata extraction (applied to message field).
     pub regex: Option<Regex>,
+    /// Reason template (supports `{field}` substitution from regex groups).
+    pub reason: Option<String>,
 }
 
 // --- Raw YAML structures for deserialization ---
@@ -64,6 +66,8 @@ pub struct RawMatchPoint {
     pub filter: String,
     #[serde(default)]
     pub regex: Option<String>,
+    #[serde(default)]
+    pub reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -111,6 +115,7 @@ fn compile_match_point(raw: &RawMatchPoint) -> Result<CompiledMatchPoint, String
         filter,
         filter_str: raw.filter.clone(),
         regex,
+        reason: raw.reason.clone(),
     })
 }
 

--- a/crates/scouty/src/region/mod.rs
+++ b/crates/scouty/src/region/mod.rs
@@ -5,6 +5,7 @@
 mod region_tests;
 
 pub mod config;
+pub mod processor;
 
 use std::collections::HashMap;
 
@@ -17,6 +18,10 @@ pub struct Region {
     pub name: String,
     /// Rendered description from template.
     pub description: Option<String>,
+    /// Rendered start point reason (e.g., "port add requested").
+    pub start_reason: Option<String>,
+    /// Rendered end point reason (e.g., "oper up").
+    pub end_reason: Option<String>,
     /// LogStore index of the start record.
     pub start_index: usize,
     /// LogStore index of the end record.

--- a/crates/scouty/src/region/processor.rs
+++ b/crates/scouty/src/region/processor.rs
@@ -1,0 +1,266 @@
+//! Region processor — evaluates log records against region definitions.
+
+#[cfg(test)]
+#[path = "processor_tests.rs"]
+mod processor_tests;
+
+use super::config::{CompiledMatchPoint, RegionDefinition};
+use super::Region;
+use crate::filter::eval;
+use crate::record::LogRecord;
+use std::collections::HashMap;
+
+/// A pending start point awaiting a matching end.
+#[derive(Debug, Clone)]
+struct PendingStart {
+    /// Index of the start record in the LogStore.
+    record_index: usize,
+    /// Timestamp of the start record.
+    timestamp: chrono::DateTime<chrono::Utc>,
+    /// Extracted metadata from the start record.
+    metadata: HashMap<String, String>,
+    /// Rendered reason from the matched start point.
+    reason: Option<String>,
+}
+
+/// Processes log records against region definitions to detect regions.
+pub struct RegionProcessor {
+    definitions: Vec<RegionDefinition>,
+    /// Pending starts per definition index.
+    pending: Vec<Vec<PendingStart>>,
+    /// Detected regions.
+    regions: Vec<Region>,
+    /// Next record index to process (for incremental processing).
+    next_index: usize,
+}
+
+impl RegionProcessor {
+    /// Create a new processor with the given region definitions.
+    pub fn new(definitions: Vec<RegionDefinition>) -> Self {
+        let pending = vec![Vec::new(); definitions.len()];
+        Self {
+            definitions,
+            pending,
+            regions: Vec::new(),
+            next_index: 0,
+        }
+    }
+
+    /// Process a batch of records from the store.
+    /// Records are processed in order; call repeatedly for incremental processing.
+    /// Returns the records that were tagged with region metadata (indices).
+    pub fn process_records(&mut self, records: &mut [LogRecord]) -> Vec<usize> {
+        let mut tagged_indices = Vec::new();
+
+        for i in 0..records.len() {
+            let absolute_index = self.next_index + i;
+
+            for def_idx in 0..self.definitions.len() {
+                // Check END points first
+                if let Some((end_meta, end_reason)) =
+                    try_match_points(&self.definitions[def_idx].end_points, &records[i])
+                {
+                    // Try correlation with pending starts
+                    if let Some(region) = self.try_correlate(
+                        def_idx,
+                        absolute_index,
+                        end_meta,
+                        end_reason,
+                        &records[i],
+                    ) {
+                        // Tag records between start and end
+                        let start_local = region.start_index.saturating_sub(self.next_index);
+                        let end_local = i;
+                        for j in start_local..=end_local.min(records.len() - 1) {
+                            let abs_j = self.next_index + j;
+                            if abs_j >= region.start_index && abs_j <= region.end_index {
+                                let pos =
+                                    if abs_j == region.start_index && abs_j == region.end_index {
+                                        "start+end"
+                                    } else if abs_j == region.start_index {
+                                        "start"
+                                    } else if abs_j == region.end_index {
+                                        "end"
+                                    } else {
+                                        "middle"
+                                    };
+                                tag_record(
+                                    &mut records[j],
+                                    &region.definition_name,
+                                    &region.name,
+                                    pos,
+                                );
+                                tagged_indices.push(abs_j);
+                            }
+                        }
+                        self.regions.push(region);
+                    }
+                }
+
+                // Check START points
+                if let Some((start_meta, start_reason)) =
+                    try_match_points(&self.definitions[def_idx].start_points, &records[i])
+                {
+                    // Purge timed-out pending starts
+                    if let Some(timeout) = self.definitions[def_idx].timeout {
+                        let ts = records[i].timestamp;
+                        self.pending[def_idx].retain(|p| {
+                            let elapsed = ts.signed_duration_since(p.timestamp);
+                            elapsed
+                                < chrono::Duration::from_std(timeout)
+                                    .unwrap_or(chrono::Duration::MAX)
+                        });
+                    }
+
+                    self.pending[def_idx].push(PendingStart {
+                        record_index: absolute_index,
+                        timestamp: records[i].timestamp,
+                        metadata: start_meta,
+                        reason: start_reason,
+                    });
+                }
+            }
+        }
+
+        self.next_index += records.len();
+        tagged_indices
+    }
+
+    /// Try to correlate an end match with a pending start.
+    fn try_correlate(
+        &mut self,
+        def_idx: usize,
+        end_index: usize,
+        end_meta: HashMap<String, String>,
+        end_reason: Option<String>,
+        _end_record: &LogRecord,
+    ) -> Option<Region> {
+        let def = &self.definitions[def_idx];
+        let pendings = &mut self.pending[def_idx];
+
+        // Walk backwards (LIFO) through pending starts
+        let mut found_idx = None;
+        for (i, pending) in pendings.iter().enumerate().rev() {
+            // Check timeout
+            if let Some(timeout) = def.timeout {
+                let elapsed = _end_record
+                    .timestamp
+                    .signed_duration_since(pending.timestamp);
+                if elapsed >= chrono::Duration::from_std(timeout).unwrap_or(chrono::Duration::MAX) {
+                    continue;
+                }
+            }
+
+            if def.correlate.is_empty() {
+                // No correlation fields → nearest pending (LIFO)
+                found_idx = Some(i);
+                break;
+            }
+
+            // Check all correlate fields match
+            let all_match = def.correlate.iter().all(|field| {
+                let start_val = pending.metadata.get(field);
+                let end_val = end_meta.get(field);
+                match (start_val, end_val) {
+                    (Some(s), Some(e)) => s == e,
+                    _ => false,
+                }
+            });
+
+            if all_match {
+                found_idx = Some(i);
+                break;
+            }
+        }
+
+        let found_idx = found_idx?;
+        let pending = pendings.remove(found_idx);
+
+        // Merge metadata (start + end, end overwrites on conflict)
+        let mut metadata = pending.metadata.clone();
+        metadata.extend(end_meta);
+
+        // Add start_reason and end_reason to metadata for template rendering
+        let start_reason = pending
+            .reason
+            .as_ref()
+            .map(|r| super::config::render_template(r, &pending.metadata));
+        let end_reason_rendered = end_reason
+            .as_ref()
+            .map(|r| super::config::render_template(r, &metadata));
+
+        if let Some(sr) = &start_reason {
+            metadata.insert("start_reason".to_string(), sr.clone());
+        }
+        if let Some(er) = &end_reason_rendered {
+            metadata.insert("end_reason".to_string(), er.clone());
+        }
+
+        let name = super::config::render_template(&def.name_template, &metadata);
+        let description = def
+            .description_template
+            .as_ref()
+            .map(|t| super::config::render_template(t, &metadata));
+
+        Some(Region {
+            definition_name: def.name.clone(),
+            name,
+            description,
+            start_reason,
+            end_reason: end_reason_rendered,
+            start_index: pending.record_index,
+            end_index,
+            metadata,
+        })
+    }
+
+    /// Get all detected regions.
+    pub fn regions(&self) -> &[Region] {
+        &self.regions
+    }
+
+    /// Get the number of detected regions.
+    pub fn region_count(&self) -> usize {
+        self.regions.len()
+    }
+
+    /// Get pending start count (for diagnostics).
+    pub fn pending_count(&self) -> usize {
+        self.pending.iter().map(|p| p.len()).sum()
+    }
+}
+
+/// Try to match a record against a list of match points.
+/// Returns extracted metadata and rendered reason if any point matches.
+fn try_match_points(
+    points: &[CompiledMatchPoint],
+    record: &LogRecord,
+) -> Option<(HashMap<String, String>, Option<String>)> {
+    for point in points {
+        if eval::eval(&point.filter, record) {
+            let mut metadata = HashMap::new();
+
+            // Extract metadata via regex
+            if let Some(re) = &point.regex {
+                if let Some(caps) = re.captures(&record.message) {
+                    for name in re.capture_names().flatten() {
+                        if let Some(m) = caps.name(name) {
+                            metadata.insert(name.to_string(), m.as_str().to_string());
+                        }
+                    }
+                }
+            }
+
+            return Some((metadata, point.reason.clone()));
+        }
+    }
+    None
+}
+
+/// Tag a record with region metadata.
+fn tag_record(record: &mut LogRecord, def_name: &str, region_name: &str, pos: &str) {
+    let meta = record.metadata.get_or_insert_with(HashMap::new);
+    meta.insert("_region".to_string(), region_name.to_string());
+    meta.insert("_region_type".to_string(), def_name.to_string());
+    meta.insert("_region_pos".to_string(), pos.to_string());
+}

--- a/crates/scouty/src/region/processor_tests.rs
+++ b/crates/scouty/src/region/processor_tests.rs
@@ -1,0 +1,281 @@
+//! Tests for RegionProcessor.
+
+mod tests {
+    use crate::record::{LogLevel, LogRecord};
+    use crate::region::config;
+    use crate::region::processor::RegionProcessor;
+    use chrono::{TimeZone, Utc};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn make_record(id: u64, ts_secs: i64, message: &str, level: Option<LogLevel>) -> LogRecord {
+        LogRecord {
+            id,
+            timestamp: Utc.timestamp_opt(ts_secs, 0).unwrap(),
+            level,
+            source: Arc::from("test.log"),
+            pid: None,
+            tid: None,
+            component_name: None,
+            process_name: None,
+            hostname: None,
+            container: None,
+            context: None,
+            function: Some("test".to_string()),
+            message: message.to_string(),
+            raw: message.to_string(),
+            metadata: None,
+            loader_id: Arc::from("test"),
+            expanded: None,
+        }
+    }
+
+    const BASIC_CONFIG: &str = r#"
+regions:
+  - name: "port_startup"
+    start_points:
+      - filter: 'message contains "addPort"'
+        regex: '(?P<port>Ethernet\d+)'
+        reason: "add {port}"
+    end_points:
+      - filter: 'message contains "oper_status up"'
+        regex: '(?P<port>Ethernet\d+)'
+        reason: "oper up {port}"
+    correlate:
+      - "port"
+    template:
+      name: "Port Startup {port}"
+      description: "{start_reason} → {end_reason}"
+    timeout: "30s"
+"#;
+
+    #[test]
+    fn test_basic_region_detection() {
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let mut records = vec![
+            make_record(0, 1000, "addPort Ethernet0", None),
+            make_record(1, 1001, "some log in between", None),
+            make_record(2, 1002, "Ethernet0 oper_status up", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        assert_eq!(proc.region_count(), 1);
+        let region = &proc.regions()[0];
+        assert_eq!(region.definition_name, "port_startup");
+        assert_eq!(region.name, "Port Startup Ethernet0");
+        assert_eq!(region.start_index, 0);
+        assert_eq!(region.end_index, 2);
+
+        // Check record tagging
+        assert_eq!(
+            records[0]
+                .metadata
+                .as_ref()
+                .unwrap()
+                .get("_region_pos")
+                .unwrap(),
+            "start"
+        );
+        assert_eq!(
+            records[1]
+                .metadata
+                .as_ref()
+                .unwrap()
+                .get("_region_pos")
+                .unwrap(),
+            "middle"
+        );
+        assert_eq!(
+            records[2]
+                .metadata
+                .as_ref()
+                .unwrap()
+                .get("_region_pos")
+                .unwrap(),
+            "end"
+        );
+    }
+
+    #[test]
+    fn test_reason_rendering() {
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let mut records = vec![
+            make_record(0, 1000, "addPort Ethernet4", None),
+            make_record(1, 1002, "Ethernet4 oper_status up", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        assert_eq!(proc.region_count(), 1);
+        let region = &proc.regions()[0];
+        assert_eq!(region.start_reason.as_deref(), Some("add Ethernet4"));
+        assert_eq!(region.end_reason.as_deref(), Some("oper up Ethernet4"));
+        assert_eq!(
+            region.description.as_deref(),
+            Some("add Ethernet4 → oper up Ethernet4")
+        );
+    }
+
+    #[test]
+    fn test_correlation_multiple_ports() {
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let mut records = vec![
+            make_record(0, 1000, "addPort Ethernet0", None),
+            make_record(1, 1001, "addPort Ethernet4", None),
+            make_record(2, 1002, "Ethernet4 oper_status up", None),
+            make_record(3, 1003, "Ethernet0 oper_status up", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        assert_eq!(proc.region_count(), 2);
+        // First completed region: Ethernet4 (end came first)
+        assert_eq!(proc.regions()[0].name, "Port Startup Ethernet4");
+        assert_eq!(proc.regions()[0].start_index, 1);
+        assert_eq!(proc.regions()[0].end_index, 2);
+        // Second: Ethernet0
+        assert_eq!(proc.regions()[1].name, "Port Startup Ethernet0");
+        assert_eq!(proc.regions()[1].start_index, 0);
+        assert_eq!(proc.regions()[1].end_index, 3);
+    }
+
+    #[test]
+    fn test_timeout_discards_stale_starts() {
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let mut records = vec![
+            make_record(0, 1000, "addPort Ethernet0", None),
+            // 60s later — beyond 30s timeout
+            make_record(1, 1060, "addPort Ethernet0", None),
+            make_record(2, 1062, "Ethernet0 oper_status up", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        assert_eq!(proc.region_count(), 1);
+        let region = &proc.regions()[0];
+        // Should correlate with the second start (fresh), not the first (stale)
+        assert_eq!(region.start_index, 1);
+        assert_eq!(region.end_index, 2);
+    }
+
+    #[test]
+    fn test_no_correlate_uses_lifo() {
+        let config = r#"
+regions:
+  - name: "request"
+    start_points:
+      - filter: 'message contains "start"'
+    end_points:
+      - filter: 'message contains "end"'
+    correlate: []
+    template:
+      name: "Request"
+"#;
+        let defs = config::load_from_str(config).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let mut records = vec![
+            make_record(0, 1000, "start A", None),
+            make_record(1, 1001, "start B", None),
+            make_record(2, 1002, "end X", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        assert_eq!(proc.region_count(), 1);
+        // LIFO: should match with the most recent start (B at index 1)
+        assert_eq!(proc.regions()[0].start_index, 1);
+    }
+
+    #[test]
+    fn test_start_plus_end_same_record() {
+        // If a record matches both start and end of different definitions,
+        // or if start_index == end_index
+        let config = r#"
+regions:
+  - name: "instant"
+    start_points:
+      - filter: 'message contains "instant"'
+    end_points:
+      - filter: 'message contains "instant"'
+    correlate: []
+    template:
+      name: "Instant"
+"#;
+        let defs = config::load_from_str(config).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        // The end check happens first, but no pending start exists yet.
+        // Then start check adds it. Next matching record will end it.
+        let mut records = vec![
+            make_record(0, 1000, "instant event", None),
+            make_record(1, 1001, "instant event", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        assert_eq!(proc.region_count(), 1);
+        assert_eq!(proc.regions()[0].start_index, 0);
+        assert_eq!(proc.regions()[0].end_index, 1);
+    }
+
+    #[test]
+    fn test_no_match_no_region() {
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let mut records = vec![
+            make_record(0, 1000, "unrelated log line", None),
+            make_record(1, 1001, "another unrelated line", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        assert_eq!(proc.region_count(), 0);
+        assert!(records[0].metadata.is_none());
+    }
+
+    #[test]
+    fn test_incremental_processing() {
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        // First batch: start only
+        let mut batch1 = vec![make_record(0, 1000, "addPort Ethernet0", None)];
+        proc.process_records(&mut batch1);
+        assert_eq!(proc.region_count(), 0);
+        assert_eq!(proc.pending_count(), 1);
+
+        // Second batch: end
+        let mut batch2 = vec![make_record(1, 1002, "Ethernet0 oper_status up", None)];
+        proc.process_records(&mut batch2);
+        assert_eq!(proc.region_count(), 1);
+        // Note: the middle records from batch1 won't be tagged since they're
+        // in a previous batch. In practice, the caller re-tags from the store.
+    }
+
+    #[test]
+    fn test_region_metadata_fields() {
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let mut records = vec![
+            make_record(0, 1000, "addPort Ethernet0", None),
+            make_record(1, 1002, "Ethernet0 oper_status up", None),
+        ];
+
+        proc.process_records(&mut records);
+
+        let region = &proc.regions()[0];
+        assert_eq!(region.metadata.get("port").unwrap(), "Ethernet0");
+    }
+}


### PR DESCRIPTION
## Summary

Implement the RegionProcessor that evaluates log records against region definitions, detects start/end boundaries, performs correlation, and creates regions.

### Features
- **End-first matching**: check END points before START points (per spec flow)
- **Correlation**: walk backwards through pending starts, match on configured metadata fields
- **LIFO fallback**: when no correlate fields specified, use nearest pending start
- **Timeout**: discard stale pending starts older than configured duration
- **Record tagging**: `_region`, `_region_type`, `_region_pos` (start/middle/end/start+end)
- **Reason templates**: start/end point `reason` field with `{field}` substitution
- **Template rendering**: region name/description with `{start_reason}`/`{end_reason}`
- **Incremental processing**: call `process_records` repeatedly for streaming

### Changes
- `region/processor.rs` — RegionProcessor implementation
- `region/processor_tests.rs` — 9 tests
- `region/mod.rs` — added `start_reason`/`end_reason` to Region
- `region/config.rs` — added `reason` field to match points

### Test Plan
All 627 tests pass (9 new).

Closes #361