### PR TITLE
[PM Spec] Table header focused color matches panel tab focused style

### DIFF
--- a/crates/scouty-tui/spec/theme.md
+++ b/crates/scouty-tui/spec/theme.md
@@ -38,7 +38,7 @@ log_levels:
   trace: { fg: "#5C5C5C" }          # Dark gray
 
 table:
-  header: { fg: "#B8C4CE", bg: "#1E2A38", bold: true }   # Light steel text on dark slate — when log table has focus
+  header: { fg: "#1B2838", bg: "#4FC3F7", bold: true }   # Accent color bg — matches panel_tab.focused style when log table has focus
   header_unfocused: { fg: "#6B7B8D", bg: "#1B2838" }     # Muted/gray — when focus is on a panel (matches panel_tab.unfocused style)
   selected: { bg: "#2A3F55" }       # Steel blue highlight — visible but not harsh
   alternating: { bg: "#0D1117" }    # Very subtle dark shade (GitHub dark style)
@@ -121,8 +121,8 @@ general:
 
 | Area | default | dark | light | solarized | landmine |
 |------|---------|------|-------|-----------|----------|
-| Header fg | ![](https://placehold.co/16x16/B8C4CE/B8C4CE.png) `#B8C4CE` bold | ![](https://placehold.co/16x16/999999/999999.png) `#999999` bold | ![](https://placehold.co/16x16/333333/333333.png) `#333333` bold | ![](https://placehold.co/16x16/586E75/586E75.png) `#586E75` bold | ![](https://placehold.co/16x16/F5A0C0/F5A0C0.png) `#F5A0C0` bold |
-| Header bg | ![](https://placehold.co/16x16/1E2A38/1E2A38.png) `#1E2A38` | ![](https://placehold.co/16x16/1A1A1A/1A1A1A.png) `#1A1A1A` | ![](https://placehold.co/16x16/E8E8E8/E8E8E8.png) `#E8E8E8` | ![](https://placehold.co/16x16/073642/073642.png) `#073642` | ![](https://placehold.co/16x16/1A0A14/1A0A14.png) `#1A0A14` |
+| Header fg | ![](https://placehold.co/16x16/1B2838/1B2838.png) `#1B2838` bold | ![](https://placehold.co/16x16/0D0D0D/0D0D0D.png) `#0D0D0D` bold | ![](https://placehold.co/16x16/FFFFFF/FFFFFF.png) `white` bold | ![](https://placehold.co/16x16/FDF6E3/FDF6E3.png) `#FDF6E3` bold | ![](https://placehold.co/16x16/0D060B/0D060B.png) `#0D060B` bold |
+| Header bg | ![](https://placehold.co/16x16/4FC3F7/4FC3F7.png) `#4FC3F7` | ![](https://placehold.co/16x16/6699CC/6699CC.png) `#6699CC` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` | ![](https://placehold.co/16x16/268BD2/268BD2.png) `#268BD2` | ![](https://placehold.co/16x16/E8577E/E8577E.png) `#E8577E` |
 | Header unfocused fg/bg | ![](https://placehold.co/16x16/6B7B8D/6B7B8D.png) `#6B7B8D` / ![](https://placehold.co/16x16/1B2838/1B2838.png) `#1B2838` | ![](https://placehold.co/16x16/555555/555555.png) `#555555` / ![](https://placehold.co/16x16/1A1A1A/1A1A1A.png) `#1A1A1A` | ![](https://placehold.co/16x16/999999/999999.png) `#999999` / ![](https://placehold.co/16x16/E8E8E8/E8E8E8.png) `#E8E8E8` | ![](https://placehold.co/16x16/657B83/657B83.png) `#657B83` / ![](https://placehold.co/16x16/073642/073642.png) `#073642` | ![](https://placehold.co/16x16/6B4A5E/6B4A5E.png) `#6B4A5E` / ![](https://placehold.co/16x16/1A0A14/1A0A14.png) `#1A0A14` |
 | Selected bg | ![](https://placehold.co/16x16/2A3F55/2A3F55.png) `#2A3F55` | ![](https://placehold.co/16x16/2A2A2A/2A2A2A.png) `#2A2A2A` | ![](https://placehold.co/16x16/D0E4F7/D0E4F7.png) `#D0E4F7` | ![](https://placehold.co/16x16/073642/073642.png) `#073642` | ![](https://placehold.co/16x16/2D1028/2D1028.png) `#2D1028` |
 | Alternating bg | ![](https://placehold.co/16x16/0D1117/0D1117.png) `#0D1117` | ![](https://placehold.co/16x16/111111/111111.png) `#111111` | ![](https://placehold.co/16x16/F8F8F8/F8F8F8.png) `#F8F8F8` | ![](https://placehold.co/16x16/002B36/002B36.png) `#002B36` | ![](https://placehold.co/16x16/0D060B/0D060B.png) `#0D060B` |
@@ -197,3 +197,4 @@ general:
 | 2026-02-24 | Added `landmine` theme (地雷系 Jirai Kei: black + pink); separator char now themeable |
 | 2026-02-28 | Added `panel_tab` theme section: focused (accent), unfocused (gray) styles for all 5 presets |
 | 2026-02-28 | Added `table.header_unfocused`: table header goes gray when focus moves to panel |
+| 2026-02-28 | Table header focused color now matches `panel_tab.focused` (accent bg) for consistent focus visual language |


### PR DESCRIPTION
Log table header focused color should match panel_tab.focused for visual consistency.

**Before:** header used a muted dark slate bg (#1E2A38) — different from panel tab accent
**After:** header uses accent bg (#4FC3F7) — same as panel_tab.focused

Visual rule: focused area = accent bg, unfocused area = muted gray. Applies to both table header and panel tabs.