### PR TITLE
Fix Tab from Log Table skipping Detail panel

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -627,6 +627,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         if !key_handled
                             && key.code == crossterm::event::KeyCode::Tab
                             && app.detail_open
+                            && app.panel_state.has_focus()
+                            && app.panel_state.active == crate::panel::PanelId::Detail
                         {
                             if let Some(record) = app.selected_record() {
                                 if record.expanded.as_ref().is_some_and(|e| !e.is_empty()) {


### PR DESCRIPTION
Closes #415

## Problem
Tab from Log Table was skipping Detail and going directly to the last active panel (Region).

## Root Cause
The detail tree Tab handler (line 627) was intercepting Tab keypresses whenever `detail_open` was true, regardless of current focus layer. When Tab was pressed from Log Table:
1. `detail_open` was still true (set when Detail was previously opened via Enter)
2. The tree focus toggle handler caught the Tab keypress
3. `key_handled` was set to true, preventing the panel system Tab handler from running
4. Result: Tab from Log Table toggled tree focus instead of cycling to Detail

## Fix
Added `app.panel_state.has_focus()` and `app.panel_state.active == PanelId::Detail` guards to the detail tree Tab handler, so it only fires when the Detail panel actually has keyboard focus.

## Testing
- All 334 tests pass
- cargo clippy clean