### PR TITLE
[PM Spec] Panel tab title highlights when panel has focus

### DIFF
--- a/crates/scouty-tui/spec/panel-system.md
+++ b/crates/scouty-tui/spec/panel-system.md
@@ -74,6 +74,7 @@ Expanded:   ▾ Detail │ Region
 - Selected panel name is highlighted (e.g., reverse video or bold)
 - Inactive panel names displayed normally
 - Tab bar is always visible (regardless of collapse/expand state)
+- **Focus indicator:** When the panel area has focus (as opposed to log table), the active panel's tab title uses a distinct highlight style (e.g., brighter color or underline) to clearly indicate that keyboard input is directed to the panel, not the log table
 
 #### Focus Model
 


### PR DESCRIPTION
When focus moves to a panel (via Ctrl+Down, Enter, r, etc.), the active panel's tab title uses a distinct highlight style to clearly indicate keyboard input is directed to the panel, not the log table.

This provides a clear visual affordance for the current focus state.