### PR TITLE
Add table header unfocused style when panel has focus

### DIFF
--- a/crates/scouty-tui/src/config/theme.rs
+++ b/crates/scouty-tui/src/config/theme.rs
@@ -149,6 +149,7 @@ impl Default for SeparatorStyle {
 #[serde(default)]
 pub struct TableTheme {
     pub header: StyleEntry,
+    pub header_unfocused: StyleEntry,
     pub selected: StyleEntry,
     pub selected_search: StyleEntry,
     pub selected_highlight: StyleEntry,
@@ -166,6 +167,10 @@ impl Default for TableTheme {
                 bg: Some(ThemeColor(Color::Rgb(30, 42, 56))),    // dark slate #1E2A38
                 bold: Some(true),
             },
+            header_unfocused: StyleEntry::fg_bg(
+                Color::Rgb(107, 123, 141), // #6B7B8D
+                Color::Rgb(30, 42, 56),
+            ),
             selected: StyleEntry::bg(Color::Rgb(42, 63, 85)), // steel blue #2A3F55
             selected_search: StyleEntry::bg(Color::Rgb(120, 120, 0)),
             selected_highlight: StyleEntry::bg(Color::Rgb(40, 60, 80)),
@@ -438,6 +443,7 @@ impl Theme {
             },
             table: TableTheme {
                 header: StyleEntry::fg_bg(Rgb(180, 180, 180), Rgb(30, 30, 40)),
+                header_unfocused: StyleEntry::fg_bg(Rgb(85, 85, 85), Rgb(30, 30, 40)),
                 selected: StyleEntry::bg(Rgb(40, 40, 55)),
                 ..TableTheme::default()
             },
@@ -511,6 +517,7 @@ impl Theme {
             },
             table: TableTheme {
                 header: StyleEntry::fg_bg(Rgb(30, 30, 40), Rgb(220, 220, 230)),
+                header_unfocused: StyleEntry::fg_bg(Rgb(153, 153, 153), Rgb(220, 220, 230)),
                 selected: StyleEntry::fg_bg(Black, Rgb(200, 210, 230)),
                 ..TableTheme::default()
             },
@@ -596,6 +603,7 @@ impl Theme {
             },
             table: TableTheme {
                 header: StyleEntry::fg_bg(base1, base02),
+                header_unfocused: StyleEntry::fg_bg(Rgb(101, 123, 131), base02), // #657B83
                 selected: StyleEntry::fg_bg(base1, base02),
                 ..TableTheme::default()
             },
@@ -689,6 +697,7 @@ impl Theme {
                     bg: Some(ThemeColor(dark_wine)),
                     bold: Some(true),
                 },
+                header_unfocused: StyleEntry::fg_bg(Rgb(107, 74, 94), dark_wine), // #6B4A5E
                 selected: StyleEntry::bg(selected_bg),
                 separator: SeparatorStyle {
                     fg: Some(ThemeColor(separator_fg)),

--- a/crates/scouty-tui/src/config/theme_tests.rs
+++ b/crates/scouty-tui/src/config/theme_tests.rs
@@ -51,4 +51,22 @@ mod tests {
         let theme = Theme::from_yaml(yaml).unwrap();
         assert_eq!(theme.table.separator.separator_char(), "|");
     }
+
+    #[test]
+    fn all_presets_have_header_unfocused() {
+        let themes = vec![
+            ("default", Theme::default()),
+            ("dark", Theme::dark()),
+            ("light", Theme::light()),
+            ("solarized", Theme::solarized()),
+            ("landmine", Theme::landmine()),
+        ];
+        for (name, theme) in &themes {
+            assert!(
+                theme.table.header_unfocused.fg.is_some(),
+                "preset '{}' missing header_unfocused fg",
+                name
+            );
+        }
+    }
 }

--- a/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/log_table_widget.rs
@@ -67,6 +67,11 @@ pub struct LogTableWidget;
 impl LogTableWidget {
     pub fn render_with_app(&self, frame: &mut Frame, area: Rect, app: &App) {
         let theme = &app.theme;
+        tracing::trace!(
+            panel_focused = app.panel_state.expanded
+                && app.panel_state.focus == crate::panel::PanelFocus::PanelContent,
+            "rendering log table header"
+        );
         let visible = app.visible_records();
         let cw = &app.col_widths;
         let vis_cols = app.column_config.visible_columns();
@@ -123,7 +128,14 @@ impl LogTableWidget {
             }
         }));
 
-        let header = Row::new(header_cells).style(theme.table.header.to_style());
+        let panel_has_focus = app.panel_state.expanded
+            && app.panel_state.focus == crate::panel::PanelFocus::PanelContent;
+        let header_style = if panel_has_focus {
+            theme.table.header_unfocused.to_style()
+        } else {
+            theme.table.header.to_style()
+        };
+        let header = Row::new(header_cells).style(header_style);
 
         let rows: Vec<Row> = visible
             .iter()


### PR DESCRIPTION
When panel content has focus, the log table header dims to `header_unfocused` color, creating a consistent visual language with the panel tab highlight.

## Changes
- Added `header_unfocused` field to `TableTheme`
- All 5 theme presets: default (#6B7B8D), dark (#555555), light (#999999), solarized (#657B83), landmine (#6B4A5E)
- Log table rendering checks panel focus state for header style
- Added tracing + test

336 tests pass ✅

Closes #422