### PR TITLE
feat: RegionStore + timeout creates regions

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -331,7 +331,7 @@ pub struct App {
     /// Density selector cursor.
     pub density_selector_cursor: usize,
     /// Detected regions from region processor.
-    pub regions: Vec<scouty::region::Region>,
+    pub regions: scouty::region::store::RegionStore,
     /// Region manager cursor position.
     pub region_manager_cursor: usize,
 }
@@ -592,7 +592,7 @@ impl App {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         })
     }
@@ -1997,7 +1997,7 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -2065,7 +2065,7 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -2130,7 +2130,7 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -2650,7 +2650,7 @@ mod field_filter_v2_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -2841,7 +2841,7 @@ mod column_follow_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -3046,7 +3046,7 @@ mod copy_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -3222,7 +3222,7 @@ mod time_jump_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -3361,7 +3361,7 @@ mod command_tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -658,8 +658,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     // Jump to the next region start after current position
                                     if let Some(record_idx) = app.filtered_indices.get(app.selected)
                                     {
-                                        if let Some(region) =
-                                            app.regions.iter().find(|r| r.start_index > *record_idx)
+                                        if let Some(region) = app
+                                            .regions
+                                            .regions()
+                                            .iter()
+                                            .find(|r| r.start_index > *record_idx)
                                         {
                                             app.jump_to_record_index(region.start_index);
                                         }
@@ -988,7 +991,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         _start,
                                         _end,
                                     ) => {
-                                        let def_name = &app.regions[window.cursor].definition_name;
+                                        let def_name =
+                                            &app.regions.regions()[window.cursor].definition_name;
                                         let expr = format!("_region_type == \"{}\"", def_name);
                                         app.add_filter_expr(&expr);
                                     }

--- a/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
@@ -12,7 +12,7 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Cell, Row, Table};
 use ratatui::Frame;
 use scouty::record::LogLevel;
-use scouty::region::Region;
+use scouty::region::store::RegionStore;
 
 /// Region gutter marker colors (matching RegionManagerWindow palette).
 const REGION_COLORS: &[Color] = &[
@@ -25,22 +25,28 @@ const REGION_COLORS: &[Color] = &[
 ];
 
 /// Build a gutter cell showing region markers for a record.
-fn region_gutter_marker(record_idx: usize, regions: &[Region]) -> Cell<'static> {
-    // Find which region(s) this record belongs to
-    for (i, region) in regions.iter().enumerate() {
-        if record_idx >= region.start_index && record_idx <= region.end_index {
-            let color = REGION_COLORS[i % REGION_COLORS.len()];
-            let marker = if record_idx == region.start_index {
-                "▶ "
-            } else if record_idx == region.end_index {
-                "◀ "
-            } else {
-                "│ "
-            };
-            return Cell::from(marker.to_string()).style(Style::default().fg(color));
-        }
+/// When overlapping, shows the innermost (shortest) region marker.
+fn region_gutter_marker(record_idx: usize, store: &RegionStore) -> Cell<'static> {
+    if let Some(region) = store.innermost_at(record_idx) {
+        // Determine color by definition name hash for consistency
+        let color_idx = region
+            .definition_name
+            .bytes()
+            .fold(0usize, |acc, b| acc.wrapping_add(b as usize));
+        let color = REGION_COLORS[color_idx % REGION_COLORS.len()];
+        let marker = if region.timed_out {
+            "░ "
+        } else if record_idx == region.start_index {
+            "▶ "
+        } else if record_idx == region.end_index {
+            "◀ "
+        } else {
+            "│ "
+        };
+        Cell::from(marker.to_string()).style(Style::default().fg(color))
+    } else {
+        Cell::from("  ".to_string())
     }
-    Cell::from("  ".to_string())
 }
 
 pub fn level_style(level: Option<LogLevel>, theme: &Theme) -> Style {

--- a/crates/scouty-tui/src/ui/windows/region_manager_window.rs
+++ b/crates/scouty-tui/src/ui/windows/region_manager_window.rs
@@ -45,6 +45,7 @@ impl RegionManagerWindow {
     pub fn from_app(app: &App) -> Self {
         let entries: Vec<RegionEntry> = app
             .regions
+            .regions()
             .iter()
             .map(|region| {
                 let start_ts = app

--- a/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/save_dialog_window_tests.rs
@@ -96,7 +96,7 @@ mod tests {
             preset_list_cursor: 0,
             density_source: DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -94,7 +94,7 @@ mod tests {
             preset_list_cursor: 0,
             density_source: crate::app::DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         }
     }
@@ -197,7 +197,7 @@ mod tests {
             preset_list_cursor: 0,
             density_source: crate::app::DensitySource::All,
             density_selector_cursor: 0,
-            regions: Vec::new(),
+            regions: scouty::region::store::RegionStore::default(),
             region_manager_cursor: 0,
         };
         let stats = StatsData::compute(&app);

--- a/crates/scouty/src/region/config.rs
+++ b/crates/scouty/src/region/config.rs
@@ -26,6 +26,8 @@ pub struct RegionDefinition {
     pub description_template: Option<String>,
     /// Max duration between start and end (None = unlimited).
     pub timeout: Option<Duration>,
+    /// Template for timeout end reason.
+    pub timeout_reason: Option<String>,
 }
 
 /// A compiled match point (filter + optional regex).
@@ -59,6 +61,8 @@ pub struct RawRegionDef {
     pub template: RawTemplate,
     #[serde(default)]
     pub timeout: Option<String>,
+    #[serde(default)]
+    pub timeout_reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -151,6 +155,7 @@ fn compile_definition(raw: &RawRegionDef) -> Result<RegionDefinition, String> {
         name_template: raw.template.name.clone(),
         description_template: raw.template.description.clone(),
         timeout,
+        timeout_reason: raw.timeout_reason.clone(),
     })
 }
 

--- a/crates/scouty/src/region/mod.rs
+++ b/crates/scouty/src/region/mod.rs
@@ -6,6 +6,7 @@ mod region_tests;
 
 pub mod config;
 pub mod processor;
+pub mod store;
 
 use std::collections::HashMap;
 
@@ -28,4 +29,6 @@ pub struct Region {
     pub end_index: usize,
     /// Merged metadata from start + end.
     pub metadata: HashMap<String, String>,
+    /// Whether this region was created due to timeout.
+    pub timed_out: bool,
 }

--- a/crates/scouty/src/region/processor.rs
+++ b/crates/scouty/src/region/processor.rs
@@ -49,67 +49,77 @@ impl RegionProcessor {
     /// Process a batch of records from the store.
     /// Records are processed in order; call repeatedly for incremental processing.
     /// Returns the records that were tagged with region metadata (indices).
-    pub fn process_records(&mut self, records: &mut [LogRecord]) -> Vec<usize> {
-        let mut tagged_indices = Vec::new();
-
-        for i in 0..records.len() {
+    pub fn process_records(&mut self, records: &[LogRecord]) {
+        for (i, record) in records.iter().enumerate() {
             let absolute_index = self.next_index + i;
 
             for def_idx in 0..self.definitions.len() {
                 // Check END points first
                 if let Some((end_meta, end_reason)) =
-                    try_match_points(&self.definitions[def_idx].end_points, &records[i])
+                    try_match_points(&self.definitions[def_idx].end_points, record)
                 {
                     // Try correlation with pending starts
-                    if let Some(region) = self.try_correlate(
-                        def_idx,
-                        absolute_index,
-                        end_meta,
-                        end_reason,
-                        &records[i],
-                    ) {
-                        // Tag records between start and end
-                        let start_local = region.start_index.saturating_sub(self.next_index);
-                        let end_local = i;
-                        for j in start_local..=end_local.min(records.len() - 1) {
-                            let abs_j = self.next_index + j;
-                            if abs_j >= region.start_index && abs_j <= region.end_index {
-                                let pos =
-                                    if abs_j == region.start_index && abs_j == region.end_index {
-                                        "start+end"
-                                    } else if abs_j == region.start_index {
-                                        "start"
-                                    } else if abs_j == region.end_index {
-                                        "end"
-                                    } else {
-                                        "middle"
-                                    };
-                                tag_record(
-                                    &mut records[j],
-                                    &region.definition_name,
-                                    &region.name,
-                                    pos,
-                                );
-                                tagged_indices.push(abs_j);
-                            }
-                        }
+                    if let Some(region) =
+                        self.try_correlate(def_idx, absolute_index, end_meta, end_reason, record)
+                    {
                         self.regions.push(region);
                     }
                 }
 
                 // Check START points
                 if let Some((start_meta, start_reason)) =
-                    try_match_points(&self.definitions[def_idx].start_points, &records[i])
+                    try_match_points(&self.definitions[def_idx].start_points, record)
                 {
-                    // Purge timed-out pending starts
+                    // Create timed-out regions for expired pending starts
                     if let Some(timeout) = self.definitions[def_idx].timeout {
                         let ts = records[i].timestamp;
-                        self.pending[def_idx].retain(|p| {
-                            let elapsed = ts.signed_duration_since(p.timestamp);
-                            elapsed
-                                < chrono::Duration::from_std(timeout)
-                                    .unwrap_or(chrono::Duration::MAX)
-                        });
+                        let timeout_chrono =
+                            chrono::Duration::from_std(timeout).unwrap_or(chrono::Duration::MAX);
+                        let (expired, remaining): (Vec<_>, Vec<_>) = self.pending[def_idx]
+                            .drain(..)
+                            .partition(|p| ts.signed_duration_since(p.timestamp) >= timeout_chrono);
+                        self.pending[def_idx] = remaining;
+
+                        // Create timed-out regions for expired starts
+                        let def = &self.definitions[def_idx];
+                        for pending in expired {
+                            let timeout_reason = def
+                                .timeout_reason
+                                .as_ref()
+                                .map(|t| super::config::render_template(t, &pending.metadata));
+
+                            let mut metadata = pending.metadata.clone();
+                            if let Some(tr) = &timeout_reason {
+                                metadata.insert("end_reason".to_string(), tr.clone());
+                            }
+                            if let Some(sr) = &pending.reason {
+                                let rendered =
+                                    super::config::render_template(sr, &pending.metadata);
+                                metadata.insert("start_reason".to_string(), rendered.clone());
+                            }
+
+                            let name =
+                                super::config::render_template(&def.name_template, &metadata);
+                            let description = def
+                                .description_template
+                                .as_ref()
+                                .map(|t| super::config::render_template(t, &metadata));
+
+                            self.regions.push(Region {
+                                definition_name: def.name.clone(),
+                                name,
+                                description,
+                                start_reason: pending
+                                    .reason
+                                    .as_ref()
+                                    .map(|r| super::config::render_template(r, &pending.metadata)),
+                                end_reason: timeout_reason,
+                                start_index: pending.record_index,
+                                end_index: pending.record_index, // timed-out: end = start
+                                metadata,
+                                timed_out: true,
+                            });
+                        }
                     }
 
                     self.pending[def_idx].push(PendingStart {
@@ -123,7 +133,6 @@ impl RegionProcessor {
         }
 
         self.next_index += records.len();
-        tagged_indices
     }
 
     /// Try to correlate an end match with a pending start.
@@ -211,6 +220,7 @@ impl RegionProcessor {
             start_index: pending.record_index,
             end_index,
             metadata,
+            timed_out: false,
         })
     }
 
@@ -257,10 +267,4 @@ fn try_match_points(
     None
 }
 
-/// Tag a record with region metadata.
-fn tag_record(record: &mut LogRecord, def_name: &str, region_name: &str, pos: &str) {
-    let meta = record.metadata.get_or_insert_with(HashMap::new);
-    meta.insert("_region".to_string(), region_name.to_string());
-    meta.insert("_region_type".to_string(), def_name.to_string());
-    meta.insert("_region_pos".to_string(), pos.to_string());
-}
+// tag_record removed: region metadata now lives in RegionStore, not on LogRecord.

--- a/crates/scouty/src/region/processor_tests.rs
+++ b/crates/scouty/src/region/processor_tests.rs
@@ -5,7 +5,6 @@ mod tests {
     use crate::region::config;
     use crate::region::processor::RegionProcessor;
     use chrono::{TimeZone, Utc};
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     fn make_record(id: u64, ts_secs: i64, message: &str, level: Option<LogLevel>) -> LogRecord {
@@ -54,13 +53,13 @@ regions:
         let defs = config::load_from_str(BASIC_CONFIG).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "addPort Ethernet0", None),
             make_record(1, 1001, "some log in between", None),
             make_record(2, 1002, "Ethernet0 oper_status up", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
         assert_eq!(proc.region_count(), 1);
         let region = &proc.regions()[0];
@@ -68,35 +67,7 @@ regions:
         assert_eq!(region.name, "Port Startup Ethernet0");
         assert_eq!(region.start_index, 0);
         assert_eq!(region.end_index, 2);
-
-        // Check record tagging
-        assert_eq!(
-            records[0]
-                .metadata
-                .as_ref()
-                .unwrap()
-                .get("_region_pos")
-                .unwrap(),
-            "start"
-        );
-        assert_eq!(
-            records[1]
-                .metadata
-                .as_ref()
-                .unwrap()
-                .get("_region_pos")
-                .unwrap(),
-            "middle"
-        );
-        assert_eq!(
-            records[2]
-                .metadata
-                .as_ref()
-                .unwrap()
-                .get("_region_pos")
-                .unwrap(),
-            "end"
-        );
+        assert!(!region.timed_out);
     }
 
     #[test]
@@ -104,12 +75,12 @@ regions:
         let defs = config::load_from_str(BASIC_CONFIG).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "addPort Ethernet4", None),
             make_record(1, 1002, "Ethernet4 oper_status up", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
         assert_eq!(proc.region_count(), 1);
         let region = &proc.regions()[0];
@@ -126,45 +97,94 @@ regions:
         let defs = config::load_from_str(BASIC_CONFIG).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "addPort Ethernet0", None),
             make_record(1, 1001, "addPort Ethernet4", None),
             make_record(2, 1002, "Ethernet4 oper_status up", None),
             make_record(3, 1003, "Ethernet0 oper_status up", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
         assert_eq!(proc.region_count(), 2);
-        // First completed region: Ethernet4 (end came first)
         assert_eq!(proc.regions()[0].name, "Port Startup Ethernet4");
         assert_eq!(proc.regions()[0].start_index, 1);
         assert_eq!(proc.regions()[0].end_index, 2);
-        // Second: Ethernet0
         assert_eq!(proc.regions()[1].name, "Port Startup Ethernet0");
         assert_eq!(proc.regions()[1].start_index, 0);
         assert_eq!(proc.regions()[1].end_index, 3);
     }
 
     #[test]
-    fn test_timeout_discards_stale_starts() {
+    fn test_timeout_creates_timed_out_region() {
+        let config_str = r#"
+regions:
+  - name: "port_startup"
+    start_points:
+      - filter: 'message contains "addPort"'
+        regex: '(?P<port>Ethernet\d+)'
+        reason: "add {port}"
+    end_points:
+      - filter: 'message contains "oper_status up"'
+        regex: '(?P<port>Ethernet\d+)'
+        reason: "oper up {port}"
+    correlate:
+      - "port"
+    template:
+      name: "Port Startup {port}"
+    timeout: "30s"
+    timeout_reason: "{port} did not come up within 30s"
+"#;
+        let defs = config::load_from_str(config_str).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let records = vec![
+            make_record(0, 1000, "addPort Ethernet0", None),
+            // 60s later — beyond 30s timeout, new start triggers timeout
+            make_record(1, 1060, "addPort Ethernet4", None),
+            make_record(2, 1062, "Ethernet4 oper_status up", None),
+        ];
+
+        proc.process_records(&records);
+
+        // Should have 2 regions: timed-out Ethernet0, normal Ethernet4
+        assert_eq!(proc.region_count(), 2);
+
+        let timed_out = &proc.regions()[0];
+        assert!(timed_out.timed_out);
+        assert_eq!(timed_out.name, "Port Startup Ethernet0");
+        assert_eq!(timed_out.start_index, 0);
+        assert_eq!(timed_out.end_index, 0); // end = start for timed-out
+        assert_eq!(
+            timed_out.end_reason.as_deref(),
+            Some("Ethernet0 did not come up within 30s")
+        );
+
+        let normal = &proc.regions()[1];
+        assert!(!normal.timed_out);
+        assert_eq!(normal.name, "Port Startup Ethernet4");
+        assert_eq!(normal.start_index, 1);
+        assert_eq!(normal.end_index, 2);
+    }
+
+    #[test]
+    fn test_timeout_correlates_with_fresh_start() {
         let defs = config::load_from_str(BASIC_CONFIG).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "addPort Ethernet0", None),
-            // 60s later — beyond 30s timeout
             make_record(1, 1060, "addPort Ethernet0", None),
             make_record(2, 1062, "Ethernet0 oper_status up", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
-        assert_eq!(proc.region_count(), 1);
-        let region = &proc.regions()[0];
-        // Should correlate with the second start (fresh), not the first (stale)
-        assert_eq!(region.start_index, 1);
-        assert_eq!(region.end_index, 2);
+        // Timed-out region + fresh-matched region
+        let normal_regions: Vec<_> = proc.regions().iter().filter(|r| !r.timed_out).collect();
+        assert_eq!(normal_regions.len(), 1);
+        assert_eq!(normal_regions[0].start_index, 1);
+        assert_eq!(normal_regions[0].end_index, 2);
     }
 
     #[test]
@@ -183,23 +203,20 @@ regions:
         let defs = config::load_from_str(config).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "start A", None),
             make_record(1, 1001, "start B", None),
             make_record(2, 1002, "end X", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
         assert_eq!(proc.region_count(), 1);
-        // LIFO: should match with the most recent start (B at index 1)
         assert_eq!(proc.regions()[0].start_index, 1);
     }
 
     #[test]
     fn test_start_plus_end_same_record() {
-        // If a record matches both start and end of different definitions,
-        // or if start_index == end_index
         let config = r#"
 regions:
   - name: "instant"
@@ -214,14 +231,12 @@ regions:
         let defs = config::load_from_str(config).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        // The end check happens first, but no pending start exists yet.
-        // Then start check adds it. Next matching record will end it.
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "instant event", None),
             make_record(1, 1001, "instant event", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
         assert_eq!(proc.region_count(), 1);
         assert_eq!(proc.regions()[0].start_index, 0);
@@ -233,15 +248,14 @@ regions:
         let defs = config::load_from_str(BASIC_CONFIG).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "unrelated log line", None),
             make_record(1, 1001, "another unrelated line", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
         assert_eq!(proc.region_count(), 0);
-        assert!(records[0].metadata.is_none());
     }
 
     #[test]
@@ -249,18 +263,14 @@ regions:
         let defs = config::load_from_str(BASIC_CONFIG).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        // First batch: start only
-        let mut batch1 = vec![make_record(0, 1000, "addPort Ethernet0", None)];
-        proc.process_records(&mut batch1);
+        let batch1 = vec![make_record(0, 1000, "addPort Ethernet0", None)];
+        proc.process_records(&batch1);
         assert_eq!(proc.region_count(), 0);
         assert_eq!(proc.pending_count(), 1);
 
-        // Second batch: end
-        let mut batch2 = vec![make_record(1, 1002, "Ethernet0 oper_status up", None)];
-        proc.process_records(&mut batch2);
+        let batch2 = vec![make_record(1, 1002, "Ethernet0 oper_status up", None)];
+        proc.process_records(&batch2);
         assert_eq!(proc.region_count(), 1);
-        // Note: the middle records from batch1 won't be tagged since they're
-        // in a previous batch. In practice, the caller re-tags from the store.
     }
 
     #[test]
@@ -268,14 +278,32 @@ regions:
         let defs = config::load_from_str(BASIC_CONFIG).unwrap();
         let mut proc = RegionProcessor::new(defs);
 
-        let mut records = vec![
+        let records = vec![
             make_record(0, 1000, "addPort Ethernet0", None),
             make_record(1, 1002, "Ethernet0 oper_status up", None),
         ];
 
-        proc.process_records(&mut records);
+        proc.process_records(&records);
 
         let region = &proc.regions()[0];
         assert_eq!(region.metadata.get("port").unwrap(), "Ethernet0");
+    }
+
+    #[test]
+    fn test_timeout_without_timeout_reason() {
+        // timeout_reason not set: end_reason should be None for timed-out regions
+        let defs = config::load_from_str(BASIC_CONFIG).unwrap();
+        let mut proc = RegionProcessor::new(defs);
+
+        let records = vec![
+            make_record(0, 1000, "addPort Ethernet0", None),
+            make_record(1, 1060, "addPort Ethernet4", None),
+        ];
+
+        proc.process_records(&records);
+
+        let timed_out: Vec<_> = proc.regions().iter().filter(|r| r.timed_out).collect();
+        assert_eq!(timed_out.len(), 1);
+        assert!(timed_out[0].end_reason.is_none());
     }
 }

--- a/crates/scouty/src/region/store.rs
+++ b/crates/scouty/src/region/store.rs
@@ -1,0 +1,71 @@
+//! RegionStore — stores detected regions with efficient index-based queries.
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod store_tests;
+
+use super::Region;
+
+/// Stores all detected regions sorted by start_index for efficient lookup.
+#[derive(Debug, Clone, Default)]
+pub struct RegionStore {
+    /// Regions sorted by start_index.
+    regions: Vec<Region>,
+}
+
+impl RegionStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self {
+            regions: Vec::new(),
+        }
+    }
+
+    /// Build a store from a list of regions (sorts internally).
+    pub fn from_regions(mut regions: Vec<Region>) -> Self {
+        regions.sort_by_key(|r| r.start_index);
+        Self { regions }
+    }
+
+    /// Add a region, maintaining sorted order.
+    pub fn push(&mut self, region: Region) {
+        let pos = self
+            .regions
+            .partition_point(|r| r.start_index <= region.start_index);
+        self.regions.insert(pos, region);
+    }
+
+    /// Query all regions that contain the given record index.
+    /// Returns regions where `start_index <= index <= end_index`.
+    pub fn regions_at(&self, index: usize) -> Vec<&Region> {
+        // Binary search for the rightmost region with start_index <= index
+        let upper = self.regions.partition_point(|r| r.start_index <= index);
+        // Check all regions up to that point
+        self.regions[..upper]
+            .iter()
+            .filter(|r| r.end_index >= index)
+            .collect()
+    }
+
+    /// Get the innermost (shortest span) region at an index.
+    pub fn innermost_at(&self, index: usize) -> Option<&Region> {
+        self.regions_at(index)
+            .into_iter()
+            .min_by_key(|r| r.end_index - r.start_index)
+    }
+
+    /// Get all regions.
+    pub fn regions(&self) -> &[Region] {
+        &self.regions
+    }
+
+    /// Number of regions.
+    pub fn len(&self) -> usize {
+        self.regions.len()
+    }
+
+    /// Whether the store is empty.
+    pub fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
+}

--- a/crates/scouty/src/region/store_tests.rs
+++ b/crates/scouty/src/region/store_tests.rs
@@ -1,0 +1,87 @@
+//! Tests for RegionStore.
+
+mod tests {
+    use crate::region::store::RegionStore;
+    use crate::region::Region;
+    use std::collections::HashMap;
+
+    fn make_region(name: &str, start: usize, end: usize) -> Region {
+        Region {
+            definition_name: "test".to_string(),
+            name: name.to_string(),
+            description: None,
+            start_reason: None,
+            end_reason: None,
+            start_index: start,
+            end_index: end,
+            metadata: HashMap::new(),
+            timed_out: false,
+        }
+    }
+
+    #[test]
+    fn test_regions_at_single() {
+        let store = RegionStore::from_regions(vec![make_region("A", 5, 10)]);
+        assert_eq!(store.regions_at(3).len(), 0);
+        assert_eq!(store.regions_at(5).len(), 1);
+        assert_eq!(store.regions_at(7).len(), 1);
+        assert_eq!(store.regions_at(10).len(), 1);
+        assert_eq!(store.regions_at(11).len(), 0);
+    }
+
+    #[test]
+    fn test_regions_at_overlapping() {
+        let store = RegionStore::from_regions(vec![
+            make_region("outer", 2, 20),
+            make_region("inner", 5, 10),
+        ]);
+        assert_eq!(store.regions_at(1).len(), 0);
+        assert_eq!(store.regions_at(3).len(), 1); // outer only
+        assert_eq!(store.regions_at(7).len(), 2); // both
+        assert_eq!(store.regions_at(15).len(), 1); // outer only
+    }
+
+    #[test]
+    fn test_innermost_at() {
+        let store = RegionStore::from_regions(vec![
+            make_region("outer", 2, 20),
+            make_region("inner", 5, 10),
+        ]);
+        let inner = store.innermost_at(7).unwrap();
+        assert_eq!(inner.name, "inner");
+    }
+
+    #[test]
+    fn test_innermost_at_no_region() {
+        let store = RegionStore::from_regions(vec![make_region("A", 5, 10)]);
+        assert!(store.innermost_at(20).is_none());
+    }
+
+    #[test]
+    fn test_push_maintains_order() {
+        let mut store = RegionStore::new();
+        store.push(make_region("B", 10, 20));
+        store.push(make_region("A", 3, 8));
+        store.push(make_region("C", 15, 25));
+        assert_eq!(store.regions()[0].name, "A");
+        assert_eq!(store.regions()[1].name, "B");
+        assert_eq!(store.regions()[2].name, "C");
+    }
+
+    #[test]
+    fn test_empty_store() {
+        let store = RegionStore::new();
+        assert!(store.is_empty());
+        assert_eq!(store.regions_at(5).len(), 0);
+        assert!(store.innermost_at(5).is_none());
+    }
+
+    #[test]
+    fn test_timed_out_regions_included() {
+        let mut r = make_region("timeout", 5, 10);
+        r.timed_out = true;
+        let store = RegionStore::from_regions(vec![r]);
+        assert_eq!(store.regions_at(7).len(), 1);
+        assert!(store.regions_at(7)[0].timed_out);
+    }
+}


### PR DESCRIPTION
## Summary

Replace LogRecord tagging with RegionStore for efficient index-based queries, and make timeouts create regions instead of silently discarding.

### RegionStore
- Stores regions sorted by `start_index` for efficient lookup
- `regions_at(index)` — returns all overlapping regions (binary search)
- `innermost_at(index)` — returns shortest-span region (for gutter overlap)
- 7 unit tests

### Remove LogRecord Tagging
- Removed `tag_record()` function and `_region`/`_region_type`/`_region_pos` metadata
- `process_records` now takes `&[LogRecord]` (immutable) instead of `&mut [LogRecord]`
- Region data queried via RegionStore by index

### Timeout Creates Region
- Timed-out pending starts now create regions with `timed_out: true`
- New `timeout_reason` config field — template for timeout end reason
- Timed-out regions visible in Region Manager with `░` gutter marker
- 2 new tests (with/without timeout_reason)

### Gutter Updated
- Uses `innermost_at()` for overlap — shows innermost region marker
- `░` visual for timed-out regions

### Test Plan
All 643 tests pass (9 new).

Closes #368