### PR TITLE
Remove Ctrl+Arrow keys and change detail fold to ←/→

### DIFF
--- a/crates/scouty-tui/src/ui/framework.rs
+++ b/crates/scouty-tui/src/ui/framework.rs
@@ -510,22 +510,13 @@ impl Widget for TabbedContainer {
     }
 
     fn handle_key(&mut self, event: KeyEvent) -> KeyAction {
-        use crossterm::event::{KeyCode, KeyModifiers};
-
-        // Ctrl+Right → next tab
-        if event.modifiers.contains(KeyModifiers::CONTROL) && event.code == KeyCode::Right {
-            self.next_tab();
-            return KeyAction::Handled;
-        }
-        // Ctrl+Left → prev tab
-        if event.modifiers.contains(KeyModifiers::CONTROL) && event.code == KeyCode::Left {
-            self.prev_tab();
-            return KeyAction::Handled;
-        }
+        use crossterm::event::KeyCode;
 
         // Shortcut keys for direct tab activation
         if let KeyCode::Char(c) = event.code {
-            if event.modifiers.is_empty() || event.modifiers == KeyModifiers::SHIFT {
+            if event.modifiers.is_empty()
+                || event.modifiers == crossterm::event::KeyModifiers::SHIFT
+            {
                 for (i, tab) in self.tabs.iter().enumerate() {
                     if tab.shortcut == Some(c) {
                         self.active = i;

--- a/crates/scouty-tui/src/ui/framework_tests.rs
+++ b/crates/scouty-tui/src/ui/framework_tests.rs
@@ -486,17 +486,15 @@ mod tests {
     }
 
     #[test]
-    fn tabbed_container_ctrl_arrows() {
+    fn tabbed_container_ctrl_arrows_removed() {
         let mut tc = make_test_tabbed();
 
         let ctrl_right = KeyEvent::new(KeyCode::Right, KeyModifiers::CONTROL);
         let ctrl_left = KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL);
 
-        assert_eq!(tc.handle_key(ctrl_right), KeyAction::Handled);
-        assert_eq!(tc.active, 1);
-
-        assert_eq!(tc.handle_key(ctrl_left), KeyAction::Handled);
-        assert_eq!(tc.active, 0);
+        // Ctrl+Arrow should no longer be handled
+        assert_eq!(tc.handle_key(ctrl_right), KeyAction::Unhandled);
+        assert_eq!(tc.handle_key(ctrl_left), KeyAction::Unhandled);
     }
 
     #[test]

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -36,26 +36,21 @@ impl StatusBarWidget {
         if panel_focused {
             match active {
                 crate::panel::PanelId::Detail => &[
-                    ("h/l", "Fold"),
+                    ("←/→", "Fold"),
                     ("H/L", "All"),
                     ("Tab/S-Tab", "Switch"),
-                    ("Ctrl+↑", "Back"),
                     ("z", "Max"),
                     ("Esc", "Close"),
                 ],
                 crate::panel::PanelId::Region => &[
                     ("j/k", "↑↓"),
                     ("Tab/S-Tab", "Switch"),
-                    ("Ctrl+↑", "Back"),
                     ("z", "Max"),
                     ("Esc", "Close"),
                 ],
-                crate::panel::PanelId::Stats => &[
-                    ("Tab/S-Tab", "Switch"),
-                    ("Ctrl+↑", "Back"),
-                    ("z", "Max"),
-                    ("Esc", "Close"),
-                ],
+                crate::panel::PanelId::Stats => {
+                    &[("Tab/S-Tab", "Switch"), ("z", "Max"), ("Esc", "Close")]
+                }
             }
         } else {
             &[

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
@@ -192,10 +192,12 @@ mod tests {
     #[test]
     fn test_detail_panel_hints_simplified() {
         let hints = StatusBarWidget::shortcut_hints(true, crate::panel::PanelId::Detail);
-        assert_eq!(hints[0], ("h/l", "Fold"));
+        assert_eq!(hints[0], ("←/→", "Fold"));
         assert_eq!(hints[1], ("H/L", "All"));
         assert_eq!(hints[2], ("Tab/S-Tab", "Switch"));
-        assert_eq!(hints[4], ("z", "Max")); // abbreviated
+        assert_eq!(hints[3], ("z", "Max"));
+        assert_eq!(hints[4], ("Esc", "Close"));
+        assert_eq!(hints.len(), 5);
     }
 
     #[test]
@@ -203,12 +205,13 @@ mod tests {
         let hints = StatusBarWidget::shortcut_hints(true, crate::panel::PanelId::Region);
         assert_eq!(hints[0], ("j/k", "↑↓"));
         assert_eq!(hints[1], ("Tab/S-Tab", "Switch"));
+        assert_eq!(hints.len(), 4);
     }
 
     #[test]
     fn test_stats_panel_hints_simplified() {
         let hints = StatusBarWidget::shortcut_hints(true, crate::panel::PanelId::Stats);
-        assert_eq!(hints.len(), 4);
+        assert_eq!(hints.len(), 3);
         assert_eq!(hints[0], ("Tab/S-Tab", "Switch"));
     }
 }

--- a/crates/scouty-tui/src/ui/windows/help_window.rs
+++ b/crates/scouty-tui/src/ui/windows/help_window.rs
@@ -91,8 +91,6 @@ impl<'a> HelpWindow<'a> {
             Line::from("  s                Save / export dialog"),
             Line::from(""),
             section("Panel Navigation"),
-            Line::from("  Ctrl+↓ / Ctrl+↑  Focus panel / log table"),
-            Line::from("  Ctrl+← / Ctrl+→  Switch panel (may not work in all terminals)"),
             Line::from("  Tab              Cycle focus forward (panel expanded)"),
             Line::from("  Shift+Tab        Cycle focus backward (panel expanded)"),
             Line::from("  z                Toggle maximize panel"),

--- a/crates/scouty-tui/src/ui/windows/main_window.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window.rs
@@ -38,11 +38,11 @@ impl MainWindow {
                 self.app.detail_tree_move_up();
                 true
             }
-            KeyCode::Char('l') | KeyCode::Enter => {
+            KeyCode::Right | KeyCode::Enter => {
                 self.app.detail_tree_toggle();
                 true
             }
-            KeyCode::Char('h') => {
+            KeyCode::Left => {
                 self.app.detail_tree_collapse_or_parent();
                 true
             }
@@ -135,28 +135,9 @@ impl MainWindow {
         }
     }
 
-    /// Handle panel system keys (Ctrl+arrows, Tab/BackTab, z).
+    /// Handle panel system keys (Tab/BackTab, z).
     fn handle_panel_keys(&mut self, key: KeyEvent) -> KeyAction {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let handled = match key.code {
-            KeyCode::Down if ctrl => {
-                self.app.panel_state.focus_panel();
-                self.app.detail_open = self.app.panel_state.expanded
-                    && self.app.panel_state.active == crate::panel::PanelId::Detail;
-                true
-            }
-            KeyCode::Up if ctrl => {
-                self.app.panel_state.focus_log_table();
-                true
-            }
-            KeyCode::Right if ctrl => {
-                self.app.panel_state.next_panel();
-                true
-            }
-            KeyCode::Left if ctrl => {
-                self.app.panel_state.prev_panel();
-                true
-            }
             KeyCode::Tab if key.modifiers.is_empty() => {
                 if self.app.panel_state.focus == crate::panel::PanelFocus::LogTable {
                     self.app.panel_state.active = crate::panel::PanelId::all()[0];
@@ -734,7 +715,7 @@ impl Window for MainWindow {
 
         if panel_focused {
             // Panel-level hints (MainWindow acts as root)
-            vec![("Ctrl+↑", "Back"), ("z", "Max"), ("Esc", "Close")]
+            vec![("z", "Max"), ("Esc", "Close")]
         } else if self.app.follow_mode {
             vec![("Esc", "Stop Follow"), ("?", "Help")]
         } else {

--- a/crates/scouty-tui/src/ui/windows/main_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window_tests.rs
@@ -92,20 +92,10 @@ mod tests {
     }
 
     #[test]
-    fn test_panel_ctrl_down_focuses_panel() {
+    fn test_ctrl_arrows_no_longer_focus_panel() {
         let mut mw = make_main_window();
-        let result = mw.handle_key(ctrl_key(KeyCode::Down));
-        assert_eq!(result, WindowAction::Handled);
-        assert!(mw.app.panel_state.has_focus());
-    }
-
-    #[test]
-    fn test_panel_ctrl_up_focuses_log_table() {
-        let mut mw = make_main_window();
-        mw.handle_key(ctrl_key(KeyCode::Down));
-        assert!(mw.app.panel_state.has_focus());
-        let result = mw.handle_key(ctrl_key(KeyCode::Up));
-        assert_eq!(result, WindowAction::Handled);
+        // Ctrl+Down should NOT focus panel anymore
+        let _result = mw.handle_key(ctrl_key(KeyCode::Down));
         assert!(!mw.app.panel_state.has_focus());
     }
 
@@ -117,6 +107,14 @@ mod tests {
 
         // j should move down in detail tree
         let result = mw.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(result, WindowAction::Handled);
+
+        // Right arrow should toggle/expand node
+        let result = mw.handle_key(key(KeyCode::Right));
+        assert_eq!(result, WindowAction::Handled);
+
+        // Left arrow should collapse/go to parent
+        let result = mw.handle_key(key(KeyCode::Left));
         assert_eq!(result, WindowAction::Handled);
 
         // Esc should exit detail tree focus


### PR DESCRIPTION
## Changes

Per spec PR #451 — major keybinding simplification:

### Removed
- `Ctrl+↑/↓` — focus jump between log table and panel
- `Ctrl+←/→` — switch between panel tabs
- Removed from: MainWindow, TabbedContainer, help window

### Changed
- Detail tree fold: `h` → `←` (Left arrow), `l` → `→` (Right arrow)
- `H/L` (fold all/unfold all) unchanged
- `Tab/Shift+Tab` is now the sole focus cycling mechanism
- `Esc` from panel returns to log table

### Status bar hints updated
```
[DETAIL] ←/→: Fold │ H/L: All │ Tab/S-Tab: Switch │ z: Max │ Esc: Close
[REGION] j/k: ↑↓ │ Tab/S-Tab: Switch │ z: Max │ Esc: Close
[STATS]  Tab/S-Tab: Switch │ z: Max │ Esc: Close
```

### Tests
- `tabbed_container_ctrl_arrows_removed` — verify Ctrl+Arrow unhandled
- `test_ctrl_arrows_no_longer_focus_panel` — verify no panel focus change
- `test_detail_tree_nav_when_focused` — verify ←/→ fold in detail tree
- Updated all hint assertion tests

726 tests ✅ | Closes #452