### PR TITLE
Add UI architecture Phase 1: Window/Widget traits, WindowStack, FocusManager

### DIFF
--- a/crates/scouty-tui/src/ui/framework.rs
+++ b/crates/scouty-tui/src/ui/framework.rs
@@ -1,0 +1,509 @@
+//! UI Architecture — Window Stack + Widget Tree framework.
+//!
+//! Phase 1: Core types only, no migration of existing code.
+//! See spec: `crates/scouty-tui/spec/ui-architecture.md`
+
+// Phase 1: framework is additive-only, not yet used by existing code.
+#![allow(dead_code)]
+
+#[cfg(test)]
+#[path = "framework_tests.rs"]
+mod framework_tests;
+
+use crossterm::event::KeyEvent;
+use ratatui::layout::Rect;
+use ratatui::Frame;
+
+// ── Key/Window Actions ──────────────────────────────────────────────
+
+/// Result of a widget handling a key event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyAction {
+    /// Input consumed — stop propagation.
+    Handled,
+    /// Input not consumed — bubble to parent.
+    Unhandled,
+}
+
+/// Result of a window handling a key event.
+pub enum WindowAction {
+    /// Input consumed, no further action.
+    Handled,
+    /// Close this window (pop from stack).
+    Close,
+    /// Push a new window on top of the stack.
+    Open(Box<dyn Window>),
+    /// Window didn't handle it.
+    Unhandled,
+}
+
+impl std::fmt::Debug for WindowAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Handled => write!(f, "Handled"),
+            Self::Close => write!(f, "Close"),
+            Self::Open(w) => write!(f, "Open({})", w.name()),
+            Self::Unhandled => write!(f, "Unhandled"),
+        }
+    }
+}
+
+impl PartialEq for WindowAction {
+    fn eq(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+impl Eq for WindowAction {}
+
+// ── Widget Trait ─────────────────────────────────────────────────────
+
+/// A composable UI element within a window.
+///
+/// Widgets form a tree; keyboard input flows from focused leaf → root
+/// via event bubbling.
+pub trait Widget {
+    /// Child widgets (empty for leaf widgets).
+    fn children(&self) -> &[Box<dyn Widget>];
+
+    /// Mutable access to child widgets (for dispatching events).
+    fn children_mut(&mut self) -> &mut [Box<dyn Widget>];
+
+    /// Render this widget into the given area.
+    fn render(&self, frame: &mut Frame, area: Rect);
+
+    /// Handle a key event. Return `Handled` to stop propagation.
+    fn handle_key(&mut self, event: KeyEvent) -> KeyAction;
+
+    /// Whether this widget can receive focus.
+    fn is_focusable(&self) -> bool;
+
+    /// Display name for debugging/tracing.
+    fn name(&self) -> &str {
+        "Widget"
+    }
+}
+
+// ── Window Trait ─────────────────────────────────────────────────────
+
+/// A top-level UI surface. Windows are managed by the WindowStack.
+pub trait Window {
+    /// Display name (for tracing and debugging).
+    fn name(&self) -> &str;
+
+    /// Render this window into the given area.
+    fn render(&self, frame: &mut Frame, area: Rect);
+
+    /// Handle a key event. The window is responsible for dispatching
+    /// to its widget tree (via FocusManager) and bubbling.
+    fn handle_key(&mut self, event: KeyEvent) -> WindowAction;
+}
+
+// ── WindowStack ─────────────────────────────────────────────────────
+
+/// Manages a stack of windows. The topmost window owns focus and input.
+pub struct WindowStack {
+    windows: Vec<Box<dyn Window>>,
+}
+
+impl WindowStack {
+    /// Create a new stack with a base window (the main window).
+    pub fn new(base: Box<dyn Window>) -> Self {
+        Self {
+            windows: vec![base],
+        }
+    }
+
+    /// Push a window onto the stack (it becomes the topmost/focused).
+    pub fn push(&mut self, window: Box<dyn Window>) {
+        tracing::info!(window = window.name(), "WindowStack: pushed window");
+        self.windows.push(window);
+    }
+
+    /// Pop the topmost window. Returns `None` if only the base remains.
+    pub fn pop(&mut self) -> Option<Box<dyn Window>> {
+        if self.windows.len() <= 1 {
+            tracing::warn!("WindowStack: cannot pop base window");
+            return None;
+        }
+        let w = self.windows.pop();
+        if let Some(ref w) = w {
+            tracing::info!(window = w.name(), "WindowStack: popped window");
+        }
+        w
+    }
+
+    /// Reference to the topmost window.
+    pub fn top(&self) -> &dyn Window {
+        self.windows
+            .last()
+            .expect("stack must never be empty")
+            .as_ref()
+    }
+
+    /// Mutable reference to the topmost window.
+    pub fn top_mut(&mut self) -> &mut dyn Window {
+        self.windows
+            .last_mut()
+            .expect("stack must never be empty")
+            .as_mut()
+    }
+
+    /// Number of windows in the stack.
+    pub fn len(&self) -> usize {
+        self.windows.len()
+    }
+
+    /// Whether the stack has only the base window.
+    pub fn is_base_only(&self) -> bool {
+        self.windows.len() == 1
+    }
+
+    /// Render all windows bottom-to-top.
+    pub fn render(&self, frame: &mut Frame, area: Rect) {
+        for window in &self.windows {
+            window.render(frame, area);
+        }
+    }
+
+    /// Dispatch a key event to the topmost window.
+    /// Handles `Close` and `Open` actions automatically.
+    pub fn handle_key(&mut self, event: KeyEvent) -> WindowAction {
+        let action = self.top_mut().handle_key(event);
+        match action {
+            WindowAction::Close => {
+                self.pop();
+                WindowAction::Handled
+            }
+            WindowAction::Open(window) => {
+                self.push(window);
+                WindowAction::Handled
+            }
+            other => other,
+        }
+    }
+}
+
+// ── FocusManager ────────────────────────────────────────────────────
+
+/// Tracks which widget in a tree has focus.
+///
+/// `focus_path` is a list of child indices from the root to the focused widget.
+/// E.g., `[1, 0]` means root's child at index 1, then that widget's child at index 0.
+pub struct FocusManager {
+    /// Path from root to focused widget (child indices).
+    focus_path: Vec<usize>,
+}
+
+impl FocusManager {
+    /// Create a new FocusManager with no initial focus (empty path = root).
+    /// Call `focus_next()` to move focus to the first focusable widget.
+    pub fn new() -> Self {
+        Self {
+            focus_path: Vec::new(),
+        }
+    }
+
+    /// Create with an explicit initial path.
+    pub fn with_path(path: Vec<usize>) -> Self {
+        Self { focus_path: path }
+    }
+
+    /// Current focus path.
+    pub fn path(&self) -> &[usize] {
+        &self.focus_path
+    }
+
+    /// Set the focus path directly.
+    pub fn set_path(&mut self, path: Vec<usize>) {
+        tracing::debug!(path = ?path, "FocusManager: focus path changed");
+        self.focus_path = path;
+    }
+
+    /// Advance focus to the next focusable widget (Tab).
+    /// Returns true if focus changed.
+    pub fn next(&mut self, root: &dyn Widget) -> bool {
+        let focusables = Self::collect_focusable_paths(root);
+        if focusables.is_empty() {
+            return false;
+        }
+        let current_idx = focusables.iter().position(|p| p == &self.focus_path);
+        let next_idx = match current_idx {
+            Some(i) => (i + 1) % focusables.len(),
+            None => 0,
+        };
+        let new_path = focusables[next_idx].clone();
+        if new_path != self.focus_path {
+            tracing::debug!(from = ?self.focus_path, to = ?new_path, "FocusManager: Tab → next");
+            self.focus_path = new_path;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Move focus to the previous focusable widget (Shift+Tab).
+    /// Returns true if focus changed.
+    pub fn prev(&mut self, root: &dyn Widget) -> bool {
+        let focusables = Self::collect_focusable_paths(root);
+        if focusables.is_empty() {
+            return false;
+        }
+        let current_idx = focusables.iter().position(|p| p == &self.focus_path);
+        let prev_idx = match current_idx {
+            Some(i) => (i + focusables.len() - 1) % focusables.len(),
+            None => focusables.len() - 1,
+        };
+        let new_path = focusables[prev_idx].clone();
+        if new_path != self.focus_path {
+            tracing::debug!(from = ?self.focus_path, to = ?new_path, "FocusManager: Shift+Tab → prev");
+            self.focus_path = new_path;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Dispatch a key event through the widget tree using event bubbling.
+    ///
+    /// Sends the event to the focused widget first. If unhandled, bubbles
+    /// up through each ancestor until handled or the root is reached.
+    pub fn dispatch_key(&self, root: &mut dyn Widget, event: KeyEvent) -> KeyAction {
+        // Build the chain of widgets from root to focused leaf
+        // We process from leaf to root (event bubbling)
+        self.dispatch_at_depth(root, event, 0)
+    }
+
+    /// Recursively dispatch: walk to focused leaf, then bubble up.
+    fn dispatch_at_depth(
+        &self,
+        widget: &mut dyn Widget,
+        event: KeyEvent,
+        depth: usize,
+    ) -> KeyAction {
+        // If we haven't reached the end of the focus path, go deeper
+        if depth < self.focus_path.len() {
+            let child_idx = self.focus_path[depth];
+            let children = widget.children_mut();
+            if child_idx < children.len() {
+                let result = self.dispatch_at_depth(children[child_idx].as_mut(), event, depth + 1);
+                if result == KeyAction::Handled {
+                    return KeyAction::Handled;
+                }
+            }
+        }
+        // Either we're at the focused widget, or a child didn't handle it — try this widget
+        let result = widget.handle_key(event);
+        if result == KeyAction::Handled {
+            tracing::debug!(widget = widget.name(), depth, "key handled by widget");
+        }
+        result
+    }
+
+    /// Collect all focusable widget paths in depth-first order.
+    fn collect_focusable_paths(root: &dyn Widget) -> Vec<Vec<usize>> {
+        let mut result = Vec::new();
+        Self::collect_recursive(root, &mut Vec::new(), &mut result);
+        result
+    }
+
+    fn collect_recursive(
+        widget: &dyn Widget,
+        current_path: &mut Vec<usize>,
+        result: &mut Vec<Vec<usize>>,
+    ) {
+        // Check this widget (skip root — root's focusability is at path [])
+        if !current_path.is_empty() && widget.is_focusable() {
+            result.push(current_path.clone());
+        }
+        // Recurse into children
+        for (i, child) in widget.children().iter().enumerate() {
+            current_path.push(i);
+            Self::collect_recursive(child.as_ref(), current_path, result);
+            current_path.pop();
+        }
+    }
+}
+
+impl Default for FocusManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── TabbedContainer ─────────────────────────────────────────────────
+
+/// Configuration for a single tab in a `TabbedContainer`.
+pub struct TabEntry {
+    /// Display name shown in the tab bar.
+    pub name: String,
+    /// Optional shortcut key character (e.g. 'd' for Detail).
+    pub shortcut: Option<char>,
+    /// The child widget for this tab.
+    pub widget: Box<dyn Widget>,
+}
+
+/// A generic container that manages multiple child widgets as tabs.
+///
+/// - Renders a tab bar with names + active highlight
+/// - Only the active tab's widget is rendered in the content area
+/// - `Ctrl+←`/`Ctrl+→` switch tabs
+/// - Delegates other keys to the active tab's child widget
+pub struct TabbedContainer {
+    pub tabs: Vec<TabEntry>,
+    pub active: usize,
+}
+
+impl TabbedContainer {
+    pub fn new(tabs: Vec<TabEntry>) -> Self {
+        Self { tabs, active: 0 }
+    }
+
+    /// Switch to the next tab (wrapping).
+    pub fn next_tab(&mut self) {
+        if !self.tabs.is_empty() {
+            self.active = (self.active + 1) % self.tabs.len();
+            tracing::debug!(
+                active = self.active,
+                name = self.tabs[self.active].name,
+                "TabbedContainer: next_tab"
+            );
+        }
+    }
+
+    /// Switch to the previous tab (wrapping).
+    pub fn prev_tab(&mut self) {
+        if !self.tabs.is_empty() {
+            self.active = if self.active == 0 {
+                self.tabs.len() - 1
+            } else {
+                self.active - 1
+            };
+            tracing::debug!(
+                active = self.active,
+                name = self.tabs[self.active].name,
+                "TabbedContainer: prev_tab"
+            );
+        }
+    }
+
+    /// Switch to a tab by index.
+    pub fn set_active(&mut self, index: usize) {
+        if index < self.tabs.len() {
+            self.active = index;
+        }
+    }
+
+    /// The name of the currently active tab.
+    pub fn active_name(&self) -> &str {
+        self.tabs.get(self.active).map_or("", |t| &t.name)
+    }
+
+    /// Number of tabs.
+    pub fn tab_count(&self) -> usize {
+        self.tabs.len()
+    }
+}
+
+impl Widget for TabbedContainer {
+    fn name(&self) -> &str {
+        "TabbedContainer"
+    }
+
+    fn children(&self) -> &[Box<dyn Widget>] {
+        // We can't return &[Box<dyn Widget>] from TabEntry vec directly,
+        // so delegate to children_mut pattern. For focus enumeration,
+        // the FocusManager will need the active child only.
+        &[]
+    }
+
+    fn children_mut(&mut self) -> &mut [Box<dyn Widget>] {
+        &mut []
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect) {
+        // Tab bar takes 1 line at top, content below.
+        if area.height < 2 || self.tabs.is_empty() {
+            return;
+        }
+
+        let tab_bar_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        };
+        let content_area = Rect {
+            x: area.x,
+            y: area.y + 1,
+            width: area.width,
+            height: area.height - 1,
+        };
+
+        // Render tab bar
+        use ratatui::style::{Color, Modifier, Style};
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::Paragraph;
+
+        let mut spans = Vec::new();
+        for (i, tab) in self.tabs.iter().enumerate() {
+            if i > 0 {
+                spans.push(Span::raw(" │ "));
+            }
+            let style = if i == self.active {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            let prefix = if i == self.active { "▸ " } else { "  " };
+            spans.push(Span::styled(format!("{}{}", prefix, tab.name), style));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), tab_bar_area);
+
+        // Render active tab content
+        if let Some(tab) = self.tabs.get(self.active) {
+            tab.widget.render(frame, content_area);
+        }
+    }
+
+    fn handle_key(&mut self, event: KeyEvent) -> KeyAction {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        // Ctrl+Right → next tab
+        if event.modifiers.contains(KeyModifiers::CONTROL) && event.code == KeyCode::Right {
+            self.next_tab();
+            return KeyAction::Handled;
+        }
+        // Ctrl+Left → prev tab
+        if event.modifiers.contains(KeyModifiers::CONTROL) && event.code == KeyCode::Left {
+            self.prev_tab();
+            return KeyAction::Handled;
+        }
+
+        // Shortcut keys for direct tab activation
+        if let KeyCode::Char(c) = event.code {
+            if event.modifiers.is_empty() || event.modifiers == KeyModifiers::SHIFT {
+                for (i, tab) in self.tabs.iter().enumerate() {
+                    if tab.shortcut == Some(c) {
+                        self.active = i;
+                        tracing::debug!(tab = tab.name, "TabbedContainer: shortcut activated");
+                        return KeyAction::Handled;
+                    }
+                }
+            }
+        }
+
+        // Delegate to active tab's widget
+        if let Some(tab) = self.tabs.get_mut(self.active) {
+            return tab.widget.handle_key(event);
+        }
+
+        KeyAction::Unhandled
+    }
+
+    fn is_focusable(&self) -> bool {
+        true
+    }
+}

--- a/crates/scouty-tui/src/ui/framework_tests.rs
+++ b/crates/scouty-tui/src/ui/framework_tests.rs
@@ -1,0 +1,549 @@
+#[cfg(test)]
+mod tests {
+    use crate::ui::framework::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use ratatui::layout::Rect;
+    use ratatui::Frame;
+
+    // ── Test helpers ─────────────────────────────────────────────
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// A simple leaf widget for testing.
+    struct TestWidget {
+        name: &'static str,
+        focusable: bool,
+        /// Keys this widget handles (returns Handled for these).
+        handled_keys: Vec<KeyCode>,
+        children: Vec<Box<dyn Widget>>,
+    }
+
+    impl TestWidget {
+        fn leaf(name: &'static str, focusable: bool, handled_keys: Vec<KeyCode>) -> Self {
+            Self {
+                name,
+                focusable,
+                handled_keys,
+                children: Vec::new(),
+            }
+        }
+
+        fn with_children(
+            name: &'static str,
+            focusable: bool,
+            handled_keys: Vec<KeyCode>,
+            children: Vec<Box<dyn Widget>>,
+        ) -> Self {
+            Self {
+                name,
+                focusable,
+                handled_keys,
+                children,
+            }
+        }
+    }
+
+    impl Widget for TestWidget {
+        fn children(&self) -> &[Box<dyn Widget>] {
+            &self.children
+        }
+        fn children_mut(&mut self) -> &mut [Box<dyn Widget>] {
+            &mut self.children
+        }
+        fn render(&self, _frame: &mut Frame, _area: Rect) {}
+        fn handle_key(&mut self, event: KeyEvent) -> KeyAction {
+            if self.handled_keys.contains(&event.code) {
+                KeyAction::Handled
+            } else {
+                KeyAction::Unhandled
+            }
+        }
+        fn is_focusable(&self) -> bool {
+            self.focusable
+        }
+        fn name(&self) -> &str {
+            self.name
+        }
+    }
+
+    /// A simple window for testing.
+    struct TestWindow {
+        name: &'static str,
+        action_on_esc: bool,
+    }
+
+    impl TestWindow {
+        fn new(name: &'static str, action_on_esc: bool) -> Self {
+            Self {
+                name,
+                action_on_esc,
+            }
+        }
+    }
+
+    impl Window for TestWindow {
+        fn name(&self) -> &str {
+            self.name
+        }
+        fn render(&self, _frame: &mut Frame, _area: Rect) {}
+        fn handle_key(&mut self, event: KeyEvent) -> WindowAction {
+            if self.action_on_esc && event.code == KeyCode::Esc {
+                WindowAction::Close
+            } else {
+                WindowAction::Unhandled
+            }
+        }
+    }
+
+    // ── WindowStack tests ────────────────────────────────────────
+
+    #[test]
+    fn window_stack_base_window() {
+        let base = Box::new(TestWindow::new("Main", false));
+        let stack = WindowStack::new(base);
+        assert_eq!(stack.len(), 1);
+        assert!(stack.is_base_only());
+        assert_eq!(stack.top().name(), "Main");
+    }
+
+    #[test]
+    fn window_stack_push_pop() {
+        let base = Box::new(TestWindow::new("Main", false));
+        let mut stack = WindowStack::new(base);
+
+        stack.push(Box::new(TestWindow::new("Help", true)));
+        assert_eq!(stack.len(), 2);
+        assert!(!stack.is_base_only());
+        assert_eq!(stack.top().name(), "Help");
+
+        let popped = stack.pop();
+        assert!(popped.is_some());
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack.top().name(), "Main");
+    }
+
+    #[test]
+    fn window_stack_cannot_pop_base() {
+        let base = Box::new(TestWindow::new("Main", false));
+        let mut stack = WindowStack::new(base);
+
+        let result = stack.pop();
+        assert!(result.is_none());
+        assert_eq!(stack.len(), 1);
+    }
+
+    #[test]
+    fn window_stack_handle_key_close() {
+        let base = Box::new(TestWindow::new("Main", false));
+        let mut stack = WindowStack::new(base);
+        stack.push(Box::new(TestWindow::new("Help", true)));
+
+        assert_eq!(stack.len(), 2);
+
+        // Esc should close the Help window
+        let result = stack.handle_key(key(KeyCode::Esc));
+        assert_eq!(result, WindowAction::Handled);
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack.top().name(), "Main");
+    }
+
+    /// A window that returns Open on '?' key to push a Help window.
+    struct OpenerWindow;
+    impl Window for OpenerWindow {
+        fn name(&self) -> &str {
+            "Opener"
+        }
+        fn render(&self, _frame: &mut Frame, _area: Rect) {}
+        fn handle_key(&mut self, event: KeyEvent) -> WindowAction {
+            if event.code == KeyCode::Char('?') {
+                WindowAction::Open(Box::new(TestWindow::new("Help", true)))
+            } else {
+                WindowAction::Handled
+            }
+        }
+    }
+
+    #[test]
+    fn window_stack_handle_key_open() {
+        let base = Box::new(OpenerWindow);
+        let mut stack = WindowStack::new(base);
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack.top().name(), "Opener");
+
+        // '?' should open Help window on top
+        let result = stack.handle_key(key(KeyCode::Char('?')));
+        assert_eq!(result, WindowAction::Handled);
+        assert_eq!(stack.len(), 2);
+        assert_eq!(stack.top().name(), "Help");
+
+        // Esc closes Help, back to Opener
+        let result = stack.handle_key(key(KeyCode::Esc));
+        assert_eq!(result, WindowAction::Handled);
+        assert_eq!(stack.len(), 1);
+        assert_eq!(stack.top().name(), "Opener");
+    }
+
+    #[test]
+    fn window_stack_input_only_goes_to_top() {
+        let base = Box::new(TestWindow::new("Main", false));
+        let mut stack = WindowStack::new(base);
+        stack.push(Box::new(TestWindow::new("Overlay", true)));
+
+        // Input goes to Overlay, not Main
+        assert_eq!(stack.top().name(), "Overlay");
+    }
+
+    #[test]
+    fn window_stack_multiple_overlays() {
+        let base = Box::new(TestWindow::new("Main", false));
+        let mut stack = WindowStack::new(base);
+        stack.push(Box::new(TestWindow::new("Help", true)));
+        stack.push(Box::new(TestWindow::new("Confirm", true)));
+
+        assert_eq!(stack.len(), 3);
+        assert_eq!(stack.top().name(), "Confirm");
+
+        stack.handle_key(key(KeyCode::Esc)); // close Confirm
+        assert_eq!(stack.top().name(), "Help");
+
+        stack.handle_key(key(KeyCode::Esc)); // close Help
+        assert_eq!(stack.top().name(), "Main");
+    }
+
+    // ── FocusManager tests ───────────────────────────────────────
+
+    #[test]
+    fn focus_manager_tab_cycles_focusable_children() {
+        let root = TestWidget::with_children(
+            "root",
+            false,
+            vec![],
+            vec![
+                Box::new(TestWidget::leaf("A", true, vec![])),
+                Box::new(TestWidget::leaf("B", false, vec![])), // not focusable
+                Box::new(TestWidget::leaf("C", true, vec![])),
+            ],
+        );
+
+        let mut fm = FocusManager::with_path(vec![0]); // focused on A
+        assert_eq!(fm.path(), &[0]);
+
+        // Tab → skip B (not focusable) → C
+        fm.next(&root);
+        assert_eq!(fm.path(), &[2]);
+
+        // Tab → wrap to A
+        fm.next(&root);
+        assert_eq!(fm.path(), &[0]);
+    }
+
+    #[test]
+    fn focus_manager_shift_tab_reverses() {
+        let root = TestWidget::with_children(
+            "root",
+            false,
+            vec![],
+            vec![
+                Box::new(TestWidget::leaf("A", true, vec![])),
+                Box::new(TestWidget::leaf("B", true, vec![])),
+                Box::new(TestWidget::leaf("C", true, vec![])),
+            ],
+        );
+
+        let mut fm = FocusManager::with_path(vec![0]); // focused on A
+
+        // Shift+Tab → wrap to C (reverse)
+        fm.prev(&root);
+        assert_eq!(fm.path(), &[2]);
+
+        // Shift+Tab → B
+        fm.prev(&root);
+        assert_eq!(fm.path(), &[1]);
+
+        // Shift+Tab → A
+        fm.prev(&root);
+        assert_eq!(fm.path(), &[0]);
+    }
+
+    #[test]
+    fn focus_manager_no_focusable_widgets() {
+        let root = TestWidget::with_children(
+            "root",
+            false,
+            vec![],
+            vec![Box::new(TestWidget::leaf("A", false, vec![]))],
+        );
+
+        let mut fm = FocusManager::new();
+        assert!(!fm.next(&root));
+        assert!(!fm.prev(&root));
+    }
+
+    #[test]
+    fn focus_manager_nested_focusable() {
+        let root = TestWidget::with_children(
+            "root",
+            false,
+            vec![],
+            vec![
+                Box::new(TestWidget::leaf("A", true, vec![])),
+                Box::new(TestWidget::with_children(
+                    "Panel",
+                    false,
+                    vec![],
+                    vec![
+                        Box::new(TestWidget::leaf("B", true, vec![])),
+                        Box::new(TestWidget::leaf("C", true, vec![])),
+                    ],
+                )),
+            ],
+        );
+
+        let mut fm = FocusManager::with_path(vec![0]); // A
+
+        // Tab → B (nested)
+        fm.next(&root);
+        assert_eq!(fm.path(), &[1, 0]);
+
+        // Tab → C (nested)
+        fm.next(&root);
+        assert_eq!(fm.path(), &[1, 1]);
+
+        // Tab → wrap to A
+        fm.next(&root);
+        assert_eq!(fm.path(), &[0]);
+    }
+
+    // ── Event bubbling tests ─────────────────────────────────────
+
+    #[test]
+    fn event_bubbling_child_handles() {
+        let mut root = TestWidget::with_children(
+            "root",
+            false,
+            vec![KeyCode::Char('q')],
+            vec![Box::new(TestWidget::leaf(
+                "Child",
+                true,
+                vec![KeyCode::Char('j')],
+            ))],
+        );
+
+        let fm = FocusManager::with_path(vec![0]); // focused on Child
+
+        // 'j' → Child handles it
+        let result = fm.dispatch_key(&mut root, key(KeyCode::Char('j')));
+        assert_eq!(result, KeyAction::Handled);
+    }
+
+    #[test]
+    fn event_bubbling_child_unhandled_parent_handles() {
+        let mut root = TestWidget::with_children(
+            "root",
+            false,
+            vec![KeyCode::Char('q')],
+            vec![Box::new(TestWidget::leaf(
+                "Child",
+                true,
+                vec![KeyCode::Char('j')],
+            ))],
+        );
+
+        let fm = FocusManager::with_path(vec![0]); // focused on Child
+
+        // 'q' → Child doesn't handle, bubbles to root → root handles
+        let result = fm.dispatch_key(&mut root, key(KeyCode::Char('q')));
+        assert_eq!(result, KeyAction::Handled);
+    }
+
+    #[test]
+    fn event_bubbling_nobody_handles() {
+        let mut root = TestWidget::with_children(
+            "root",
+            false,
+            vec![KeyCode::Char('q')],
+            vec![Box::new(TestWidget::leaf(
+                "Child",
+                true,
+                vec![KeyCode::Char('j')],
+            ))],
+        );
+
+        let fm = FocusManager::with_path(vec![0]);
+
+        // 'x' → nobody handles
+        let result = fm.dispatch_key(&mut root, key(KeyCode::Char('x')));
+        assert_eq!(result, KeyAction::Unhandled);
+    }
+
+    #[test]
+    fn event_bubbling_nested() {
+        // root(handles 'q') → Panel(handles 'p') → Leaf(handles 'j')
+        let mut root = TestWidget::with_children(
+            "root",
+            false,
+            vec![KeyCode::Char('q')],
+            vec![Box::new(TestWidget::with_children(
+                "Panel",
+                false,
+                vec![KeyCode::Char('p')],
+                vec![Box::new(TestWidget::leaf(
+                    "Leaf",
+                    true,
+                    vec![KeyCode::Char('j')],
+                ))],
+            ))],
+        );
+
+        let fm = FocusManager::with_path(vec![0, 0]); // focused on Leaf
+
+        // 'j' → Leaf handles
+        assert_eq!(
+            fm.dispatch_key(&mut root, key(KeyCode::Char('j'))),
+            KeyAction::Handled
+        );
+
+        // 'p' → Leaf unhandled → Panel handles
+        assert_eq!(
+            fm.dispatch_key(&mut root, key(KeyCode::Char('p'))),
+            KeyAction::Handled
+        );
+
+        // 'q' → Leaf unhandled → Panel unhandled → root handles
+        assert_eq!(
+            fm.dispatch_key(&mut root, key(KeyCode::Char('q'))),
+            KeyAction::Handled
+        );
+
+        // 'x' → nobody handles
+        assert_eq!(
+            fm.dispatch_key(&mut root, key(KeyCode::Char('x'))),
+            KeyAction::Unhandled
+        );
+    }
+
+    // ── KeyAction / WindowAction tests ───────────────────────────
+
+    #[test]
+    fn key_action_equality() {
+        assert_eq!(KeyAction::Handled, KeyAction::Handled);
+        assert_ne!(KeyAction::Handled, KeyAction::Unhandled);
+    }
+
+    #[test]
+    fn window_action_equality() {
+        assert_eq!(WindowAction::Handled, WindowAction::Handled);
+        assert_eq!(WindowAction::Close, WindowAction::Close);
+        assert_ne!(WindowAction::Handled, WindowAction::Close);
+    }
+
+    // ── TabbedContainer tests ───────────────────────────────────────
+
+    fn make_tab_entry(name: &str, shortcut: Option<char>, handles: Option<KeyCode>) -> TabEntry {
+        TabEntry {
+            name: name.to_string(),
+            shortcut,
+            widget: Box::new(TestWidget {
+                name: Box::leak(name.to_string().into_boxed_str()),
+                focusable: true,
+                handled_keys: handles.into_iter().collect(),
+                children: vec![],
+            }),
+        }
+    }
+
+    fn make_test_tabbed() -> TabbedContainer {
+        TabbedContainer::new(vec![
+            make_tab_entry("Detail", Some('d'), Some(KeyCode::Char('j'))),
+            make_tab_entry("Region", Some('r'), Some(KeyCode::Char('k'))),
+            make_tab_entry("Stats", Some('S'), None),
+        ])
+    }
+
+    #[test]
+    fn tabbed_container_next_prev() {
+        let mut tc = make_test_tabbed();
+        assert_eq!(tc.active, 0);
+        assert_eq!(tc.active_name(), "Detail");
+
+        tc.next_tab();
+        assert_eq!(tc.active, 1);
+        assert_eq!(tc.active_name(), "Region");
+
+        tc.next_tab();
+        assert_eq!(tc.active, 2);
+
+        tc.next_tab(); // wrap
+        assert_eq!(tc.active, 0);
+
+        tc.prev_tab(); // wrap back
+        assert_eq!(tc.active, 2);
+
+        tc.prev_tab();
+        assert_eq!(tc.active, 1);
+    }
+
+    #[test]
+    fn tabbed_container_ctrl_arrows() {
+        let mut tc = make_test_tabbed();
+
+        let ctrl_right = KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL);
+        let ctrl_left = KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL);
+
+        assert_eq!(tc.handle_key(ctrl_right), KeyAction::Handled);
+        assert_eq!(tc.active, 1);
+
+        assert_eq!(tc.handle_key(ctrl_left), KeyAction::Handled);
+        assert_eq!(tc.active, 0);
+    }
+
+    #[test]
+    fn tabbed_container_shortcut_keys() {
+        let mut tc = make_test_tabbed();
+
+        // 'r' activates Region
+        let r_key = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE);
+        assert_eq!(tc.handle_key(r_key), KeyAction::Handled);
+        assert_eq!(tc.active, 1);
+
+        // 'd' activates Detail
+        let d_key = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE);
+        assert_eq!(tc.handle_key(d_key), KeyAction::Handled);
+        assert_eq!(tc.active, 0);
+
+        // 'S' activates Stats (shift char)
+        let s_key = KeyEvent::new(KeyCode::Char('S'), KeyModifiers::SHIFT);
+        assert_eq!(tc.handle_key(s_key), KeyAction::Handled);
+        assert_eq!(tc.active, 2);
+    }
+
+    #[test]
+    fn tabbed_container_delegates_to_active() {
+        let mut tc = make_test_tabbed();
+        // Active = Detail (handles 'j')
+        let j_key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+        assert_eq!(tc.handle_key(j_key), KeyAction::Handled);
+
+        // 'k' is not handled by Detail
+        let k_key = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
+        assert_eq!(tc.handle_key(k_key), KeyAction::Unhandled);
+
+        // Switch to Region, now 'k' handled
+        tc.next_tab();
+        assert_eq!(tc.handle_key(k_key), KeyAction::Handled);
+    }
+
+    #[test]
+    fn tabbed_container_is_focusable() {
+        let tc = make_test_tabbed();
+        assert!(tc.is_focusable());
+    }
+
+    #[test]
+    fn tabbed_container_tab_count() {
+        let tc = make_test_tabbed();
+        assert_eq!(tc.tab_count(), 3);
+    }
+}

--- a/crates/scouty-tui/src/ui/mod.rs
+++ b/crates/scouty-tui/src/ui/mod.rs
@@ -1,5 +1,6 @@
 //! TUI component architecture — trait, dispatch, and component modules.
 
+pub mod framework;
 pub mod widgets;
 pub mod windows;
 


### PR DESCRIPTION
Closes #434

## Overview
Additive-only implementation of the new UI architecture framework per `spec/ui-architecture.md`. No existing code is modified.

## New types (`ui/framework.rs`)

### Traits
- **`Window`**: `name()`, `render()`, `handle_key() -> WindowAction`
- **`Widget`**: `children()`, `children_mut()`, `render()`, `handle_key() -> KeyAction`, `is_focusable()`, `name()`

### Enums
- **`WindowAction`**: `Handled`, `Close`, `Open(Box<dyn Window>)`, `Unhandled`
- **`KeyAction`**: `Handled`, `Unhandled`

### Structs
- **`WindowStack`**: Manages a stack of windows. Only topmost receives input. Auto-handles `Close` (pop) and `Open` (push). Base window cannot be popped.
- **`FocusManager`**: Tracks `focus_path` (indices from root to focused widget). Supports `next()`/`prev()` for Tab/Shift+Tab cycling among focusable widgets. `dispatch_key()` implements event bubbling from focused leaf → parent → root.

## Test coverage (15 new tests)
- WindowStack: push/pop, base protection, close/open dispatch, multiple overlays
- FocusManager: Tab cycling (skip non-focusable), Shift+Tab reverse, nested widgets
- Event bubbling: child handles, parent handles on bubble, nobody handles, 3-level nesting

## Testing
- All 352 tests pass
- cargo clippy clean