### PR TITLE
Fix: Enter/r/S expand panel without switching focus

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -1623,20 +1623,16 @@ impl App {
     }
 
     pub fn toggle_detail(&mut self) {
-        self.detail_open = !self.detail_open;
-        tracing::debug!(detail_open = self.detail_open, "toggled detail panel");
-        if self.detail_open {
-            self.panel_state.open(crate::panel::PanelId::Detail);
-            // Auto-focus tree if expanded data is available
-            if let Some(record) = self.selected_record() {
-                if record.expanded.as_ref().is_some_and(|e| !e.is_empty()) {
-                    self.detail_tree_focus = true;
-                    self.detail_tree_cursor = 0;
-                }
-            }
-        } else {
+        self.panel_state
+            .toggle_expand(crate::panel::PanelId::Detail);
+        self.detail_open =
+            self.panel_state.expanded && self.panel_state.active == crate::panel::PanelId::Detail;
+        tracing::debug!(
+            detail_open = self.detail_open,
+            "toggled detail panel (focus unchanged)"
+        );
+        if !self.detail_open {
             self.detail_tree_focus = false;
-            self.panel_state.close();
         }
     }
 

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -908,7 +908,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         app.bookmark_manager_cursor = 0;
                                     }
                                     Action::RegionManager => {
-                                        app.panel_state.open(crate::panel::PanelId::Region);
+                                        app.panel_state
+                                            .toggle_expand(crate::panel::PanelId::Region);
                                     }
                                     Action::NextRegion => {
                                         // Jump to the next region start after current position
@@ -926,16 +927,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         }
                                     }
                                     Action::Stats => {
-                                        use crate::panel::PanelId;
-                                        if app.panel_state.expanded
-                                            && app.panel_state.active == PanelId::Stats
-                                        {
-                                            app.panel_state.close();
-                                            tracing::debug!("S key: closed Stats panel");
-                                        } else {
-                                            app.panel_state.open(PanelId::Stats);
-                                            tracing::debug!("S key: opened Stats panel");
-                                        }
+                                        app.panel_state.toggle_expand(crate::panel::PanelId::Stats);
                                     }
                                 }
                             }

--- a/crates/scouty-tui/src/panel.rs
+++ b/crates/scouty-tui/src/panel.rs
@@ -134,6 +134,22 @@ impl PanelState {
         self.maximized = false;
     }
 
+    /// Toggle panel expand/collapse without changing focus.
+    /// If expanding a different panel, switch active but keep focus on log table.
+    pub fn toggle_expand(&mut self, panel: PanelId) {
+        if self.expanded && self.active == panel {
+            // Collapse
+            self.expanded = false;
+            self.maximized = false;
+            tracing::debug!(?panel, "panel: collapsed (focus unchanged)");
+        } else {
+            // Expand (or switch to different panel)
+            self.active = panel;
+            self.expanded = true;
+            tracing::debug!(?panel, "panel: expanded (focus unchanged)");
+        }
+    }
+
     /// Focus down into panel content (expand if collapsed).
     pub fn focus_panel(&mut self) {
         self.expanded = true;

--- a/crates/scouty-tui/src/panel_tests.rs
+++ b/crates/scouty-tui/src/panel_tests.rs
@@ -275,4 +275,52 @@ mod tests {
         state.close();
         assert!(!state.expanded);
     }
+
+    /// toggle_expand opens panel without changing focus
+    #[test]
+    fn test_toggle_expand_no_focus_change() {
+        let mut state = PanelState::default();
+        assert_eq!(state.focus, PanelFocus::LogTable);
+
+        // Expand Detail — focus should stay on LogTable
+        state.toggle_expand(PanelId::Detail);
+        assert!(state.expanded);
+        assert_eq!(state.active, PanelId::Detail);
+        assert_eq!(state.focus, PanelFocus::LogTable);
+
+        // Collapse Detail
+        state.toggle_expand(PanelId::Detail);
+        assert!(!state.expanded);
+        assert_eq!(state.focus, PanelFocus::LogTable);
+    }
+
+    /// toggle_expand switches active panel without focus change
+    #[test]
+    fn test_toggle_expand_switch_panel() {
+        let mut state = PanelState::default();
+
+        state.toggle_expand(PanelId::Detail);
+        assert!(state.expanded);
+        assert_eq!(state.active, PanelId::Detail);
+
+        // Switch to Region — stays expanded, focus unchanged
+        state.toggle_expand(PanelId::Region);
+        assert!(state.expanded);
+        assert_eq!(state.active, PanelId::Region);
+        assert_eq!(state.focus, PanelFocus::LogTable);
+    }
+
+    /// toggle_expand while panel focused keeps focus in panel
+    #[test]
+    fn test_toggle_expand_preserves_panel_focus() {
+        let mut state = PanelState::default();
+        state.open(PanelId::Detail); // opens AND focuses
+        assert_eq!(state.focus, PanelFocus::PanelContent);
+
+        // Switch to Region via toggle_expand — focus should stay as PanelContent
+        state.toggle_expand(PanelId::Region);
+        assert!(state.expanded);
+        assert_eq!(state.active, PanelId::Region);
+        assert_eq!(state.focus, PanelFocus::PanelContent);
+    }
 }


### PR DESCRIPTION
## Changes

`Enter`, `r`, `S` keys now only expand/collapse panels — **focus stays on log table**.

### Before
- `Enter` → expand Detail + focus moves into panel
- `r` → expand Region + focus moves into panel
- `S` → expand Stats + focus moves into panel

### After  
- `Enter` → expand/collapse Detail, focus stays on log table
- `r` → expand/collapse Region, focus stays on log table
- `S` → expand/collapse Stats, focus stays on log table
- `Tab` / `Ctrl+↓` → enter panel (unchanged)

### Implementation
- New `PanelState::toggle_expand(panel)` — expand/collapse without touching focus
- All 3 shortcut handlers use `toggle_expand()` instead of `open()`

### Tests
- `test_toggle_expand_no_focus_change`
- `test_toggle_expand_switch_panel`
- `test_toggle_expand_preserves_panel_focus`

707 tests ✅ | Closes #442