### PR TITLE
[PM Spec] Migrate Statistics from overlay to panel system as third tab

### DIFF
--- a/crates/scouty-tui/spec/panel-system.md
+++ b/crates/scouty-tui/spec/panel-system.md
@@ -48,7 +48,7 @@ The detail panel and region UI (region manager + density chart) currently have i
 │                                                       │
 │                    Log Table                           │
 │                                                       │
-├─── [Detail] ── [Region] ─────────────────────────────┤  ← Panel Tab Bar (only this line when collapsed)
+├─── [Detail] ── [Region] ── [Stats] ─────────────────────┤  ← Panel Tab Bar (only this line when collapsed)
 │                                                       │
 │              Active Panel Content                     │
 │                                                       │
@@ -59,7 +59,7 @@ The detail panel and region UI (region manager + density chart) currently have i
 ```
 
 - Panel area sits between the log table and the status bar
-- **Collapsed:** only the panel tab bar is visible (one line height), showing tab names like `[Detail] [Region]` with the selected tab highlighted
+- **Collapsed:** only the panel tab bar is visible (one line height), showing tab names like `[Detail] [Region] [Stats]` with the selected tab highlighted
 - **Expanded:** tab bar + panel content area; each panel has its own default height (see individual panel definitions)
 - Only one panel is expanded at a time
 

--- a/crates/scouty-tui/spec/stats.md
+++ b/crates/scouty-tui/spec/stats.md
@@ -1,15 +1,20 @@
-# Stats Summary
+# Stats Panel
 
 ## Overview
 
-A statistics overlay providing a quick overview of log data distribution: level breakdown, top components, time range, and record counts.
-
+A statistics panel providing a quick overview of log data distribution: level breakdown, top components, time range, and record counts. Part of the [panel system](panel-system.md).
 
 ## Design
 
-### Stats Overlay (`S`)
+### Panel Integration
 
-Centered popup (similar to Help window) showing:
+**Tab name:** `Stats`
+**Shortcut:** `S` (opens panel and switches to Stats tab; if already active, closes panel)
+**Default height:** `Percentage(40)` (same as Region panel)
+
+Tab order: `[Detail] [Region] [Stats]`
+
+### Stats Content
 
 **Level Distribution** — count, percentage, and horizontal bar chart:
 ```
@@ -28,7 +33,14 @@ DEBUG: 4,012 (30.7%) ████████████████
 
 ### Data Source
 
-Statistics are based on current `filtered_indices` (not full dataset). Reopening after filter change shows updated stats.
+Statistics are based on current `filtered_indices` (not full dataset). Switching to the Stats tab after a filter change shows updated stats.
+
+### Status Bar Hints
+
+When Stats panel has focus:
+```
+[STATS] Tab: Next Tab │ Ctrl+↑: Back │ z: Maximize │ Esc: Close
+```
 
 ### P1: Top Source Files
 
@@ -39,3 +51,4 @@ When multiple files loaded, show per-file record count.
 | Date | Change |
 |------|--------|
 | 2026-02-22 | Stats summary overlay with level distribution, top components |
+| 2026-02-28 | Migrated from overlay to panel system as third panel tab |

--- a/crates/scouty-tui/spec/status-bar.md
+++ b/crates/scouty-tui/spec/status-bar.md
@@ -100,6 +100,11 @@ Shortcut hints are **context-sensitive** — they update based on current focus:
 [REGION] j/k: Navigate │ Tab: Next Tab │ Ctrl+↑: Back │ z: Maximize │ Esc: Close
 ```
 
+**Stats Panel focus:**
+```
+[STATS] Tab: Next Tab │ Ctrl+↑: Back │ z: Maximize │ Esc: Close
+```
+
 When focus switches (e.g., `Ctrl+↓` to enter panel, `Tab` to switch panel, `Ctrl+↑` to return to log table), the status bar line 2 immediately updates to show the relevant shortcuts for the new context.
 
 **Mode B — Input mode:**
@@ -145,3 +150,4 @@ Navigation (j/k/PageUp/PageDown/g/G) does **not** trigger recomputation. Only th
 | 2026-02-23 | Time per column snaps up to standard intervals (5/15/30 for s and m) |
 | 2026-02-24 | Density chart level/highlight selector (d/D keys) |
 | 2026-02-28 | Status bar line 2 shows context-sensitive shortcuts based on current focus (log table / detail panel / region panel) |
+| 2026-02-28 | Added Stats panel focus hints `[STATS]` |


### PR DESCRIPTION
Move Statistics from a centered overlay popup to the panel system as the third panel tab.

**Tab order:** `[Detail] [Region] [Stats]`

- **Shortcut:** `S` toggles Stats panel (open/close)
- **Default height:** `Percentage(40)`
- **Content:** Level distribution, top components, time range, record counts (same as before)
- **Data source:** Based on current `filtered_indices`, updates on filter change
- **Tab cycling:** Tab/Shift+Tab now cycles through 3 panels + log table
- **Status bar:** `[STATS] Tab: Next Tab │ Ctrl+↑: Back │ z: Maximize │ Esc: Close`