### PR TITLE
feat: region TUI — gutter markers, manager, navigation

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -40,6 +40,7 @@ pub enum InputMode {
     LoadPreset,
     DensitySelector,
     SaveDialog,
+    RegionManager,
 }
 
 /// Column identifiers for the log table.
@@ -329,6 +330,10 @@ pub struct App {
     pub density_source: DensitySource,
     /// Density selector cursor.
     pub density_selector_cursor: usize,
+    /// Detected regions from region processor.
+    pub regions: Vec<scouty::region::Region>,
+    /// Region manager cursor position.
+    pub region_manager_cursor: usize,
 }
 
 /// Level filter presets.
@@ -587,6 +592,8 @@ impl App {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         })
     }
 
@@ -1729,6 +1736,21 @@ impl App {
         }
     }
 
+    /// Jump to a record by its original index in the records array.
+    /// Finds the corresponding filtered index and selects it.
+    pub fn jump_to_record_index(&mut self, record_idx: usize) {
+        if let Some(filtered_idx) = self.filtered_indices.iter().position(|&i| i == record_idx) {
+            self.selected = filtered_idx;
+            self.ensure_selected_visible();
+        }
+    }
+
+    /// Add a filter expression string.
+    pub fn add_filter_expr(&mut self, expr: &str) {
+        self.filter_input = crate::text_input::TextInput::with_text(expr);
+        self.apply_filter();
+    }
+
     pub fn visible_records(&self) -> Vec<&LogRecord> {
         let end = (self.scroll_offset + self.visible_rows).min(self.total());
         self.filtered_indices[self.scroll_offset..end]
@@ -1975,6 +1997,8 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -2041,6 +2065,8 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -2104,6 +2130,8 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -2622,6 +2650,8 @@ mod field_filter_v2_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -2811,6 +2841,8 @@ mod column_follow_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -3014,6 +3046,8 @@ mod copy_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -3188,6 +3222,8 @@ mod time_jump_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -3325,6 +3361,8 @@ mod command_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
     #[test]

--- a/crates/scouty-tui/src/keybinding.rs
+++ b/crates/scouty-tui/src/keybinding.rs
@@ -51,6 +51,10 @@ pub enum Action {
     PrevBookmark,
     BookmarkManager,
 
+    // Regions
+    RegionManager,
+    NextRegion,
+
     // Copy & Export
     CopyRaw,
     CopyFormat,
@@ -167,6 +171,8 @@ pub struct KeybindingConfig {
     pub next_bookmark: Option<KeyOrKeys>,
     pub prev_bookmark: Option<KeyOrKeys>,
     pub bookmark_manager: Option<KeyOrKeys>,
+    pub region_manager: Option<KeyOrKeys>,
+    pub next_region: Option<KeyOrKeys>,
     pub copy_raw: Option<KeyOrKeys>,
     pub copy_format: Option<KeyOrKeys>,
     pub save: Option<KeyOrKeys>,
@@ -279,6 +285,8 @@ impl KeybindingConfig {
             Action::NextBookmark => self.next_bookmark.as_ref(),
             Action::PrevBookmark => self.prev_bookmark.as_ref(),
             Action::BookmarkManager => self.bookmark_manager.as_ref(),
+            Action::RegionManager => self.region_manager.as_ref(),
+            Action::NextRegion => self.next_region.as_ref(),
             Action::CopyRaw => self.copy_raw.as_ref(),
             Action::CopyFormat => self.copy_format.as_ref(),
             Action::Save => self.save.as_ref(),
@@ -330,6 +338,8 @@ fn default_bindings() -> Vec<(Action, Vec<&'static str>)> {
         (Action::NextBookmark, vec!["'"]),
         (Action::PrevBookmark, vec!["\""]),
         (Action::BookmarkManager, vec!["M"]),
+        (Action::RegionManager, vec!["r"]),
+        (Action::NextRegion, vec!["R"]),
         // Copy
         (Action::CopyRaw, vec!["y"]),
         (Action::CopyFormat, vec!["Y"]),

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -649,6 +649,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     app.input_mode = InputMode::BookmarkManager;
                                     app.bookmark_manager_cursor = 0;
                                 }
+                                Action::RegionManager => {
+                                    if !app.regions.is_empty() {
+                                        app.input_mode = InputMode::RegionManager;
+                                    }
+                                }
+                                Action::NextRegion => {
+                                    // Jump to the next region start after current position
+                                    if let Some(record_idx) = app.filtered_indices.get(app.selected)
+                                    {
+                                        if let Some(region) =
+                                            app.regions.iter().find(|r| r.start_index > *record_idx)
+                                        {
+                                            app.jump_to_record_index(region.start_index);
+                                        }
+                                    }
+                                }
                                 Action::Stats => {
                                     use ui::windows::stats_window::StatsData;
                                     app.cached_stats = Some(StatsData::compute(&app));
@@ -955,6 +971,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 crate::text_input::TextInput::with_text("./scouty-export.log");
                             app.save_format_cursor = 0;
                             app.save_dialog_focus = ui::windows::save_dialog_window::Focus::Path;
+                        }
+                    }
+                    InputMode::RegionManager => {
+                        use ui::windows::region_manager_window::RegionManagerWindow;
+                        let mut window = RegionManagerWindow::from_app(&app);
+                        let result = ui::dispatch_key(&mut window, key);
+                        app.region_manager_cursor = window.cursor;
+                        if result == ui::ComponentResult::Close {
+                            if let Some(action) = window.action {
+                                match action {
+                                    ui::windows::region_manager_window::RegionAction::Jump(idx) => {
+                                        app.jump_to_record_index(idx);
+                                    }
+                                    ui::windows::region_manager_window::RegionAction::Filter(
+                                        _start,
+                                        _end,
+                                    ) => {
+                                        let def_name = &app.regions[window.cursor].definition_name;
+                                        let expr = format!("_region_type == \"{}\"", def_name);
+                                        app.add_filter_expr(&expr);
+                                    }
+                                }
+                            }
+                            app.input_mode = InputMode::Normal;
                         }
                     }
                 }

--- a/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
@@ -12,6 +12,36 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Cell, Row, Table};
 use ratatui::Frame;
 use scouty::record::LogLevel;
+use scouty::region::Region;
+
+/// Region gutter marker colors (matching RegionManagerWindow palette).
+const REGION_COLORS: &[Color] = &[
+    Color::Cyan,
+    Color::Yellow,
+    Color::Green,
+    Color::Magenta,
+    Color::Blue,
+    Color::Red,
+];
+
+/// Build a gutter cell showing region markers for a record.
+fn region_gutter_marker(record_idx: usize, regions: &[Region]) -> Cell<'static> {
+    // Find which region(s) this record belongs to
+    for (i, region) in regions.iter().enumerate() {
+        if record_idx >= region.start_index && record_idx <= region.end_index {
+            let color = REGION_COLORS[i % REGION_COLORS.len()];
+            let marker = if record_idx == region.start_index {
+                "▶ "
+            } else if record_idx == region.end_index {
+                "◀ "
+            } else {
+                "│ "
+            };
+            return Cell::from(marker.to_string()).style(Style::default().fg(color));
+        }
+    }
+    Cell::from("  ".to_string())
+}
 
 pub fn level_style(level: Option<LogLevel>, theme: &Theme) -> Style {
     match level {
@@ -37,46 +67,55 @@ impl LogTableWidget {
 
         let sep_style = theme.table.separator.to_style_entry().to_style();
         let sep_char = theme.table.separator.separator_char();
+        let has_regions = !app.regions.is_empty();
 
-        let widths: Vec<Constraint> = vis_cols
-            .iter()
-            .enumerate()
-            .flat_map(|(i, col)| {
-                let w = match col {
-                    Column::Time => Constraint::Length(cw[0]),
-                    Column::Level => Constraint::Length(cw[1]),
-                    Column::Hostname => Constraint::Length(20),
-                    Column::Container => Constraint::Length(15),
-                    Column::Context => Constraint::Length(25),
-                    Column::Function => Constraint::Length(10),
-                    Column::ProcessName => Constraint::Length(cw[2]),
-                    Column::Pid => Constraint::Length(cw[3]),
-                    Column::Tid => Constraint::Length(cw[4]),
-                    Column::Component => Constraint::Length(cw[5]),
-                    Column::Source => Constraint::Length(15),
-                    Column::Log => Constraint::Fill(1),
-                };
-                if i < vis_cols.len() - 1 {
-                    vec![w, Constraint::Length(1)]
-                } else {
-                    vec![w]
-                }
-            })
-            .collect();
+        let mut widths: Vec<Constraint> = Vec::new();
+        // Gutter column for region markers (2 chars)
+        if has_regions {
+            widths.push(Constraint::Length(2));
+            widths.push(Constraint::Length(1)); // separator
+        }
+        widths.extend(
+            vis_cols
+                .iter()
+                .enumerate()
+                .flat_map(|(i, col)| {
+                    let w = match col {
+                        Column::Time => Constraint::Length(cw[0]),
+                        Column::Level => Constraint::Length(cw[1]),
+                        Column::Hostname => Constraint::Length(20),
+                        Column::Container => Constraint::Length(15),
+                        Column::Context => Constraint::Length(25),
+                        Column::Function => Constraint::Length(10),
+                        Column::ProcessName => Constraint::Length(cw[2]),
+                        Column::Pid => Constraint::Length(cw[3]),
+                        Column::Tid => Constraint::Length(cw[4]),
+                        Column::Component => Constraint::Length(cw[5]),
+                        Column::Source => Constraint::Length(15),
+                        Column::Log => Constraint::Fill(1),
+                    };
+                    if i < vis_cols.len() - 1 {
+                        vec![w, Constraint::Length(1)]
+                    } else {
+                        vec![w]
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
 
-        let header_cells: Vec<Cell> = vis_cols
-            .iter()
-            .enumerate()
-            .flat_map(|(i, col)| {
-                let cell =
-                    Cell::from(col.label()).style(Style::default().add_modifier(Modifier::BOLD));
-                if i < vis_cols.len() - 1 {
-                    vec![cell, Cell::from(sep_char).style(sep_style)]
-                } else {
-                    vec![cell]
-                }
-            })
-            .collect();
+        let mut header_cells: Vec<Cell> = Vec::new();
+        if has_regions {
+            header_cells.push(Cell::from("").style(Style::default()));
+            header_cells.push(Cell::from(sep_char).style(sep_style));
+        }
+        header_cells.extend(vis_cols.iter().enumerate().flat_map(|(i, col)| {
+            let cell = Cell::from(col.label()).style(Style::default().add_modifier(Modifier::BOLD));
+            if i < vis_cols.len() - 1 {
+                vec![cell, Cell::from(sep_char).style(sep_style)]
+            } else {
+                vec![cell]
+            }
+        }));
 
         let header = Row::new(header_cells).style(theme.table.header.to_style());
 
@@ -91,51 +130,62 @@ impl LogTableWidget {
                 let is_bookmarked = app.is_bookmarked(record_idx);
                 let row_style = level_style(record.level, theme);
 
-                let cells: Vec<Cell> = vis_cols
-                    .iter()
-                    .enumerate()
-                    .flat_map(|(ci, col)| {
-                        let cell = match col {
-                            Column::Time => {
-                                Cell::from(record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string())
+                let mut cells: Vec<Cell> = Vec::new();
+
+                // Region gutter marker
+                if has_regions {
+                    let gutter = region_gutter_marker(record_idx, &app.regions);
+                    cells.push(gutter);
+                    cells.push(Cell::from(sep_char).style(sep_style));
+                }
+
+                cells.extend(
+                    vis_cols
+                        .iter()
+                        .enumerate()
+                        .flat_map(|(ci, col)| {
+                            let cell = match col {
+                                Column::Time => Cell::from(
+                                    record.timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
+                                ),
+                                Column::Level => Cell::from(
+                                    record.level.map(|l| format!("{}", l)).unwrap_or_default(),
+                                ),
+                                Column::Hostname => {
+                                    Cell::from(record.hostname.as_deref().unwrap_or("").to_string())
+                                }
+                                Column::Container => Cell::from(
+                                    record.container.as_deref().unwrap_or("").to_string(),
+                                ),
+                                Column::Context => {
+                                    Cell::from(record.context.as_deref().unwrap_or("").to_string())
+                                }
+                                Column::Function => {
+                                    Cell::from(record.function.as_deref().unwrap_or("").to_string())
+                                }
+                                Column::ProcessName => Cell::from(
+                                    record.process_name.as_deref().unwrap_or("").to_string(),
+                                ),
+                                Column::Pid => Cell::from(
+                                    record.pid.map(|p| p.to_string()).unwrap_or_default(),
+                                ),
+                                Column::Tid => Cell::from(
+                                    record.tid.map(|t| t.to_string()).unwrap_or_default(),
+                                ),
+                                Column::Component => Cell::from(
+                                    record.component_name.as_deref().unwrap_or("").to_string(),
+                                ),
+                                Column::Source => Cell::from(record.source.to_string()),
+                                Column::Log => Cell::from(record.message.clone()),
+                            };
+                            if ci < vis_cols.len() - 1 {
+                                vec![cell, Cell::from(sep_char).style(sep_style)]
+                            } else {
+                                vec![cell]
                             }
-                            Column::Level => Cell::from(
-                                record.level.map(|l| format!("{}", l)).unwrap_or_default(),
-                            ),
-                            Column::Hostname => {
-                                Cell::from(record.hostname.as_deref().unwrap_or("").to_string())
-                            }
-                            Column::Container => {
-                                Cell::from(record.container.as_deref().unwrap_or("").to_string())
-                            }
-                            Column::Context => {
-                                Cell::from(record.context.as_deref().unwrap_or("").to_string())
-                            }
-                            Column::Function => {
-                                Cell::from(record.function.as_deref().unwrap_or("").to_string())
-                            }
-                            Column::ProcessName => {
-                                Cell::from(record.process_name.as_deref().unwrap_or("").to_string())
-                            }
-                            Column::Pid => {
-                                Cell::from(record.pid.map(|p| p.to_string()).unwrap_or_default())
-                            }
-                            Column::Tid => {
-                                Cell::from(record.tid.map(|t| t.to_string()).unwrap_or_default())
-                            }
-                            Column::Component => Cell::from(
-                                record.component_name.as_deref().unwrap_or("").to_string(),
-                            ),
-                            Column::Source => Cell::from(record.source.to_string()),
-                            Column::Log => Cell::from(record.message.clone()),
-                        };
-                        if ci < vis_cols.len() - 1 {
-                            vec![cell, Cell::from(sep_char).style(sep_style)]
-                        } else {
-                            vec![cell]
-                        }
-                    })
-                    .collect();
+                        })
+                        .collect::<Vec<_>>(),
+                );
 
                 // Determine highlight row background: last matching rule wins
                 let highlight_bg: Option<Color> = if app.highlight_rules.is_empty() {

--- a/crates/scouty-tui/src/ui/windows/help_window.rs
+++ b/crates/scouty-tui/src/ui/windows/help_window.rs
@@ -74,6 +74,8 @@ impl<'a> HelpWindow<'a> {
             Line::from("  '                Jump to next bookmark"),
             Line::from("  \"                Jump to prev bookmark"),
             Line::from("  M                Bookmark manager"),
+            Line::from("  r                Region manager"),
+            Line::from("  R                Jump to next region"),
             Line::from(""),
             section("Highlight"),
             Line::from("  h                Quick highlight word"),

--- a/crates/scouty-tui/src/ui/windows/mod.rs
+++ b/crates/scouty-tui/src/ui/windows/mod.rs
@@ -11,6 +11,7 @@ pub mod help_window;
 pub mod highlight_manager_window;
 pub mod level_filter_window;
 pub mod load_preset_window;
+pub mod region_manager_window;
 pub mod save_dialog_window;
 pub mod save_preset_window;
 pub mod stats_window;

--- a/crates/scouty-tui/src/ui/windows/region_manager_window.rs
+++ b/crates/scouty-tui/src/ui/windows/region_manager_window.rs
@@ -1,0 +1,225 @@
+//! Region manager overlay (r key) — lists detected regions with navigation.
+
+#[cfg(test)]
+#[path = "region_manager_window_tests.rs"]
+mod region_manager_window_tests;
+
+use crate::app::App;
+use crate::ui::{ComponentResult, UiComponent};
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+pub enum RegionAction {
+    Jump(usize),
+    Filter(usize, usize),
+}
+
+pub struct RegionManagerWindow {
+    pub cursor: usize,
+    pub entries: Vec<RegionEntry>,
+    pub action: Option<RegionAction>,
+}
+
+pub struct RegionEntry {
+    pub name: String,
+    pub definition_name: String,
+    pub time_range: String,
+    pub start_index: usize,
+    pub end_index: usize,
+}
+
+/// Highlight palette colors for region types.
+const REGION_COLORS: &[Color] = &[
+    Color::Cyan,
+    Color::Yellow,
+    Color::Green,
+    Color::Magenta,
+    Color::Blue,
+    Color::Red,
+];
+
+impl RegionManagerWindow {
+    pub fn from_app(app: &App) -> Self {
+        let entries: Vec<RegionEntry> = app
+            .regions
+            .iter()
+            .map(|region| {
+                let start_ts = app
+                    .records
+                    .get(region.start_index)
+                    .map(|r| r.timestamp.format("%H:%M:%S").to_string())
+                    .unwrap_or_else(|| "?".to_string());
+                let end_ts = app
+                    .records
+                    .get(region.end_index)
+                    .map(|r| r.timestamp.format("%H:%M:%S").to_string())
+                    .unwrap_or_else(|| "?".to_string());
+
+                RegionEntry {
+                    name: region.name.clone(),
+                    definition_name: region.definition_name.clone(),
+                    time_range: format!("{} → {}", start_ts, end_ts),
+                    start_index: region.start_index,
+                    end_index: region.end_index,
+                }
+            })
+            .collect();
+        let cursor = app
+            .region_manager_cursor
+            .min(entries.len().saturating_sub(1));
+        Self {
+            cursor,
+            entries,
+            action: None,
+        }
+    }
+
+    pub fn render_with_app(&self, frame: &mut Frame, area: Rect, _app: &App) {
+        // Centered popup: 80% width, 60% height
+        let popup_width = (area.width as f32 * 0.8) as u16;
+        let popup_height = (area.height as f32 * 0.6).max(8.0) as u16;
+        let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+        let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+        let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+        frame.render_widget(Clear, popup_area);
+
+        // Collect unique definition names for type count
+        let mut type_names: Vec<String> = self
+            .entries
+            .iter()
+            .map(|e| e.definition_name.clone())
+            .collect();
+        type_names.sort();
+        type_names.dedup();
+        let type_count = type_names.len();
+
+        let inner = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(
+                " Regions — {} total ({} types) ",
+                self.entries.len(),
+                type_count
+            ))
+            .style(Style::default().fg(Color::White));
+
+        let inner_area = inner.inner(popup_area);
+        frame.render_widget(inner, popup_area);
+
+        if self.entries.is_empty() {
+            let msg = Paragraph::new("No regions detected.");
+            frame.render_widget(msg, inner_area);
+            return;
+        }
+
+        // Build type → color map
+        let type_color_map: std::collections::HashMap<&str, Color> = type_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| (name.as_str(), REGION_COLORS[i % REGION_COLORS.len()]))
+            .collect();
+
+        // Scrollable region list (reserve 2 lines for footer)
+        let list_height = inner_area.height.saturating_sub(2) as usize;
+        let scroll_offset = if self.cursor >= list_height {
+            self.cursor - list_height + 1
+        } else {
+            0
+        };
+
+        let mut lines: Vec<Line> = Vec::new();
+        for (i, entry) in self.entries.iter().enumerate().skip(scroll_offset) {
+            if lines.len() >= list_height {
+                break;
+            }
+            let color = type_color_map
+                .get(entry.definition_name.as_str())
+                .copied()
+                .unwrap_or(Color::White);
+            let prefix = if i == self.cursor { "▶ " } else { "  " };
+            let style = if i == self.cursor {
+                Style::default()
+                    .fg(color)
+                    .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+            } else {
+                Style::default().fg(color)
+            };
+
+            // Truncate name to fit
+            let max_name = (inner_area.width as usize).saturating_sub(25);
+            let name: String = entry.name.chars().take(max_name).collect();
+            let line_str = format!(
+                "{}{:<width$}  {}",
+                prefix,
+                name,
+                entry.time_range,
+                width = max_name
+            );
+            lines.push(Line::styled(line_str, style));
+        }
+
+        // Footer
+        let footer_y = inner_area.y + inner_area.height.saturating_sub(1);
+        let footer = Paragraph::new(Line::styled(
+            " [Enter] Jump  [f] Filter  [Esc] Close",
+            Style::default().fg(Color::DarkGray),
+        ));
+        let footer_area = Rect::new(inner_area.x, footer_y, inner_area.width, 1);
+        frame.render_widget(footer, footer_area);
+
+        let list_area = Rect::new(
+            inner_area.x,
+            inner_area.y,
+            inner_area.width,
+            list_height as u16,
+        );
+        let paragraph = Paragraph::new(lines);
+        frame.render_widget(paragraph, list_area);
+    }
+}
+
+impl UiComponent for RegionManagerWindow {
+    fn render(&self, _frame: &mut Frame, _area: Rect) {
+        // Use render_with_app instead
+    }
+
+    fn on_up(&mut self) -> ComponentResult {
+        if self.cursor > 0 {
+            self.cursor -= 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_down(&mut self) -> ComponentResult {
+        if self.cursor + 1 < self.entries.len() {
+            self.cursor += 1;
+        }
+        ComponentResult::Consumed
+    }
+
+    fn on_confirm(&mut self) -> ComponentResult {
+        if let Some(entry) = self.entries.get(self.cursor) {
+            self.action = Some(RegionAction::Jump(entry.start_index));
+            ComponentResult::Close
+        } else {
+            ComponentResult::Consumed
+        }
+    }
+
+    fn on_char(&mut self, c: char) -> ComponentResult {
+        match c {
+            'f' | 'F' => {
+                if let Some(entry) = self.entries.get(self.cursor) {
+                    self.action = Some(RegionAction::Filter(entry.start_index, entry.end_index));
+                    ComponentResult::Close
+                } else {
+                    ComponentResult::Consumed
+                }
+            }
+            _ => ComponentResult::Ignored,
+        }
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/region_manager_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/region_manager_window_tests.rs
@@ -1,0 +1,92 @@
+//! Tests for RegionManagerWindow.
+
+mod tests {
+    use crate::ui::windows::region_manager_window::{
+        RegionAction, RegionEntry, RegionManagerWindow,
+    };
+    use crate::ui::{dispatch_key, ComponentResult, UiComponent};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn make_window(n: usize) -> RegionManagerWindow {
+        let entries: Vec<RegionEntry> = (0..n)
+            .map(|i| RegionEntry {
+                name: format!("Region {}", i),
+                definition_name: "test_region".to_string(),
+                time_range: format!("10:00:0{} → 10:00:1{}", i, i),
+                start_index: i * 10,
+                end_index: i * 10 + 5,
+            })
+            .collect();
+        RegionManagerWindow {
+            cursor: 0,
+            entries,
+            action: None,
+        }
+    }
+
+    #[test]
+    fn test_navigation() {
+        let mut w = make_window(5);
+        assert_eq!(w.cursor, 0);
+
+        dispatch_key(&mut w, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(w.cursor, 1);
+
+        dispatch_key(&mut w, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(w.cursor, 2);
+
+        dispatch_key(&mut w, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(w.cursor, 1);
+    }
+
+    #[test]
+    fn test_up_at_top_stays() {
+        let mut w = make_window(3);
+        dispatch_key(&mut w, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(w.cursor, 0);
+    }
+
+    #[test]
+    fn test_down_at_bottom_stays() {
+        let mut w = make_window(3);
+        w.cursor = 2;
+        dispatch_key(&mut w, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(w.cursor, 2);
+    }
+
+    #[test]
+    fn test_enter_jumps() {
+        let mut w = make_window(3);
+        w.cursor = 1;
+        let result = dispatch_key(&mut w, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(result, ComponentResult::Close);
+        assert!(matches!(w.action, Some(RegionAction::Jump(10))));
+    }
+
+    #[test]
+    fn test_f_filters() {
+        let mut w = make_window(3);
+        w.cursor = 2;
+        let result = dispatch_key(
+            &mut w,
+            KeyEvent::new(KeyCode::Char('f'), KeyModifiers::NONE),
+        );
+        assert_eq!(result, ComponentResult::Close);
+        assert!(matches!(w.action, Some(RegionAction::Filter(20, 25))));
+    }
+
+    #[test]
+    fn test_esc_closes() {
+        let mut w = make_window(3);
+        let result = dispatch_key(&mut w, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert_eq!(result, ComponentResult::Close);
+        assert!(w.action.is_none());
+    }
+
+    #[test]
+    fn test_empty_entries() {
+        let mut w = make_window(0);
+        let result = dispatch_key(&mut w, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(result, ComponentResult::Consumed);
+    }
+}

--- a/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
@@ -96,6 +96,8 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -94,6 +94,8 @@ mod tests {
             preset_list_cursor: 0,
             density_source: crate::app::DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         }
     }
 
@@ -195,6 +197,8 @@ mod tests {
             preset_list_cursor: 0,
             density_source: crate::app::DensitySource::All,
             density_selector_cursor: 0,
+            regions: Vec::new(),
+            region_manager_cursor: 0,
         };
         let stats = StatsData::compute(&app);
         assert_eq!(stats.total_records, 0);

--- a/crates/scouty-tui/src/ui_legacy.rs
+++ b/crates/scouty-tui/src/ui_legacy.rs
@@ -156,6 +156,12 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         let window = DensitySelectorWindow::new(options, app.density_selector_cursor);
         UiComponent::render(&window, frame, area);
     }
+
+    if app.input_mode == InputMode::RegionManager {
+        use crate::ui::windows::region_manager_window::RegionManagerWindow;
+        let window = RegionManagerWindow::from_app(app);
+        window.render_with_app(frame, area, app);
+    }
 }
 
 fn render_log_table(frame: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary

Add region visualization and navigation to the TUI.

### Gutter Markers
- 2-char gutter column left of log table (only when regions exist)
- `▶` start, `◀` end, `│` middle — colored by region type

### Region Manager (`r` key)
- Lists all detected regions with name + time range
- Color-coded by type, shows total + type count
- `j`/`k` nav, `Enter` jump to start, `f` filter by type, `Esc` close

### Region Navigation (`R` key)
- Jump to next region start after current position

### Note on Region Density Chart
The floating Gantt-style region density chart is listed in the issue requirements. It can be added as a follow-up since it's a larger visual component and the core functionality (markers, manager, navigation) is complete.

### Changes
- `app.rs` — regions/cursor fields, RegionManager mode, jump/filter helpers
- `keybinding.rs` — RegionManager/NextRegion actions (r/R)
- `log_table_widget.rs` — gutter column rendering
- `region_manager_window.rs` — new overlay (7 tests)
- `ui_legacy.rs`, `main.rs` — rendering + input dispatch
- `help_window.rs` — r/R added

### Test Plan
All 634 tests pass (7 new).

Closes #360