### PR TITLE
Address PR #426 review comments

### DIFF
--- a/crates/scouty-tui/src/config/theme.rs
+++ b/crates/scouty-tui/src/config/theme.rs
@@ -445,7 +445,7 @@ impl Theme {
                 header: StyleEntry {
                     fg: Some(ThemeColor(Black)),
                     bg: Some(ThemeColor(Rgb(100, 160, 180))),
-                    bold: Some(true),
+                    bold: None,
                 },
                 header_unfocused: StyleEntry::fg_bg(Rgb(85, 85, 85), Rgb(30, 30, 40)),
                 selected: StyleEntry::bg(Rgb(40, 40, 55)),
@@ -523,7 +523,7 @@ impl Theme {
                 header: StyleEntry {
                     fg: Some(ThemeColor(White)),
                     bg: Some(ThemeColor(Rgb(0, 120, 150))),
-                    bold: Some(true),
+                    bold: None,
                 },
                 header_unfocused: StyleEntry::fg_bg(Rgb(153, 153, 153), Rgb(220, 220, 230)),
                 selected: StyleEntry::fg_bg(Black, Rgb(200, 210, 230)),
@@ -613,7 +613,7 @@ impl Theme {
                 header: StyleEntry {
                     fg: Some(ThemeColor(base03)),
                     bg: Some(ThemeColor(blue)),
-                    bold: Some(true),
+                    bold: None,
                 },
                 header_unfocused: StyleEntry::fg_bg(Rgb(101, 123, 131), base02), // #657B83
                 selected: StyleEntry::fg_bg(base1, base02),

--- a/crates/scouty-tui/src/config/theme_tests.rs
+++ b/crates/scouty-tui/src/config/theme_tests.rs
@@ -54,14 +54,8 @@ mod tests {
 
     #[test]
     fn all_presets_have_header_unfocused() {
-        let themes = vec![
-            ("default", Theme::default()),
-            ("dark", Theme::dark()),
-            ("light", Theme::light()),
-            ("solarized", Theme::solarized()),
-            ("landmine", Theme::landmine()),
-        ];
-        for (name, theme) in &themes {
+        for name in Theme::builtin_names() {
+            let theme = Theme::builtin(name).unwrap();
             assert!(
                 theme.table.header_unfocused.fg.is_some(),
                 "preset '{}' missing header_unfocused fg",
@@ -72,14 +66,8 @@ mod tests {
 
     #[test]
     fn all_presets_header_matches_panel_tab_focused() {
-        let themes = vec![
-            ("default", Theme::default()),
-            ("dark", Theme::dark()),
-            ("light", Theme::light()),
-            ("solarized", Theme::solarized()),
-            ("landmine", Theme::landmine()),
-        ];
-        for (name, theme) in &themes {
+        for name in Theme::builtin_names() {
+            let theme = Theme::builtin(name).unwrap();
             assert_eq!(
                 theme.table.header.fg, theme.panel_tab.focused.fg,
                 "preset '{}': table.header.fg should match panel_tab.focused.fg",


### PR DESCRIPTION
Follow-up to PR #426 review comments:

1. **Remove unintended bold** from dark/light/solarized table header — previously these used `StyleEntry::fg_bg()` (no bold), PR #426 accidentally added `bold: Some(true)`
2. **Use `builtin_names()`** in theme tests instead of hardcoded preset list — auto-covers future presets

337 tests pass ✅