### PR TITLE
Add runtime tracing for key events and state changes

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -485,10 +485,12 @@ impl App {
         ssh_connect_timeout: u32,
         ssh_keepalive_interval: u32,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        tracing::info!(file_count = paths.len(), "loading files");
         let mut store = scouty::store::LogStore::new();
         let mut record_id: u64 = 0;
 
         for path in paths {
+            tracing::info!(%path, "loading file");
             if is_ssh_url(path) {
                 let url = SshUrl::parse(path).map_err(|e| {
                     Box::<dyn std::error::Error>::from(format!("Invalid SSH URL '{}': {}", path, e))
@@ -546,6 +548,7 @@ impl App {
         store.compact_ooo();
         let records: Vec<Arc<LogRecord>> = store.iter_arc().cloned().collect();
         let total_records = records.len();
+        tracing::info!(total_records, "files loaded, records parsed");
         let filtered_indices: Vec<usize> = (0..records.len()).collect();
         let col_widths = Self::compute_col_widths(&records, &filtered_indices);
 
@@ -878,7 +881,9 @@ impl App {
             self.filter_error = None;
             return;
         }
-        match expr::parse(self.filter_input.value()) {
+        let filter_text = self.filter_input.value().to_string();
+        tracing::info!(filter = %filter_text, "applying filter");
+        match expr::parse(&filter_text) {
             Ok(parsed_expr) => {
                 self.filters.push(FilterEntry {
                     label: self.filter_input.value().to_string(),
@@ -1249,6 +1254,7 @@ impl App {
     /// Clear all filters.
     #[instrument(skip(self))]
     pub fn clear_filters(&mut self) {
+        tracing::info!("clearing all filters");
         self.filters.clear();
         self.reapply_filters();
     }
@@ -1262,6 +1268,7 @@ impl App {
             self.clear_search();
             return;
         }
+        tracing::info!(pattern = %self.search_input.value(), "executing search");
         let pattern = match regex::RegexBuilder::new(self.search_input.value())
             .case_insensitive(true)
             .build()
@@ -1348,8 +1355,18 @@ impl App {
             let id = self.records[ri].id;
             if !self.bookmarks.remove(&id) {
                 self.bookmarks.insert(id);
+                tracing::debug!(
+                    record_id = id,
+                    total = self.bookmarks.len(),
+                    "bookmark added"
+                );
                 self.set_status(format!("Bookmark added (total: {})", self.bookmarks.len()));
             } else {
+                tracing::debug!(
+                    record_id = id,
+                    total = self.bookmarks.len(),
+                    "bookmark removed"
+                );
                 self.set_status(format!(
                     "Bookmark removed (total: {})",
                     self.bookmarks.len()
@@ -1611,6 +1628,7 @@ impl App {
 
     pub fn toggle_detail(&mut self) {
         self.detail_open = !self.detail_open;
+        tracing::debug!(detail_open = self.detail_open, "toggled detail panel");
         if self.detail_open {
             self.panel_state.open(crate::panel::PanelId::Detail);
             // Auto-focus tree if expanded data is available

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -562,6 +562,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 app.clear_status();
 
+                tracing::debug!(
+                    key_code = ?key.code,
+                    modifiers = ?key.modifiers,
+                    input_mode = ?app.input_mode,
+                    "key event"
+                );
+
                 match app.input_mode {
                     InputMode::Normal => {
                         use keybinding::Action;
@@ -777,6 +784,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                         if !key_handled {
                             if let Some(action) = keymap.action(&key) {
+                                tracing::debug!(?action, "action dispatched");
                                 match action {
                                     Action::Quit => {
                                         should_break = true;

--- a/crates/scouty-tui/src/panel.rs
+++ b/crates/scouty-tui/src/panel.rs
@@ -137,27 +137,32 @@ impl PanelState {
     pub fn focus_panel(&mut self) {
         self.expanded = true;
         self.focus = PanelFocus::PanelContent;
+        tracing::debug!(active = ?self.active, "panel focus: entered panel content");
     }
 
     /// Focus back to log table.
     pub fn focus_log_table(&mut self) {
         self.focus = PanelFocus::LogTable;
+        tracing::debug!("panel focus: returned to log table");
     }
 
     /// Switch to next panel tab.
     pub fn next_panel(&mut self) {
         self.active = self.active.next();
+        tracing::debug!(active = ?self.active, "panel: switched to next tab");
     }
 
     /// Switch to previous panel tab.
     pub fn prev_panel(&mut self) {
         self.active = self.active.prev();
+        tracing::debug!(active = ?self.active, "panel: switched to prev tab");
     }
 
     /// Toggle maximize.
     pub fn toggle_maximize(&mut self) {
         if self.expanded {
             self.maximized = !self.maximized;
+            tracing::debug!(maximized = self.maximized, "panel: toggled maximize");
         }
     }
 

--- a/crates/scouty-tui/src/ui/windows/save_dialog_window.rs
+++ b/crates/scouty-tui/src/ui/windows/save_dialog_window.rs
@@ -69,6 +69,7 @@ impl SaveDialogWindow {
     pub fn execute_save(app: &App, path: &str, format: ExportFormat) -> String {
         use std::io::{BufWriter, Write};
 
+        tracing::info!(%path, ?format, records = app.filtered_indices.len(), "saving export");
         let count = app.filtered_indices.len();
 
         let file = match std::fs::File::create(path) {


### PR DESCRIPTION
## Summary

With `--log debug`, the log file now captures meaningful runtime events:

### Key events
- Every key press: key code, modifiers, current input mode
- Action dispatch: which keybinding action was triggered

### Panel operations
- Focus changes: enter/leave panel content, return to log table
- Tab switching: next/prev panel
- Maximize toggle
- Detail panel open/close

### Filter & Search
- Filter apply (with expression text) and clear
- Search execution (with pattern)

### File operations
- File loading: per-file and summary with total record count
- Save/export: path, format, record count

### Other
- Bookmark add/remove
- Toggle detail

All 331 tests pass ✅

Closes #403