### PR TITLE
Add CategoryStore data model and YAML config loading

### DIFF
--- a/crates/scouty/src/category.rs
+++ b/crates/scouty/src/category.rs
@@ -1,0 +1,206 @@
+//! Log categorization — data model, config loading, and stats tracking.
+//!
+//! Categories are named classification rules with filter expressions.
+//! Each incoming log record is evaluated against all categories;
+//! matching records increment the category's count and density histogram.
+
+#[cfg(test)]
+#[path = "category_tests.rs"]
+mod category_tests;
+
+use crate::filter::expr::{self, Expr};
+use serde::Deserialize;
+use std::path::Path;
+
+// ── Data Model ──────────────────────────────────────────────────────
+
+/// A parsed category definition ready for evaluation.
+#[derive(Debug)]
+pub struct CategoryDefinition {
+    pub name: String,
+    pub filter: Expr,
+}
+
+/// Per-category runtime statistics.
+#[derive(Debug)]
+pub struct CategoryStats {
+    pub definition: CategoryDefinition,
+    pub count: usize,
+    /// Time-bucketed histogram (same bucketing as density chart).
+    pub density: Vec<u64>,
+}
+
+impl CategoryStats {
+    pub fn new(definition: CategoryDefinition, bucket_count: usize) -> Self {
+        Self {
+            definition,
+            count: 0,
+            density: vec![0; bucket_count],
+        }
+    }
+
+    /// Record a match, optionally updating the density bucket.
+    pub fn record_match(&mut self, bucket_index: Option<usize>) {
+        self.count += 1;
+        if let Some(idx) = bucket_index {
+            if idx < self.density.len() {
+                self.density[idx] += 1;
+            }
+        }
+    }
+
+    /// Resize density histogram (e.g., when time range changes).
+    pub fn resize_density(&mut self, new_len: usize) {
+        self.density.resize(new_len, 0);
+    }
+}
+
+/// Collection of category stats, ordered as defined in config.
+#[derive(Debug, Default)]
+pub struct CategoryStore {
+    pub categories: Vec<CategoryStats>,
+}
+
+impl CategoryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a store from parsed definitions with a given density bucket count.
+    pub fn from_definitions(definitions: Vec<CategoryDefinition>, bucket_count: usize) -> Self {
+        let categories = definitions
+            .into_iter()
+            .map(|d| CategoryStats::new(d, bucket_count))
+            .collect();
+        Self { categories }
+    }
+
+    /// Reset all counts and density data.
+    pub fn reset(&mut self) {
+        for cat in &mut self.categories {
+            cat.count = 0;
+            cat.density.fill(0);
+        }
+    }
+}
+
+// ── Config Loading ──────────────────────────────────────────────────
+
+/// Raw YAML category entry (before filter parsing).
+#[derive(Debug, Deserialize)]
+struct RawCategory {
+    name: String,
+    filter: String,
+}
+
+/// Raw YAML config file.
+#[derive(Debug, Deserialize)]
+struct RawCategoryConfig {
+    categories: Vec<RawCategory>,
+}
+
+/// Load category definitions from a single YAML file.
+/// Invalid filters produce warnings (via the returned Vec) and are skipped.
+pub(crate) fn load_file(path: &Path) -> (Vec<CategoryDefinition>, Vec<String>) {
+    let mut definitions = Vec::new();
+    let mut warnings = Vec::new();
+
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) => {
+            warnings.push(format!("Failed to read {}: {}", path.display(), e));
+            return (definitions, warnings);
+        }
+    };
+
+    let config: RawCategoryConfig = match serde_yaml::from_str(&content) {
+        Ok(c) => c,
+        Err(e) => {
+            warnings.push(format!("Failed to parse {}: {}", path.display(), e));
+            return (definitions, warnings);
+        }
+    };
+
+    for raw in config.categories {
+        match expr::parse(&raw.filter) {
+            Ok(filter) => {
+                tracing::debug!(name = %raw.name, filter = %raw.filter, "Loaded category");
+                definitions.push(CategoryDefinition {
+                    name: raw.name,
+                    filter,
+                });
+            }
+            Err(e) => {
+                warnings.push(format!(
+                    "Category '{}' has invalid filter '{}': {}",
+                    raw.name, raw.filter, e
+                ));
+            }
+        }
+    }
+
+    (definitions, warnings)
+}
+
+/// Load category definitions from all standard config directories.
+/// Returns definitions in precedence order (system → user → project).
+pub fn load_categories() -> (Vec<CategoryDefinition>, Vec<String>) {
+    let mut all_definitions = Vec::new();
+    let mut all_warnings = Vec::new();
+
+    let dirs = category_config_dirs();
+    for dir in dirs {
+        if !dir.exists() {
+            continue;
+        }
+        tracing::debug!(dir = %dir.display(), "Scanning category config directory");
+
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) => {
+                all_warnings.push(format!("Failed to read directory {}: {}", dir.display(), e));
+                continue;
+            }
+        };
+
+        let mut files: Vec<_> = entries
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .map(|ext| ext == "yaml" || ext == "yml")
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        // Sort for deterministic order
+        files.sort_by_key(|e| e.file_name());
+
+        for entry in files {
+            let (defs, warns) = load_file(&entry.path());
+            all_definitions.extend(defs);
+            all_warnings.extend(warns);
+        }
+    }
+
+    (all_definitions, all_warnings)
+}
+
+/// Return the standard category config directories in precedence order.
+fn category_config_dirs() -> Vec<std::path::PathBuf> {
+    let mut dirs = Vec::new();
+
+    // System
+    dirs.push(std::path::PathBuf::from("/etc/scouty/categories"));
+
+    // User
+    if let Some(home) = dirs::home_dir() {
+        dirs.push(home.join(".scouty").join("categories"));
+    }
+
+    // Project
+    dirs.push(std::path::PathBuf::from("./scouty-categories"));
+
+    dirs
+}

--- a/crates/scouty/src/category_tests.rs
+++ b/crates/scouty/src/category_tests.rs
@@ -1,0 +1,176 @@
+#[cfg(test)]
+mod tests {
+    use crate::category::*;
+    use crate::filter::expr;
+    use std::io::Write;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn make_definition(name: &str, filter_str: &str) -> CategoryDefinition {
+        CategoryDefinition {
+            name: name.to_string(),
+            filter: expr::parse(filter_str).unwrap(),
+        }
+    }
+
+    // ── CategoryStats tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_category_stats_new() {
+        let def = make_definition("test", "level == \"error\"");
+        let stats = CategoryStats::new(def, 10);
+        assert_eq!(stats.count, 0);
+        assert_eq!(stats.density.len(), 10);
+        assert!(stats.density.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn test_category_stats_record_match() {
+        let def = make_definition("test", "level == \"error\"");
+        let mut stats = CategoryStats::new(def, 5);
+
+        stats.record_match(Some(2));
+        assert_eq!(stats.count, 1);
+        assert_eq!(stats.density[2], 1);
+
+        stats.record_match(Some(2));
+        assert_eq!(stats.count, 2);
+        assert_eq!(stats.density[2], 2);
+
+        // No bucket
+        stats.record_match(None);
+        assert_eq!(stats.count, 3);
+
+        // Out of bounds bucket (should not panic)
+        stats.record_match(Some(100));
+        assert_eq!(stats.count, 4);
+    }
+
+    #[test]
+    fn test_category_stats_resize_density() {
+        let def = make_definition("test", "level == \"error\"");
+        let mut stats = CategoryStats::new(def, 5);
+        stats.density[0] = 10;
+        stats.resize_density(8);
+        assert_eq!(stats.density.len(), 8);
+        assert_eq!(stats.density[0], 10); // preserved
+        assert_eq!(stats.density[7], 0); // new zeros
+    }
+
+    // ── CategoryStore tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_store_from_definitions() {
+        let defs = vec![
+            make_definition("errors", "level == \"error\""),
+            make_definition("warnings", "level == \"warning\""),
+        ];
+        let store = CategoryStore::from_definitions(defs, 20);
+        assert_eq!(store.categories.len(), 2);
+        assert_eq!(store.categories[0].definition.name, "errors");
+        assert_eq!(store.categories[1].definition.name, "warnings");
+    }
+
+    #[test]
+    fn test_store_reset() {
+        let defs = vec![make_definition("test", "level == \"error\"")];
+        let mut store = CategoryStore::from_definitions(defs, 5);
+        store.categories[0].count = 42;
+        store.categories[0].density[0] = 10;
+        store.reset();
+        assert_eq!(store.categories[0].count, 0);
+        assert!(store.categories[0].density.iter().all(|&v| v == 0));
+    }
+
+    // ── Config loading tests ────────────────────────────────────────
+
+    #[test]
+    fn test_load_file_valid() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.yaml");
+        let mut f = std::fs::File::create(&file).unwrap();
+        write!(
+            f,
+            r#"categories:
+  - name: "Errors"
+    filter: 'level == "error"'
+  - name: "Warnings"
+    filter: 'level == "warning"'
+"#
+        )
+        .unwrap();
+
+        let (defs, warnings) = load_file(&file);
+        assert!(warnings.is_empty(), "warnings: {:?}", warnings);
+        assert_eq!(defs.len(), 2);
+        assert_eq!(defs[0].name, "Errors");
+        assert_eq!(defs[1].name, "Warnings");
+    }
+
+    #[test]
+    fn test_load_file_invalid_filter_skipped() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.yaml");
+        let mut f = std::fs::File::create(&file).unwrap();
+        write!(
+            f,
+            r#"categories:
+  - name: "Good"
+    filter: 'level == "error"'
+  - name: "Bad"
+    filter: '=== invalid ==='
+  - name: "Also Good"
+    filter: 'message contains "hello"'
+"#
+        )
+        .unwrap();
+
+        let (defs, warnings) = load_file(&file);
+        assert_eq!(defs.len(), 2, "Should skip invalid filter");
+        assert_eq!(defs[0].name, "Good");
+        assert_eq!(defs[1].name, "Also Good");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("Bad"));
+    }
+
+    #[test]
+    fn test_load_file_invalid_yaml() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("bad.yaml");
+        std::fs::write(&file, "not: valid: yaml: [[[").unwrap();
+
+        let (defs, warnings) = load_file(&file);
+        assert!(defs.is_empty());
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn test_load_file_missing() {
+        let (defs, warnings) = load_file(Path::new("/nonexistent/path.yaml"));
+        assert!(defs.is_empty());
+        assert_eq!(warnings.len(), 1);
+    }
+
+    #[test]
+    fn test_load_file_complex_filters() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.yaml");
+        let mut f = std::fs::File::create(&file).unwrap();
+        write!(
+            f,
+            r#"categories:
+  - name: "Complex AND"
+    filter: 'component == "bgp" AND level >= "info"'
+  - name: "Complex OR"
+    filter: 'level == "error" OR level == "critical"'
+  - name: "Contains"
+    filter: 'message contains "link state"'
+"#
+        )
+        .unwrap();
+
+        let (defs, warnings) = load_file(&file);
+        assert!(warnings.is_empty(), "warnings: {:?}", warnings);
+        assert_eq!(defs.len(), 3);
+    }
+}

--- a/crates/scouty/src/lib.rs
+++ b/crates/scouty/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod category;
 pub mod filter;
 pub mod loader;
 pub mod parser;


### PR DESCRIPTION
## Changes

Implement categorization Phase 1 per spec (PR #454).

### Data Model
- `CategoryDefinition` — name + parsed `Expr` filter
- `CategoryStats` — definition + count + density histogram (`Vec<u64>`)
- `CategoryStore` — ordered collection with `from_definitions()` and `reset()`

### Config Loading
- YAML files from 3 standard dirs: `/etc/scouty/categories/`, `~/.scouty/categories/`, `./scouty-categories/`
- Filter parsing reuses existing `filter::expr::parse()`
- Invalid filters → warning + skip (other categories still load)
- Files sorted alphabetically for deterministic order

### Config Format
```yaml
categories:
  - name: "BGP Updates"
    filter: 'component == "bgp" AND level >= "info"'
  - name: "Port Flaps"
    filter: 'message contains "link state changed"'
```

### Tests (10 new)
- `test_category_stats_new` / `record_match` / `resize_density`
- `test_store_from_definitions` / `reset`
- `test_load_file_valid` / `invalid_filter_skipped` / `invalid_yaml` / `missing` / `complex_filters`

736 tests ✅ | Closes #455