### PR TITLE
Fix Tab/Shift+Tab panel cycling blocked by tree focus

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -608,10 +608,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     app.detail_tree_quick_filter();
                                     true
                                 }
-                                KeyCode::Tab => {
-                                    app.detail_tree_focus = false;
-                                    true
-                                }
                                 KeyCode::Esc => {
                                     app.detail_tree_focus = false;
                                     true
@@ -620,21 +616,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             };
                             if handled {
                                 key_handled = true;
-                            }
-                        }
-
-                        // Tab toggles tree focus when detail panel is open with expanded data
-                        if !key_handled
-                            && key.code == crossterm::event::KeyCode::Tab
-                            && app.detail_open
-                            && app.panel_state.has_focus()
-                            && app.panel_state.active == crate::panel::PanelId::Detail
-                        {
-                            if let Some(record) = app.selected_record() {
-                                if record.expanded.as_ref().is_some_and(|e| !e.is_empty()) {
-                                    app.detail_tree_focus = !app.detail_tree_focus;
-                                    key_handled = true;
-                                }
                             }
                         }
 
@@ -742,15 +723,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     if key.modifiers.is_empty() && app.panel_state.expanded =>
                                 {
                                     if app.panel_state.focus == crate::panel::PanelFocus::LogTable {
-                                        // Always start at first panel (Detail)
                                         app.panel_state.active = crate::panel::PanelId::all()[0];
                                         app.panel_state.focus_panel();
+                                        tracing::debug!(active = ?app.panel_state.active, "Tab: log table → panel");
                                     } else {
                                         let all = crate::panel::PanelId::all();
                                         if app.panel_state.active == *all.last().unwrap() {
+                                            app.detail_tree_focus = false;
                                             app.panel_state.focus_log_table();
+                                            tracing::debug!("Tab: last panel → log table");
                                         } else {
+                                            app.detail_tree_focus = false;
                                             app.panel_state.next_panel();
+                                            tracing::debug!(active = ?app.panel_state.active, "Tab: → next panel");
                                         }
                                     }
                                     true
@@ -758,16 +743,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 // Shift+Tab cycles backward: Log Table → Region → Detail → Log Table
                                 KeyCode::BackTab if app.panel_state.expanded => {
                                     if app.panel_state.focus == crate::panel::PanelFocus::LogTable {
-                                        // Always start at last panel (Region)
                                         let all = crate::panel::PanelId::all();
                                         app.panel_state.active = *all.last().unwrap();
                                         app.panel_state.focus_panel();
+                                        tracing::debug!(active = ?app.panel_state.active, "Shift+Tab: log table → panel");
                                     } else {
                                         let all = crate::panel::PanelId::all();
                                         if app.panel_state.active == all[0] {
+                                            app.detail_tree_focus = false;
                                             app.panel_state.focus_log_table();
+                                            tracing::debug!("Shift+Tab: first panel → log table");
                                         } else {
+                                            app.detail_tree_focus = false;
                                             app.panel_state.prev_panel();
+                                            tracing::debug!(active = ?app.panel_state.active, "Shift+Tab: → prev panel");
                                         }
                                     }
                                     true

--- a/crates/scouty-tui/src/panel_tests.rs
+++ b/crates/scouty-tui/src/panel_tests.rs
@@ -205,4 +205,39 @@ mod tests {
         assert_eq!(state.active, PanelId::Detail);
         assert_eq!(state.focus, PanelFocus::PanelContent);
     }
+
+    /// Verify Shift+Tab direction: Log Table → Region → Detail → Log Table
+    #[test]
+    fn test_shift_tab_reverse_direction() {
+        let mut state = PanelState::default();
+        state.open(PanelId::Detail);
+        state.focus_log_table();
+
+        // Shift+Tab from log table → last panel (Region)
+        let all = PanelId::all();
+        state.active = *all.last().unwrap();
+        state.focus_panel();
+        assert_eq!(state.active, PanelId::Region);
+
+        // Shift+Tab from Region → prev panel (Detail)
+        state.prev_panel();
+        assert_eq!(state.active, PanelId::Detail);
+
+        // Shift+Tab from Detail (first) → log table
+        assert_eq!(state.active, all[0]);
+        state.focus_log_table();
+        assert_eq!(state.focus, PanelFocus::LogTable);
+
+        // Verify direction is opposite to Tab forward
+        // Tab forward: LogTable → Detail → Region → LogTable
+        // Shift+Tab:   LogTable → Region → Detail → LogTable
+        state.active = *all.last().unwrap(); // Region
+        state.focus_panel();
+        state.prev_panel();
+        assert_eq!(
+            state.active,
+            PanelId::Detail,
+            "Shift+Tab from Region should go to Detail"
+        );
+    }
 }

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -251,24 +251,13 @@ impl StatusBarWidget {
             } else {
                 let shortcuts: &[(&str, &str)] = if panel_focused {
                     match app.panel_state.active {
-                        crate::panel::PanelId::Detail => {
-                            if app.detail_tree_focus {
-                                &[
-                                    ("Tab", "Exit Tree"),
-                                    ("Esc", "Exit Tree"),
-                                    ("Ctrl+↑", "Back"),
-                                    ("z", "Maximize"),
-                                ]
-                            } else {
-                                &[
-                                    ("Tab", "Next Tab"),
-                                    ("Ctrl+↑", "Back"),
-                                    ("z", "Maximize"),
-                                    ("Esc", "Close"),
-                                    ("?", "Help"),
-                                ]
-                            }
-                        }
+                        crate::panel::PanelId::Detail => &[
+                            ("Tab", "Next Tab"),
+                            ("Ctrl+↑", "Back"),
+                            ("z", "Maximize"),
+                            ("Esc", "Close"),
+                            ("?", "Help"),
+                        ],
                         crate::panel::PanelId::Region => &[
                             ("j/k", "Navigate"),
                             ("Tab", "Next Tab"),


### PR DESCRIPTION
## Root Cause

Detail panel's tree focus toggle intercepted Tab before the panel cycling handler. Tab got stuck on Detail instead of advancing to Region.

## Changes

- Remove Tab from tree focus toggle (use Esc to exit tree focus instead)
- Remove standalone tree focus toggle handler that intercepted Tab
- Add tracing to Tab/Shift+Tab cycle transitions
- Clear `detail_tree_focus` when cycling away from Detail
- Simplify status bar hints (no more tree-specific Tab hints)
- Added `test_shift_tab_reverse_direction` test

**Cycles:**
- Tab: Log Table → Detail → Region → Log Table ✅
- Shift+Tab: Log Table → Region → Detail → Log Table ✅

335 tests pass ✅

Closes #419