### PR TITLE
Simplify status bar hints: merge keys and abbreviate

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -28,6 +28,47 @@ fn spans_display_width(spans: &[Span]) -> usize {
 }
 
 impl StatusBarWidget {
+    /// Return the shortcut hints for the current mode/panel state.
+    pub fn shortcut_hints(
+        panel_focused: bool,
+        active: crate::panel::PanelId,
+    ) -> &'static [(&'static str, &'static str)] {
+        if panel_focused {
+            match active {
+                crate::panel::PanelId::Detail => &[
+                    ("h/l", "Fold"),
+                    ("H/L", "All"),
+                    ("Tab/S-Tab", "Switch"),
+                    ("Ctrl+↑", "Back"),
+                    ("z", "Max"),
+                    ("Esc", "Close"),
+                ],
+                crate::panel::PanelId::Region => &[
+                    ("j/k", "↑↓"),
+                    ("Tab/S-Tab", "Switch"),
+                    ("Ctrl+↑", "Back"),
+                    ("z", "Max"),
+                    ("Esc", "Close"),
+                ],
+                crate::panel::PanelId::Stats => &[
+                    ("Tab/S-Tab", "Switch"),
+                    ("Ctrl+↑", "Back"),
+                    ("z", "Max"),
+                    ("Esc", "Close"),
+                ],
+            }
+        } else {
+            &[
+                ("j/k", "↑↓"),
+                ("/", "Search"),
+                ("f", "Filter"),
+                ("-/=", "Exclude/Include"),
+                ("Enter", "Detail"),
+                ("?", "Help"),
+            ]
+        }
+    }
+
     /// Snap a raw ms-per-bucket value up to the nearest standard interval.
     /// Standard intervals: 5s, 15s, 30s, 5m, 15m, 30m, 1h, 2h, 6h, 12h, 24h.
     /// Values below 5s are returned as-is (milliseconds).
@@ -250,40 +291,7 @@ impl StatusBarWidget {
                     theme.status_bar.shortcut_key.to_style(),
                 ));
             } else {
-                let shortcuts: &[(&str, &str)] = if panel_focused {
-                    match app.panel_state.active {
-                        crate::panel::PanelId::Detail => &[
-                            ("h/l", "Fold"),
-                            ("H/L", "All"),
-                            ("Tab/S-Tab", "Switch"),
-                            ("Ctrl+↑", "Back"),
-                            ("z", "Max"),
-                            ("Esc", "Close"),
-                        ],
-                        crate::panel::PanelId::Region => &[
-                            ("j/k", "↑↓"),
-                            ("Tab/S-Tab", "Switch"),
-                            ("Ctrl+↑", "Back"),
-                            ("z", "Max"),
-                            ("Esc", "Close"),
-                        ],
-                        crate::panel::PanelId::Stats => &[
-                            ("Tab/S-Tab", "Switch"),
-                            ("Ctrl+↑", "Back"),
-                            ("z", "Max"),
-                            ("Esc", "Close"),
-                        ],
-                    }
-                } else {
-                    &[
-                        ("j/k", "↑↓"),
-                        ("/", "Search"),
-                        ("f", "Filter"),
-                        ("-/=", "Exclude/Include"),
-                        ("Enter", "Detail"),
-                        ("?", "Help"),
-                    ]
-                };
+                let shortcuts = Self::shortcut_hints(panel_focused, app.panel_state.active);
 
                 let used = spans_display_width(&spans);
                 let mut remaining = (area.width as usize).saturating_sub(used);

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
@@ -179,50 +179,10 @@ mod tests {
         ); // → 6h
     }
 
-    /// Helper: return the shortcut hints for a given mode/panel state.
-    fn get_hints(
-        panel_focused: bool,
-        active: crate::panel::PanelId,
-    ) -> Vec<(&'static str, &'static str)> {
-        if panel_focused {
-            match active {
-                crate::panel::PanelId::Detail => vec![
-                    ("h/l", "Fold"),
-                    ("H/L", "All"),
-                    ("Tab/S-Tab", "Switch"),
-                    ("Ctrl+↑", "Back"),
-                    ("z", "Max"),
-                    ("Esc", "Close"),
-                ],
-                crate::panel::PanelId::Region => vec![
-                    ("j/k", "↑↓"),
-                    ("Tab/S-Tab", "Switch"),
-                    ("Ctrl+↑", "Back"),
-                    ("z", "Max"),
-                    ("Esc", "Close"),
-                ],
-                crate::panel::PanelId::Stats => vec![
-                    ("Tab/S-Tab", "Switch"),
-                    ("Ctrl+↑", "Back"),
-                    ("z", "Max"),
-                    ("Esc", "Close"),
-                ],
-            }
-        } else {
-            vec![
-                ("j/k", "↑↓"),
-                ("/", "Search"),
-                ("f", "Filter"),
-                ("-/=", "Exclude/Include"),
-                ("Enter", "Detail"),
-                ("?", "Help"),
-            ]
-        }
-    }
-
+    /// Helper: return the shortcut hints via the production method.
     #[test]
     fn test_view_mode_hints_simplified() {
-        let hints = get_hints(false, crate::panel::PanelId::Detail);
+        let hints = StatusBarWidget::shortcut_hints(false, crate::panel::PanelId::Detail);
         // j/k merged, -/= merged, no separate Exclude/Include/ExclField/InclField
         assert_eq!(hints[0], ("j/k", "↑↓"));
         assert_eq!(hints[3], ("-/=", "Exclude/Include"));
@@ -231,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_detail_panel_hints_simplified() {
-        let hints = get_hints(true, crate::panel::PanelId::Detail);
+        let hints = StatusBarWidget::shortcut_hints(true, crate::panel::PanelId::Detail);
         assert_eq!(hints[0], ("h/l", "Fold"));
         assert_eq!(hints[1], ("H/L", "All"));
         assert_eq!(hints[2], ("Tab/S-Tab", "Switch"));
@@ -240,14 +200,14 @@ mod tests {
 
     #[test]
     fn test_region_panel_hints_simplified() {
-        let hints = get_hints(true, crate::panel::PanelId::Region);
+        let hints = StatusBarWidget::shortcut_hints(true, crate::panel::PanelId::Region);
         assert_eq!(hints[0], ("j/k", "↑↓"));
         assert_eq!(hints[1], ("Tab/S-Tab", "Switch"));
     }
 
     #[test]
     fn test_stats_panel_hints_simplified() {
-        let hints = get_hints(true, crate::panel::PanelId::Stats);
+        let hints = StatusBarWidget::shortcut_hints(true, crate::panel::PanelId::Stats);
         assert_eq!(hints.len(), 4);
         assert_eq!(hints[0], ("Tab/S-Tab", "Switch"));
     }


### PR DESCRIPTION
## Changes

Simplify status bar key hints by merging related keys and using abbreviations.

### Before
```
[VIEW] /: Search │ f: Filter │ -: Exclude │ =: Include │ _: ExclField │ +: InclField │ Enter: Detail │ c: Columns │ ?: Help
[DETAIL] Tab: Next Tab │ Ctrl+↑: Back │ z: Maximize │ Esc: Close │ ?: Help
```

### After
```
[VIEW] j/k: ↑↓ │ /: Search │ f: Filter │ -/=: Exclude/Include │ Enter: Detail │ ?: Help
[DETAIL] h/l: Fold │ H/L: All │ Tab/S-Tab: Switch │ Ctrl+↑: Back │ z: Max │ Esc: Close
[REGION] j/k: ↑↓ │ Tab/S-Tab: Switch │ Ctrl+↑: Back │ z: Max │ Esc: Close
[STATS] Tab/S-Tab: Switch │ Ctrl+↑: Back │ z: Max │ Esc: Close
```

### Tests
- `test_view_mode_hints_simplified`
- `test_detail_panel_hints_simplified`
- `test_region_panel_hints_simplified`
- `test_stats_panel_hints_simplified`

711 tests ✅ | Closes #446