### PR TITLE
UI Architecture Phase 3: Extract panel key handlers

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/detail_panel_keys.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_keys.rs
@@ -1,0 +1,62 @@
+//! Detail panel key handling and shortcut hints.
+//!
+//! Extracted from MainWindow — handles tree navigation when the detail
+//! panel has focus.
+
+#[cfg(test)]
+#[path = "detail_panel_keys_tests.rs"]
+mod detail_panel_keys_tests;
+
+use crate::app::App;
+use crate::ui::framework::KeyAction;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Handle a key event when the detail panel tree has focus.
+pub fn handle_key(app: &mut App, key: KeyEvent) -> KeyAction {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let handled = match key.code {
+        KeyCode::Char('j') | KeyCode::Down if !ctrl => {
+            app.detail_tree_move_down();
+            true
+        }
+        KeyCode::Char('k') | KeyCode::Up if !ctrl => {
+            app.detail_tree_move_up();
+            true
+        }
+        KeyCode::Right | KeyCode::Enter => {
+            app.detail_tree_toggle();
+            true
+        }
+        KeyCode::Left => {
+            app.detail_tree_collapse_or_parent();
+            true
+        }
+        KeyCode::Char('H') => {
+            app.detail_tree_collapse_all();
+            true
+        }
+        KeyCode::Char('L') => {
+            app.detail_tree_expand_all();
+            true
+        }
+        KeyCode::Char('f') => {
+            app.detail_tree_quick_filter();
+            true
+        }
+        KeyCode::Esc => {
+            app.detail_tree_focus = false;
+            true
+        }
+        _ => false,
+    };
+    if handled {
+        KeyAction::Handled
+    } else {
+        KeyAction::Unhandled
+    }
+}
+
+/// Shortcut hints for the detail panel (tree focused).
+pub fn shortcut_hints() -> Vec<(&'static str, &'static str)> {
+    vec![("←/→", "Fold"), ("H/L", "All")]
+}

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_keys_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_keys_tests.rs
@@ -1,0 +1,55 @@
+#[cfg(test)]
+mod tests {
+    use crate::app::App;
+    use crate::ui::framework::KeyAction;
+    use crate::ui::widgets::detail_panel_keys::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn test_app() -> App {
+        let mut app = App::load_stdin(Vec::new()).unwrap();
+        app.detail_open = true;
+        app.detail_tree_focus = true;
+        app
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn test_j_handled() {
+        let mut app = test_app();
+        assert_eq!(
+            handle_key(&mut app, key(KeyCode::Char('j'))),
+            KeyAction::Handled
+        );
+    }
+
+    #[test]
+    fn test_esc_exits_focus() {
+        let mut app = test_app();
+        assert_eq!(handle_key(&mut app, key(KeyCode::Esc)), KeyAction::Handled);
+        assert!(!app.detail_tree_focus);
+    }
+
+    #[test]
+    fn test_unhandled_key() {
+        let mut app = test_app();
+        assert_eq!(
+            handle_key(&mut app, key(KeyCode::Char('x'))),
+            KeyAction::Unhandled
+        );
+    }
+
+    #[test]
+    fn test_shortcut_hints() {
+        let hints = shortcut_hints();
+        assert_eq!(hints[0], ("←/→", "Fold"));
+        assert_eq!(hints[1], ("H/L", "All"));
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/mod.rs
+++ b/crates/scouty-tui/src/ui/widgets/mod.rs
@@ -1,9 +1,12 @@
 //! Persistent widget components (always present in the layout).
 
+pub mod detail_panel_keys;
 pub mod detail_panel_widget;
 pub mod filter_input_widget;
 pub mod log_table_widget;
+pub mod region_panel_keys;
 pub mod region_panel_widget;
 pub mod search_input_widget;
+pub mod stats_panel_keys;
 pub mod stats_panel_widget;
 pub mod status_bar_widget;

--- a/crates/scouty-tui/src/ui/widgets/region_panel_keys.rs
+++ b/crates/scouty-tui/src/ui/widgets/region_panel_keys.rs
@@ -1,0 +1,79 @@
+//! Region panel key handling and shortcut hints.
+//!
+//! Extracted from MainWindow — handles navigation when the region
+//! panel has focus.
+
+#[cfg(test)]
+#[path = "region_panel_keys_tests.rs"]
+mod region_panel_keys_tests;
+
+use crate::app::App;
+use crate::ui::framework::KeyAction;
+use crate::ui::widgets::region_panel_widget::RegionPanelWidget;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Handle a key event when the region panel has focus.
+pub fn handle_key(app: &mut App, key: KeyEvent) -> KeyAction {
+    let entries = RegionPanelWidget::build_entries(app);
+    let max_cursor = entries.len().saturating_sub(1);
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+    let handled = match key.code {
+        KeyCode::Char('j') | KeyCode::Down if !ctrl => {
+            if app.region_manager_cursor < max_cursor {
+                app.region_manager_cursor += 1;
+            }
+            true
+        }
+        KeyCode::Char('k') | KeyCode::Up if !ctrl => {
+            if app.region_manager_cursor > 0 {
+                app.region_manager_cursor -= 1;
+            }
+            true
+        }
+        KeyCode::Enter => {
+            if let Some(entry) = entries.get(app.region_manager_cursor) {
+                app.jump_to_record_index(entry.start_index);
+                app.panel_state.focus_log_table();
+            }
+            true
+        }
+        KeyCode::Char('f') => {
+            if let Some(entry) = entries.get(app.region_manager_cursor) {
+                let expr = format!("_region_type == \"{}\"", entry.definition_name);
+                app.add_filter_expr(&expr);
+            }
+            true
+        }
+        KeyCode::Char('t') => {
+            if let Some(entry) = entries.get(app.region_manager_cursor) {
+                if app.region_panel_type_filter.as_deref() == Some(&entry.definition_name) {
+                    app.region_panel_type_filter = None;
+                } else {
+                    app.region_panel_type_filter = Some(entry.definition_name.clone());
+                }
+                app.region_manager_cursor = 0;
+            }
+            true
+        }
+        KeyCode::Char('s') => {
+            app.region_panel_sort = app.region_panel_sort.toggle();
+            true
+        }
+        KeyCode::Esc => {
+            app.panel_state.focus_log_table();
+            true
+        }
+        _ => false,
+    };
+    if handled {
+        KeyAction::Handled
+    } else {
+        KeyAction::Unhandled
+    }
+}
+
+/// Shortcut hints for the region panel.
+pub fn shortcut_hints() -> Vec<(&'static str, &'static str)> {
+    vec![("j/k", "↑↓")]
+}

--- a/crates/scouty-tui/src/ui/widgets/region_panel_keys_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/region_panel_keys_tests.rs
@@ -1,0 +1,60 @@
+#[cfg(test)]
+mod tests {
+    use crate::app::App;
+    use crate::ui::framework::KeyAction;
+    use crate::ui::widgets::region_panel_keys::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn test_app() -> App {
+        App::load_stdin(Vec::new()).unwrap()
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn test_j_handled() {
+        let mut app = test_app();
+        assert_eq!(
+            handle_key(&mut app, key(KeyCode::Char('j'))),
+            KeyAction::Handled
+        );
+    }
+
+    #[test]
+    fn test_s_toggles_sort() {
+        let mut app = test_app();
+        let original = app.region_panel_sort;
+        handle_key(&mut app, key(KeyCode::Char('s')));
+        assert_ne!(app.region_panel_sort, original);
+    }
+
+    #[test]
+    fn test_esc_focuses_log_table() {
+        let mut app = test_app();
+        app.panel_state.focus_panel();
+        handle_key(&mut app, key(KeyCode::Esc));
+        assert_eq!(app.panel_state.focus, crate::panel::PanelFocus::LogTable);
+    }
+
+    #[test]
+    fn test_unhandled_key() {
+        let mut app = test_app();
+        assert_eq!(
+            handle_key(&mut app, key(KeyCode::Char('x'))),
+            KeyAction::Unhandled
+        );
+    }
+
+    #[test]
+    fn test_shortcut_hints() {
+        let hints = shortcut_hints();
+        assert_eq!(hints[0], ("j/k", "↑↓"));
+    }
+}

--- a/crates/scouty-tui/src/ui/widgets/stats_panel_keys.rs
+++ b/crates/scouty-tui/src/ui/widgets/stats_panel_keys.rs
@@ -1,0 +1,10 @@
+//! Stats panel shortcut hints.
+//!
+//! The stats panel has no interactive keys — it's read-only.
+//! Common panel keys (Tab/S-Tab to switch, z to maximize, Esc to close)
+//! are handled by MainWindow and included in its hints.
+
+/// Shortcut hints for the stats panel (empty — no panel-specific keys).
+pub fn shortcut_hints() -> Vec<(&'static str, &'static str)> {
+    vec![]
+}

--- a/crates/scouty-tui/src/ui/windows/main_window.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window.rs
@@ -11,7 +11,7 @@ mod main_window_tests;
 use crate::app::{App, InputMode};
 use crate::keybinding::{Action, Keymap};
 use crate::ui::framework::{KeyAction, Window, WindowAction};
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::layout::Rect;
 use ratatui::Frame;
 
@@ -28,111 +28,12 @@ impl MainWindow {
 
     /// Handle keys when detail tree has focus.
     fn handle_detail_tree_key(&mut self, key: KeyEvent) -> KeyAction {
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-        let handled = match key.code {
-            KeyCode::Char('j') | KeyCode::Down if !ctrl => {
-                self.app.detail_tree_move_down();
-                true
-            }
-            KeyCode::Char('k') | KeyCode::Up if !ctrl => {
-                self.app.detail_tree_move_up();
-                true
-            }
-            KeyCode::Right | KeyCode::Enter => {
-                self.app.detail_tree_toggle();
-                true
-            }
-            KeyCode::Left => {
-                self.app.detail_tree_collapse_or_parent();
-                true
-            }
-            KeyCode::Char('H') => {
-                self.app.detail_tree_collapse_all();
-                true
-            }
-            KeyCode::Char('L') => {
-                self.app.detail_tree_expand_all();
-                true
-            }
-            KeyCode::Char('f') => {
-                self.app.detail_tree_quick_filter();
-                true
-            }
-            KeyCode::Esc => {
-                self.app.detail_tree_focus = false;
-                true
-            }
-            _ => false,
-        };
-        if handled {
-            KeyAction::Handled
-        } else {
-            KeyAction::Unhandled
-        }
+        crate::ui::widgets::detail_panel_keys::handle_key(&mut self.app, key)
     }
 
     /// Handle keys when region panel has focus.
     fn handle_region_panel_key(&mut self, key: KeyEvent) -> KeyAction {
-        use crate::ui::widgets::region_panel_widget::RegionPanelWidget;
-
-        let entries = RegionPanelWidget::build_entries(&self.app);
-        let max_cursor = entries.len().saturating_sub(1);
-        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-
-        let handled = match key.code {
-            KeyCode::Char('j') | KeyCode::Down if !ctrl => {
-                if self.app.region_manager_cursor < max_cursor {
-                    self.app.region_manager_cursor += 1;
-                }
-                true
-            }
-            KeyCode::Char('k') | KeyCode::Up if !ctrl => {
-                if self.app.region_manager_cursor > 0 {
-                    self.app.region_manager_cursor -= 1;
-                }
-                true
-            }
-            KeyCode::Enter => {
-                if let Some(entry) = entries.get(self.app.region_manager_cursor) {
-                    self.app.jump_to_record_index(entry.start_index);
-                    self.app.panel_state.focus_log_table();
-                }
-                true
-            }
-            KeyCode::Char('f') => {
-                if let Some(entry) = entries.get(self.app.region_manager_cursor) {
-                    let expr = format!("_region_type == \"{}\"", entry.definition_name);
-                    self.app.add_filter_expr(&expr);
-                }
-                true
-            }
-            KeyCode::Char('t') => {
-                if let Some(entry) = entries.get(self.app.region_manager_cursor) {
-                    if self.app.region_panel_type_filter.as_deref() == Some(&entry.definition_name)
-                    {
-                        self.app.region_panel_type_filter = None;
-                    } else {
-                        self.app.region_panel_type_filter = Some(entry.definition_name.clone());
-                    }
-                    self.app.region_manager_cursor = 0;
-                }
-                true
-            }
-            KeyCode::Char('s') => {
-                self.app.region_panel_sort = self.app.region_panel_sort.toggle();
-                true
-            }
-            KeyCode::Esc => {
-                self.app.panel_state.focus_log_table();
-                true
-            }
-            _ => false,
-        };
-        if handled {
-            KeyAction::Handled
-        } else {
-            KeyAction::Unhandled
-        }
+        crate::ui::widgets::region_panel_keys::handle_key(&mut self.app, key)
     }
 
     /// Handle panel system keys (Tab/BackTab, z).
@@ -714,8 +615,23 @@ impl Window for MainWindow {
             && self.app.panel_state.focus == crate::panel::PanelFocus::PanelContent;
 
         if panel_focused {
-            // Panel-level hints (MainWindow acts as root)
-            vec![("z", "Max"), ("Esc", "Close")]
+            // Collect panel-specific hints first, then common panel hints
+            let mut hints: Vec<(&str, &str)> = match self.app.panel_state.active {
+                crate::panel::PanelId::Detail => {
+                    crate::ui::widgets::detail_panel_keys::shortcut_hints()
+                }
+                crate::panel::PanelId::Region => {
+                    crate::ui::widgets::region_panel_keys::shortcut_hints()
+                }
+                crate::panel::PanelId::Stats => {
+                    crate::ui::widgets::stats_panel_keys::shortcut_hints()
+                }
+            };
+            // Common panel hints from MainWindow
+            hints.push(("Tab/S-Tab", "Switch"));
+            hints.push(("z", "Max"));
+            hints.push(("Esc", "Close"));
+            hints
         } else if self.app.follow_mode {
             vec![("Esc", "Stop Follow"), ("?", "Help")]
         } else {


### PR DESCRIPTION
## Summary

Extract detail/region/stats panel key handling from MainWindow into dedicated modules, completing Phase 3 of the UI architecture migration.

### Changes

- **detail_panel_keys**: handles tree navigation (j/k/h/l/H/L/f/Esc) with shortcut hints
- **region_panel_keys**: handles region list (j/k/Enter/f/t/s/Esc) with shortcut hints  
- **stats_panel_keys**: shortcut hints only (read-only panel, no interactive keys)

Each module provides:
- `handle_key(app, key) -> KeyAction`: panel-specific key dispatch
- `shortcut_hints() -> Vec<hints>`: panel-specific status bar hints

MainWindow now delegates to these modules and collects hints dynamically: panel-specific hints first, then common panel hints (Tab/S-Tab, z, Esc).

### Testing

- 9 new tests across panel key modules
- 391 total tests pass
- Clippy clean

Closes #436