### PR TITLE
fix: detail panel title and Ctrl+arrow focus switching

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -517,13 +517,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                         // Detail panel tree navigation (when focused)
                         if app.detail_open && app.detail_tree_focus {
-                            use crossterm::event::KeyCode;
+                            use crossterm::event::{KeyCode, KeyModifiers};
+                            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
                             let handled = match key.code {
-                                KeyCode::Char('j') | KeyCode::Down => {
+                                KeyCode::Char('j') | KeyCode::Down if !ctrl => {
                                     app.detail_tree_move_down();
                                     true
                                 }
-                                KeyCode::Char('k') | KeyCode::Up => {
+                                KeyCode::Char('k') | KeyCode::Up if !ctrl => {
                                     app.detail_tree_move_up();
                                     true
                                 }
@@ -577,19 +578,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             && app.panel_state.active == crate::panel::PanelId::Region
                         {
                             use crate::ui::widgets::region_panel_widget::RegionPanelWidget;
-                            use crossterm::event::KeyCode;
+                            use crossterm::event::{KeyCode, KeyModifiers};
 
                             let entries = RegionPanelWidget::build_entries(&app);
                             let max_cursor = entries.len().saturating_sub(1);
+                            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
                             let handled = match key.code {
-                                KeyCode::Char('j') | KeyCode::Down => {
+                                KeyCode::Char('j') | KeyCode::Down if !ctrl => {
                                     if app.region_manager_cursor < max_cursor {
                                         app.region_manager_cursor += 1;
                                     }
                                     true
                                 }
-                                KeyCode::Char('k') | KeyCode::Up => {
+                                KeyCode::Char('k') | KeyCode::Up if !ctrl => {
                                     if app.region_manager_cursor > 0 {
                                         app.region_manager_cursor -= 1;
                                     }

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_widget.rs
@@ -274,7 +274,7 @@ impl DetailPanelWidget {
         let left_title = if has_expanded {
             " Expanded "
         } else {
-            " Message "
+            " Log Content "
         };
         let left_border_style = if app.detail_tree_focus && has_expanded {
             theme
@@ -451,7 +451,7 @@ impl DetailPanelWidget {
             }
         } else {
             lines.push(Line::styled(
-                "Message:",
+                "Log Content:",
                 theme.detail_panel.section_header.to_style(),
             ));
             let content = if record.message.is_empty() {


### PR DESCRIPTION
## Summary

Fix two bugs:

### Bug 1: Detail panel title (Closes #386)
Left panel title shows "Message" instead of "Log Content" per spec. Changed in both split and single-column layouts.

### Bug 2: Ctrl+arrow focus switching (Closes #387)
`Ctrl+↑/↓/←/→` panel focus switching doesn't work when detail tree or region panel is focused. The key handlers matched `KeyCode::Up/Down` without checking for Ctrl modifier, consuming the key before the panel system handler. Added `!ctrl` guards.

### Test Plan
- `cargo test -p scouty-tui` — 331 tests pass
- `cargo clippy -p scouty-tui -- -D warnings` — clean

Closes #386, Closes #387