### PR TITLE
[PM Spec] Detail panel arrow keys, remove Ctrl+arrow shortcuts

### DIFF
--- a/crates/scouty-tui/spec/overview.md
+++ b/crates/scouty-tui/spec/overview.md
@@ -133,9 +133,7 @@ Components notify App via return values or callbacks. App updates shared state (
 | `M` | Bookmark manager |
 | `S` | Stats summary |
 | `r` / `R` | Region panel / jump to next region start |
-| `Ctrl+↓` | Focus panel (expand if collapsed) |
-| `Ctrl+↑` | Focus log table (from panel) |
-| `Ctrl+←`/`Ctrl+→` | Switch between panels |
+| `Tab`/`Shift+Tab` | Cycle focus: Log Table → Detail → Region → Stats → Log Table (expand if collapsed) |
 | `z` | Toggle panel maximize/restore |
 | `]`/`[` | Relative time jump (forward/backward) |
 | `Ctrl+]` | Toggle follow mode |

--- a/crates/scouty-tui/spec/panel-system.md
+++ b/crates/scouty-tui/spec/panel-system.md
@@ -25,8 +25,7 @@ The detail panel and region UI (region manager + density chart) currently have i
 - [ ] **Panel Framework** — unified panel trait/interface defining render, keybinding, collapse/expand behavior (dependency: none)
 - [ ] **Detail Panel Migration** — migrate existing detail panel to a panel system instance (dependency: Panel Framework)
 - [ ] **Region Panel** — combine region manager + region density chart into a single region panel (dependency: Panel Framework)
-- [ ] **Panel Switching** — `Ctrl+←`/`Ctrl+→` to switch between panels (dependency: Panel Framework)
-- [ ] **Focus Switching** — `Ctrl+↑`/`Ctrl+↓` to switch focus between log table and current panel (dependency: Panel Framework)
+- [ ] **Panel Switching** — `Tab`/`Shift+Tab` to cycle focus between log table and panels (dependency: Panel Framework)
 - [ ] **Panel Maximize** — `z` to toggle maximize/restore; maximized panel fills log table + panel area (dependency: Panel Framework)
 
 ### P1 — Should Have
@@ -87,13 +86,10 @@ Focus switching:
 
 | Shortcut | Behavior |
 |----------|----------|
-| `Ctrl+↓` | Log Table → Panel Content (expand current panel, focus enters panel) |
-| `Ctrl+↑` | Panel Content → Log Table (focus returns to log table, panel stays expanded) |
-| `Ctrl+←` / `Ctrl+→` | Switch to previous/next panel (if expanded, switch content; if collapsed, only switch tab highlight). **Note:** may not work in macOS Terminal.app or terminals that don't emit xterm-style modifier sequences. |
-| `Tab` | Cycle focus forward: Log Table → Detail → Region → Log Table → … (expands panel if collapsed) |
+| `Tab` | Cycle focus forward: Log Table → Detail → Region → Stats → Log Table → … (expands panel if collapsed) |
 | `Shift+Tab` | Cycle focus backward (reverse of Tab) |
 | `Esc` | Panel Content → Log Table (focus returns to log table) |
-| Original shortcut | Directly open/close corresponding panel without changing focus (e.g., `Enter` toggles Detail, `r` toggles Region, `S` toggles Stats). Focus stays on the current widget (typically log table). Use `Ctrl+↓` or `Tab` to move focus into the panel. |
+| Original shortcut | Directly open/close corresponding panel without changing focus (e.g., `Enter` toggles Detail, `r` toggles Region, `S` toggles Stats). Focus stays on the current widget (typically log table). Use `Tab` to move focus into the panel. |
 
 #### Shared Panel Operations (all panels)
 
@@ -101,11 +97,8 @@ Focus switching:
 |----------|----------|
 | `j`/`k` | Navigate up/down within panel |
 | `Esc` | Return focus to log table |
-| `Ctrl+↑` | Return focus to log table |
-| `Ctrl+↓` | (no-op when already in panel) |
-| `Ctrl+←`/`Ctrl+→` | Switch panel |
-| `Tab` | Cycle to next panel or back to log table |
-| `Shift+Tab` | Cycle to previous panel or back to log table |
+| `Esc` | Return focus to log table |
+| `Tab`/`Shift+Tab` | Cycle to next/previous panel or back to log table |
 
 **Maximize:**
 
@@ -144,7 +137,7 @@ Panel-specific operations:
 | Shortcut | Behavior |
 |----------|----------|
 | `Tab` | Switch focus between left and right areas |
-| `h`/`l` | Collapse/expand tree node (left side expansion tree) |
+| `←`/`→` | Collapse/expand tree node (left side expansion tree) |
 | `H`/`L` | Collapse all / expand all |
 | `f` | Create filter from current field |
 
@@ -216,9 +209,9 @@ Gutter markers in the log table (▶/│/◀) are preserved unchanged. They are 
 
 ## Acceptance Criteria
 
-- [ ] `Enter` opens Detail panel, then `Ctrl+→` switches to Region panel
+- [ ] `Enter` opens Detail panel, then `Tab` switches to Region panel
 - [ ] `r` directly opens Region panel
-- [ ] `Ctrl+↑`/`Ctrl+↓` switch focus between log table and panel
+- [ ] `Tab`/`Shift+Tab` cycle focus between log table and panels
 - [ ] Tab bar takes only one line when collapsed
 - [ ] Log table height auto-shrinks when panel expands
 - [ ] Region panel left-right split: left region list, right timeline (~30% width, min 40 chars)

--- a/crates/scouty-tui/spec/status-bar.md
+++ b/crates/scouty-tui/spec/status-bar.md
@@ -94,17 +94,17 @@ Shortcut hints are **dynamically collected** from the widget tree — see [ui-ar
 
 **Detail Panel focus:**
 ```
-[DETAIL] h/l: Fold │ H/L: All │ Tab/S-Tab: Switch │ Ctrl+↑: Back │ z: Max │ Esc: Close
+[DETAIL] ←/→: Fold │ H/L: All │ Tab/S-Tab: Switch │ z: Max │ Esc: Close
 ```
 
 **Region Panel focus:**
 ```
-[REGION] j/k: ↑↓ │ Tab/S-Tab: Switch │ Ctrl+↑: Back │ z: Max │ Esc: Close
+[REGION] j/k: ↑↓ │ Tab/S-Tab: Switch │ z: Max │ Esc: Close
 ```
 
 **Stats Panel focus:**
 ```
-[STATS] Tab/S-Tab: Switch │ Ctrl+↑: Back │ z: Max │ Esc: Close
+[STATS] Tab/S-Tab: Switch │ z: Max │ Esc: Close
 ```
 
 When focus switches (e.g., `Ctrl+↓` to enter panel, `Tab` to switch panel, `Ctrl+↑` to return to log table), the status bar line 2 immediately updates to show the relevant shortcuts for the new context.

--- a/crates/scouty-tui/spec/ui-architecture.md
+++ b/crates/scouty-tui/spec/ui-architecture.md
@@ -143,9 +143,9 @@ The status bar collects shortcut hints by walking the widget tree from the **foc
 ```
 RegionPanelWidget.shortcut_hints() → [("j/k", "↑↓"), ("Enter", "Jump")]
 TabbedContainer.shortcut_hints()   → [("Tab/S-Tab", "Switch")]
-MainWindow.shortcut_hints()        → [("Ctrl+↑", "Back"), ("z", "Max"), ("Esc", "Close")]
+MainWindow.shortcut_hints()        → [("z", "Max"), ("Esc", "Close")]
 
-Status bar: [REGION] j/k: ↑↓ │ Enter: Jump │ Tab/S-Tab: Switch │ Ctrl+↑: Back │ z: Max │ Esc: Close
+Status bar: [REGION] j/k: ↑↓ │ Enter: Jump │ Tab/S-Tab: Switch │ z: Max │ Esc: Close
 ```
 
 **Example — focus on LogTableWidget:**


### PR DESCRIPTION
Two changes:

**1. Detail panel fold/expand keys:** `h`/`l` → `←`/`→` (arrow keys)
- More intuitive: left collapses, right expands
- `H`/`L` (collapse all / expand all) remains unchanged

**2. Remove all Ctrl+arrow shortcuts:**
- `Ctrl+↑`/`Ctrl+↓` (focus switching) — removed
- `Ctrl+←`/`Ctrl+→` (panel switching) — removed
- `Tab`/`Shift+Tab` is now the sole mechanism for both focus cycling and panel switching
- `Esc` returns to log table from panel

Simplifies keybindings and avoids terminal compatibility issues with Ctrl+arrow.

Updated: panel-system.md, overview.md, status-bar.md, ui-architecture.md