### PR TITLE
[PM Spec] Panel shortcuts (Enter/r/S) open panel without switching focus

### DIFF
--- a/crates/scouty-tui/spec/panel-system.md
+++ b/crates/scouty-tui/spec/panel-system.md
@@ -93,7 +93,7 @@ Focus switching:
 | `Tab` | Cycle focus forward: Log Table → Detail → Region → Log Table → … (expands panel if collapsed) |
 | `Shift+Tab` | Cycle focus backward (reverse of Tab) |
 | `Esc` | Panel Content → Log Table (focus returns to log table) |
-| Original shortcut | Directly open corresponding panel and gain focus (e.g., `Enter` opens Detail, `r` opens Region) |
+| Original shortcut | Directly open/close corresponding panel without changing focus (e.g., `Enter` toggles Detail, `r` toggles Region, `S` toggles Stats). Focus stays on the current widget (typically log table). Use `Ctrl+↓` or `Tab` to move focus into the panel. |
 
 #### Shared Panel Operations (all panels)
 


### PR DESCRIPTION
Panel shortcut keys expand/collapse the panel but do NOT move focus:

- `Enter` → toggle Detail panel, focus stays on log table
- `r` → toggle Region panel, focus stays on log table  
- `S` → toggle Stats panel, focus stays on log table

To move focus into the panel, use `Ctrl+↓` or `Tab`.