### PR TITLE
feat: migrate Detail panel to panel framework

### DIFF
--- a/crates/scouty-tui/src/panel.rs
+++ b/crates/scouty-tui/src/panel.rs
@@ -6,6 +6,30 @@
 #[path = "panel_tests.rs"]
 mod panel_tests;
 
+/// Trait for panel implementations.
+///
+/// Each panel provides metadata (name, shortcut, height strategy) and
+/// rendering. Panels that need access to shared application state use
+/// `render_with_app` for rendering while still implementing the trait
+/// for registration and dispatch.
+pub trait Panel {
+    /// Display name for the tab bar (e.g. "Detail").
+    fn name(&self) -> &str;
+
+    /// Keyboard shortcut to open this panel directly (e.g. Some('\r') for Enter).
+    /// Returns `None` if no direct shortcut.
+    fn shortcut(&self) -> Option<char>;
+
+    /// Default height strategy for this panel.
+    fn default_height(&self) -> PanelHeight;
+
+    /// Whether this panel has content available to display.
+    fn is_available(&self) -> bool;
+
+    /// Called when the log table cursor changes to a new index.
+    fn on_log_cursor_changed(&mut self, index: usize);
+}
+
 /// Height strategy for a panel.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PanelHeight {

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
@@ -474,3 +474,28 @@ impl UiComponent for DetailPanelWidget {
         false
     }
 }
+
+impl crate::panel::Panel for DetailPanelWidget {
+    fn name(&self) -> &str {
+        "Detail"
+    }
+
+    fn shortcut(&self) -> Option<char> {
+        // Enter key opens the Detail panel (handled as KeyCode::Enter in main.rs)
+        Some('\r')
+    }
+
+    fn default_height(&self) -> crate::panel::PanelHeight {
+        crate::panel::PanelHeight::FitContent
+    }
+
+    fn is_available(&self) -> bool {
+        // Detail panel is always available when there are records
+        true
+    }
+
+    fn on_log_cursor_changed(&mut self, _index: usize) {
+        // Detail panel content auto-updates via App::selected_record(),
+        // so no explicit action is needed here.
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget_tests.rs
@@ -246,4 +246,41 @@ mod tests {
         };
         assert_eq!(content2, "hello world");
     }
+
+    // --- Panel trait tests ---
+
+    use crate::panel::{Panel, PanelHeight, PanelId};
+
+    #[test]
+    fn test_detail_panel_trait_name() {
+        let widget = DetailPanelWidget;
+        assert_eq!(Panel::name(&widget), "Detail");
+        assert_eq!(Panel::name(&widget), PanelId::Detail.name());
+    }
+
+    #[test]
+    fn test_detail_panel_trait_shortcut() {
+        let widget = DetailPanelWidget;
+        assert_eq!(widget.shortcut(), Some('\r'));
+    }
+
+    #[test]
+    fn test_detail_panel_trait_default_height() {
+        let widget = DetailPanelWidget;
+        assert_eq!(widget.default_height(), PanelHeight::FitContent);
+        assert_eq!(widget.default_height(), PanelId::Detail.default_height());
+    }
+
+    #[test]
+    fn test_detail_panel_trait_is_available() {
+        let widget = DetailPanelWidget;
+        assert!(widget.is_available());
+    }
+
+    #[test]
+    fn test_detail_panel_trait_on_cursor_changed() {
+        let mut widget = DetailPanelWidget;
+        // Should not panic
+        widget.on_log_cursor_changed(42);
+    }
 }


### PR DESCRIPTION
## Summary

Define a `Panel` trait in the panel module and implement it for `DetailPanelWidget`, formally registering the Detail panel as a panel framework participant.

**Note:** This PR is based on the `feature/panel-framework` branch (PR #382). Please merge #382 first.

### Changes

- **`panel.rs`**: Added `Panel` trait with methods: `name()`, `shortcut()`, `default_height()`, `is_available()`, `on_log_cursor_changed()`
- **`detail_panel_widget.rs`**: Implemented `Panel` trait for `DetailPanelWidget`
  - Name: "Detail", Shortcut: Enter, Height: FitContent
  - `is_available()` returns true (always available when records exist)
  - `on_log_cursor_changed()` is a no-op (content auto-updates via `App::selected_record()`)
- **Tests**: Added 5 new tests verifying trait implementation and consistency with `PanelId` metadata

### Behavior

Detail panel works identically to before. Tab bar shows "Detail" tab. All existing tests pass plus 5 new ones.

### Test Plan

- `cargo test -p scouty-tui` — all 314 tests pass
- `cargo clippy -p scouty-tui -- -D warnings` — clean

Closes #379