### PR TITLE
UI Phase 5: Complete overlay stack migration

### DIFF
--- a/crates/scouty-tui/src/ui/windows/main_window.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window.rs
@@ -121,26 +121,58 @@ impl MainWindow {
             Action::ScrollToTop => self.app.scroll_to_top(),
             Action::ScrollToBottom => self.app.scroll_to_bottom(),
             Action::ToggleDetail => self.app.toggle_detail(),
-            Action::Filter => self.app.input_mode = InputMode::Filter,
-            Action::Search => self.app.input_mode = InputMode::Search,
+            Action::Filter => {
+                self.app.input_mode = InputMode::Filter;
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::FilterOverlay::new(),
+                ));
+            }
+            Action::Search => {
+                self.app.input_mode = InputMode::Search;
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::SearchOverlay::new(),
+                ));
+            }
             Action::JumpForward => {
                 self.app.input_mode = InputMode::JumpForward;
                 self.app.time_input.clear();
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::JumpOverlay::new(true),
+                ));
             }
             Action::JumpBackward => {
                 self.app.input_mode = InputMode::JumpBackward;
                 self.app.time_input.clear();
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::JumpOverlay::new(false),
+                ));
             }
             Action::QuickExclude => {
                 self.app.input_mode = InputMode::QuickExclude;
                 self.app.quick_filter_input.clear();
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::QuickFilterOverlay::new(true),
+                ));
             }
             Action::QuickInclude => {
                 self.app.input_mode = InputMode::QuickInclude;
                 self.app.quick_filter_input.clear();
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::QuickFilterOverlay::new(false),
+                ));
             }
-            Action::FieldExclude => self.app.open_field_filter(true),
-            Action::FieldInclude => self.app.open_field_filter(false),
+            Action::FieldExclude => {
+                self.app.open_field_filter(true);
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::FieldFilterOverlay::new(),
+                ));
+            }
+            Action::FieldInclude => {
+                self.app.open_field_filter(false);
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::FieldFilterOverlay::new(),
+                ));
+            }
             Action::FilterManager => {
                 self.app.input_mode = InputMode::FilterManager;
                 self.app.filter_manager_cursor = 0;
@@ -175,6 +207,9 @@ impl MainWindow {
             Action::GotoLine => {
                 self.app.input_mode = InputMode::GotoLine;
                 self.app.goto_input.clear();
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::GotoLineOverlay::new(),
+                ));
             }
             Action::ToggleFollow => self.app.toggle_follow(),
             Action::NextMatch => self.app.next_search_match(),
@@ -187,6 +222,9 @@ impl MainWindow {
             Action::CopyFormat => {
                 self.app.input_mode = InputMode::CopyFormat;
                 self.app.copy_format_cursor = 0;
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::CopyFormatOverlay::new(),
+                ));
             }
             Action::Save => {
                 self.app.input_mode = InputMode::SaveDialog;
@@ -211,10 +249,16 @@ impl MainWindow {
             Action::Command => {
                 self.app.command_input.clear();
                 self.app.input_mode = InputMode::Command;
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::CommandOverlay::new(),
+                ));
             }
             Action::AddHighlight => {
                 self.app.input_mode = InputMode::Highlight;
                 self.app.highlight_input.clear();
+                self.overlay_stack.push(Box::new(
+                    crate::ui::windows::overlay_adapters::HighlightOverlay::new(),
+                ));
             }
             Action::HighlightManager => {
                 self.app.input_mode = InputMode::HighlightManager;
@@ -294,214 +338,17 @@ impl MainWindow {
 
     /// Handle a key event for overlay input modes (Filter, Search, etc.).
     /// Returns `true` if should quit.
-    pub fn handle_overlay_key(&mut self, key: KeyEvent) -> bool {
-        match self.app.input_mode {
-            InputMode::Normal => unreachable!(),
-            InputMode::Filter => match key.code {
-                KeyCode::Enter => {
-                    self.app.apply_filter();
-                    if self.app.filter_error.is_none() {
-                        self.app.input_mode = InputMode::Normal;
-                    }
-                }
-                KeyCode::Esc => self.app.input_mode = InputMode::Normal,
-                _ => {
-                    if self.app.filter_input.handle_key(key) {
-                        self.app.filter_error = None;
-                    }
-                }
-            },
-            InputMode::Search => match key.code {
-                KeyCode::Enter => {
-                    self.app.execute_search();
-                    self.app.input_mode = InputMode::Normal;
-                }
-                KeyCode::Esc => self.app.input_mode = InputMode::Normal,
-                _ => {
-                    self.app.search_input.handle_key(key);
-                }
-            },
-            InputMode::JumpForward | InputMode::JumpBackward => match key.code {
-                KeyCode::Enter => {
-                    let forward = self.app.input_mode == InputMode::JumpForward;
-                    if self.app.jump_relative(forward) {
-                        self.app.input_mode = InputMode::Normal;
-                    }
-                }
-                KeyCode::Esc => self.app.input_mode = InputMode::Normal,
-                _ => {
-                    self.app.time_input.handle_key(key);
-                }
-            },
-            InputMode::GotoLine => {
-                use crate::ui::windows::goto_line_window::GotoLineWindow;
-                let mut window = GotoLineWindow::new();
-                window.input = self.app.goto_input.value().to_string();
-                let result = crate::ui::dispatch_key(&mut window, key);
-                self.app.goto_input.set(&window.input);
-                if result == crate::ui::ComponentResult::Close {
-                    if window.confirmed {
-                        self.app.goto_line();
-                    }
-                    self.app.input_mode = InputMode::Normal;
-                }
-            }
-            InputMode::QuickExclude => match key.code {
-                KeyCode::Enter => {
-                    self.app.apply_quick_exclude();
-                    self.app.input_mode = InputMode::Normal;
-                }
-                KeyCode::Esc => self.app.input_mode = InputMode::Normal,
-                _ => {
-                    self.app.quick_filter_input.handle_key(key);
-                }
-            },
-            InputMode::QuickInclude => match key.code {
-                KeyCode::Enter => {
-                    self.app.apply_quick_include();
-                    self.app.input_mode = InputMode::Normal;
-                }
-                KeyCode::Esc => self.app.input_mode = InputMode::Normal,
-                _ => {
-                    self.app.quick_filter_input.handle_key(key);
-                }
-            },
-            InputMode::FieldFilter => {
-                use crate::ui::windows::field_filter_window::FieldFilterWindow;
-                if let Some(mut window) = FieldFilterWindow::from_app(&self.app) {
-                    let result = crate::ui::dispatch_key(&mut window, key);
-                    match result {
-                        crate::ui::ComponentResult::Close => {
-                            if window.confirmed {
-                                window.sync_to_app(&mut self.app);
-                                self.app.apply_field_filter();
-                            } else {
-                                self.app.field_filter = None;
-                            }
-                            self.app.input_mode = InputMode::Normal;
-                        }
-                        _ => {
-                            window.sync_to_app(&mut self.app);
-                        }
-                    }
-                } else {
-                    self.app.input_mode = InputMode::Normal;
-                }
-            }
-            InputMode::FilterManager => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::ColumnSelector => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::CopyFormat => {
-                use crate::ui::windows::copy_format_window::CopyFormatWindow;
-                let mut window = CopyFormatWindow::from_app(&self.app);
-                let result = crate::ui::dispatch_key(&mut window, key);
-                self.app.copy_format_cursor = window.cursor;
-                if result == crate::ui::ComponentResult::Close {
-                    if window.confirmed {
-                        CopyFormatWindow::select_format(&mut self.app, window.selected_format());
-                    }
-                    self.app.input_mode = InputMode::Normal;
-                    self.app.copy_format_cursor = 0;
-                }
-            }
-            InputMode::Help => {
-                // Dispatched via overlay_stack — shouldn't reach here.
-                // Fallback: close the mode.
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::Command => match key.code {
-                KeyCode::Enter => {
-                    self.app.execute_command();
-                    self.app.input_mode = InputMode::Normal;
-                    if self.app.should_quit {
-                        return true;
-                    }
-                }
-                KeyCode::Esc => {
-                    self.app.input_mode = InputMode::Normal;
-                }
-                _ => {
-                    self.app.command_input.handle_key(key);
-                }
-            },
-            InputMode::Highlight => match key.code {
-                KeyCode::Enter => {
-                    let pattern = self.app.highlight_input.value().to_string();
-                    if let Err(e) = self.app.add_highlight_rule(&pattern) {
-                        self.app.set_status(e);
-                    }
-                    self.app.input_mode = InputMode::Normal;
-                }
-                KeyCode::Esc => {
-                    self.app.input_mode = InputMode::Normal;
-                }
-                _ => {
-                    self.app.highlight_input.handle_key(key);
-                }
-            },
-            InputMode::HighlightManager => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::BookmarkManager => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::LevelFilter => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::SavePreset => {
-                use crate::ui::windows::save_preset_window::SavePresetWindow;
-                let mut window = SavePresetWindow::new();
-                window.input = self.app.preset_name_input.clone();
-                let result = crate::ui::dispatch_key(&mut window, key);
-                self.app.preset_name_input = window.input;
-                if result == crate::ui::ComponentResult::Close {
-                    if window.confirmed {
-                        let name = self.app.preset_name_input.value().to_string();
-                        self.app.save_filter_preset(&name);
-                    }
-                    self.app.input_mode = InputMode::Normal;
-                }
-            }
-            InputMode::LoadPreset => {
-                use crate::ui::windows::load_preset_window::LoadPresetWindow;
-                let mut window = LoadPresetWindow::new(self.app.preset_list.clone());
-                window.cursor = self.app.preset_list_cursor;
-                let result = crate::ui::dispatch_key(&mut window, key);
-                if let Some(ref name) = window.delete_name {
-                    let _ = crate::config::filter_preset::delete_preset(name);
-                }
-                self.app.preset_list = window.presets;
-                self.app.preset_list_cursor = window.cursor;
-                if result == crate::ui::ComponentResult::Close {
-                    if window.confirmed {
-                        if let Some(ref name) = window.selected {
-                            self.app.load_filter_preset(name);
-                        }
-                    }
-                    self.app.input_mode = InputMode::Normal;
-                }
-            }
-            InputMode::DensitySelector => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::SaveDialog => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-            InputMode::RegionManager => {
-                // Dispatched via overlay_stack
-                self.app.input_mode = InputMode::Normal;
-            }
-        }
+    /// Legacy overlay key handler — now all modes dispatched via overlay_stack.
+    /// This fallback handles the case where overlay_stack is empty but
+    /// input_mode is non-Normal (shouldn't happen, but safety).
+    pub fn handle_overlay_key(&mut self, _key: KeyEvent) -> bool {
+        // All modes are now dispatched via overlay_stack.
+        // If we reach here, something went wrong — reset to Normal.
+        tracing::warn!(
+            mode = ?self.app.input_mode,
+            "handle_overlay_key reached unexpectedly, resetting to Normal"
+        );
+        self.app.input_mode = InputMode::Normal;
         false
     }
 }
@@ -530,6 +377,30 @@ impl Window for MainWindow {
         // Overlay stack gets priority — input isolation
         if !self.overlay_stack.is_empty() {
             self.overlay_stack.handle_key(&mut self.app, event);
+
+            // After overlay close, check if a transition was requested
+            // (e.g., FilterManager → SavePreset/LoadPreset)
+            if self.overlay_stack.is_empty() && self.app.input_mode != InputMode::Normal {
+                match self.app.input_mode {
+                    InputMode::SavePreset => {
+                        self.overlay_stack.push(Box::new(
+                            crate::ui::windows::overlay_adapters::SavePresetOverlay::new(),
+                        ));
+                    }
+                    InputMode::LoadPreset => {
+                        self.overlay_stack.push(Box::new(
+                            crate::ui::windows::overlay_adapters::LoadPresetOverlay::new(),
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+
+            // Check if command mode triggered quit
+            if self.app.should_quit {
+                return WindowAction::Close;
+            }
+
             return WindowAction::Handled;
         }
 

--- a/crates/scouty-tui/src/ui/windows/overlay_adapters.rs
+++ b/crates/scouty-tui/src/ui/windows/overlay_adapters.rs
@@ -381,3 +381,499 @@ impl OverlayWindow for DensitySelectorOverlay {
         vec![("j/k", "Select"), ("Enter", "Apply"), ("Esc", "Close")]
     }
 }
+
+// ── SearchOverlay ───────────────────────────────────────────────────
+
+pub struct SearchOverlay;
+
+impl SearchOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for SearchOverlay {
+    fn name(&self) -> &str {
+        "Search"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {
+        // Search input rendered inline by ui_legacy
+    }
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Enter => {
+                app.execute_search();
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            KeyCode::Esc => {
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            _ => {
+                app.search_input.handle_key(key);
+                WindowAction::Handled
+            }
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Search"), ("Esc", "Cancel")]
+    }
+}
+
+// ── FilterOverlay ───────────────────────────────────────────────────
+
+pub struct FilterOverlay;
+
+impl FilterOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for FilterOverlay {
+    fn name(&self) -> &str {
+        "Filter"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {
+        // Filter input rendered inline by ui_legacy
+    }
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Enter => {
+                app.apply_filter();
+                if app.filter_error.is_none() {
+                    app.input_mode = InputMode::Normal;
+                    WindowAction::Close
+                } else {
+                    WindowAction::Handled
+                }
+            }
+            KeyCode::Esc => {
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            _ => {
+                if app.filter_input.handle_key(key) {
+                    app.filter_error = None;
+                }
+                WindowAction::Handled
+            }
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Apply"), ("Esc", "Cancel")]
+    }
+}
+
+// ── JumpOverlay ─────────────────────────────────────────────────────
+
+pub struct JumpOverlay {
+    pub forward: bool,
+}
+
+impl JumpOverlay {
+    pub fn new(forward: bool) -> Self {
+        Self { forward }
+    }
+}
+
+impl OverlayWindow for JumpOverlay {
+    fn name(&self) -> &str {
+        if self.forward {
+            "JumpForward"
+        } else {
+            "JumpBackward"
+        }
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Enter => {
+                if app.jump_relative(self.forward) {
+                    app.input_mode = InputMode::Normal;
+                    WindowAction::Close
+                } else {
+                    WindowAction::Handled
+                }
+            }
+            KeyCode::Esc => {
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            _ => {
+                app.time_input.handle_key(key);
+                WindowAction::Handled
+            }
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Jump"), ("Esc", "Cancel")]
+    }
+}
+
+// ── GotoLineOverlay ─────────────────────────────────────────────────
+
+pub struct GotoLineOverlay;
+
+impl GotoLineOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for GotoLineOverlay {
+    fn name(&self) -> &str {
+        "GotoLine"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crate::ui::windows::goto_line_window::GotoLineWindow;
+        let mut window = GotoLineWindow::new();
+        window.input = app.goto_input.value().to_string();
+        let result = dispatch_key(&mut window, key);
+        app.goto_input.set(&window.input);
+        if result == ComponentResult::Close {
+            if window.confirmed {
+                app.goto_line();
+            }
+            app.input_mode = InputMode::Normal;
+            WindowAction::Close
+        } else {
+            WindowAction::Handled
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Go"), ("Esc", "Cancel")]
+    }
+}
+
+// ── QuickFilterOverlay ──────────────────────────────────────────────
+
+pub struct QuickFilterOverlay {
+    pub exclude: bool,
+}
+
+impl QuickFilterOverlay {
+    pub fn new(exclude: bool) -> Self {
+        Self { exclude }
+    }
+}
+
+impl OverlayWindow for QuickFilterOverlay {
+    fn name(&self) -> &str {
+        if self.exclude {
+            "QuickExclude"
+        } else {
+            "QuickInclude"
+        }
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Enter => {
+                if self.exclude {
+                    app.apply_quick_exclude();
+                } else {
+                    app.apply_quick_include();
+                }
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            KeyCode::Esc => {
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            _ => {
+                app.quick_filter_input.handle_key(key);
+                WindowAction::Handled
+            }
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Apply"), ("Esc", "Cancel")]
+    }
+}
+
+// ── FieldFilterOverlay ──────────────────────────────────────────────
+
+pub struct FieldFilterOverlay;
+
+impl FieldFilterOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for FieldFilterOverlay {
+    fn name(&self) -> &str {
+        "FieldFilter"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crate::ui::windows::field_filter_window::FieldFilterWindow;
+        if let Some(mut window) = FieldFilterWindow::from_app(app) {
+            let result = dispatch_key(&mut window, key);
+            match result {
+                ComponentResult::Close => {
+                    if window.confirmed {
+                        window.sync_to_app(app);
+                        app.apply_field_filter();
+                    } else {
+                        app.field_filter = None;
+                    }
+                    app.input_mode = InputMode::Normal;
+                    WindowAction::Close
+                }
+                _ => {
+                    window.sync_to_app(app);
+                    WindowAction::Handled
+                }
+            }
+        } else {
+            app.input_mode = InputMode::Normal;
+            WindowAction::Close
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Apply"), ("Esc", "Cancel")]
+    }
+}
+
+// ── CopyFormatOverlay ───────────────────────────────────────────────
+
+pub struct CopyFormatOverlay;
+
+impl CopyFormatOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for CopyFormatOverlay {
+    fn name(&self) -> &str {
+        "CopyFormat"
+    }
+
+    fn render(&self, frame: &mut Frame, area: Rect, app: &App) {
+        use crate::ui::windows::copy_format_window::CopyFormatWindow;
+        let window = CopyFormatWindow::from_app(app);
+        <CopyFormatWindow as UiComponent>::render(&window, frame, area);
+    }
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crate::ui::windows::copy_format_window::CopyFormatWindow;
+        let mut window = CopyFormatWindow::from_app(app);
+        let result = dispatch_key(&mut window, key);
+        app.copy_format_cursor = window.cursor;
+        if result == ComponentResult::Close {
+            if window.confirmed {
+                CopyFormatWindow::select_format(app, window.selected_format());
+            }
+            app.input_mode = InputMode::Normal;
+            app.copy_format_cursor = 0;
+            WindowAction::Close
+        } else {
+            WindowAction::Handled
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("j/k", "Select"), ("Enter", "Copy"), ("Esc", "Cancel")]
+    }
+}
+
+// ── CommandOverlay ──────────────────────────────────────────────────
+
+pub struct CommandOverlay;
+
+impl CommandOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for CommandOverlay {
+    fn name(&self) -> &str {
+        "Command"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Enter => {
+                app.execute_command();
+                app.input_mode = InputMode::Normal;
+                if app.should_quit {
+                    // Signal quit through WindowAction — MainWindow will check should_quit
+                }
+                WindowAction::Close
+            }
+            KeyCode::Esc => {
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            _ => {
+                app.command_input.handle_key(key);
+                WindowAction::Handled
+            }
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Execute"), ("Esc", "Cancel")]
+    }
+}
+
+// ── HighlightOverlay ────────────────────────────────────────────────
+
+pub struct HighlightOverlay;
+
+impl HighlightOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for HighlightOverlay {
+    fn name(&self) -> &str {
+        "Highlight"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Enter => {
+                let pattern = app.highlight_input.value().to_string();
+                if let Err(e) = app.add_highlight_rule(&pattern) {
+                    app.set_status(e);
+                }
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            KeyCode::Esc => {
+                app.input_mode = InputMode::Normal;
+                WindowAction::Close
+            }
+            _ => {
+                app.highlight_input.handle_key(key);
+                WindowAction::Handled
+            }
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Add"), ("Esc", "Cancel")]
+    }
+}
+
+// ── SavePresetOverlay ───────────────────────────────────────────────
+
+pub struct SavePresetOverlay;
+
+impl SavePresetOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for SavePresetOverlay {
+    fn name(&self) -> &str {
+        "SavePreset"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crate::ui::windows::save_preset_window::SavePresetWindow;
+        let mut window = SavePresetWindow::new();
+        window.input = app.preset_name_input.clone();
+        let result = dispatch_key(&mut window, key);
+        app.preset_name_input = window.input;
+        if result == ComponentResult::Close {
+            if window.confirmed {
+                let name = app.preset_name_input.value().to_string();
+                app.save_filter_preset(&name);
+            }
+            app.input_mode = InputMode::Normal;
+            WindowAction::Close
+        } else {
+            WindowAction::Handled
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("Enter", "Save"), ("Esc", "Cancel")]
+    }
+}
+
+// ── LoadPresetOverlay ───────────────────────────────────────────────
+
+pub struct LoadPresetOverlay;
+
+impl LoadPresetOverlay {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl OverlayWindow for LoadPresetOverlay {
+    fn name(&self) -> &str {
+        "LoadPreset"
+    }
+
+    fn render(&self, _frame: &mut Frame, _area: Rect, _app: &App) {}
+
+    fn handle_key(&mut self, app: &mut App, key: KeyEvent) -> WindowAction {
+        use crate::ui::windows::load_preset_window::LoadPresetWindow;
+        let mut window = LoadPresetWindow::new(app.preset_list.clone());
+        window.cursor = app.preset_list_cursor;
+        let result = dispatch_key(&mut window, key);
+        if let Some(ref name) = window.delete_name {
+            let _ = crate::config::filter_preset::delete_preset(name);
+        }
+        app.preset_list = window.presets;
+        app.preset_list_cursor = window.cursor;
+        if result == ComponentResult::Close {
+            if window.confirmed {
+                if let Some(ref name) = window.selected {
+                    app.load_filter_preset(name);
+                }
+            }
+            app.input_mode = InputMode::Normal;
+            WindowAction::Close
+        } else {
+            WindowAction::Handled
+        }
+    }
+
+    fn shortcut_hints(&self) -> Vec<(&str, &str)> {
+        vec![("d", "Delete"), ("Enter", "Load"), ("Esc", "Cancel")]
+    }
+}


### PR DESCRIPTION
## Summary

Migrate all remaining InputMode handlers from MainWindow's inline `handle_overlay_key` to overlay adapters. This is the final phase of the UI architecture migration.

### Changes

**`handle_overlay_key` reduced from ~200 lines to 5-line safety fallback** — all input modes now dispatched via `overlay_stack`.

### New Overlay Adapters (11)

| Overlay | Trigger | Description |
|---------|---------|-------------|
| SearchOverlay | `/` | Search input |
| FilterOverlay | `f` | Filter expression input |
| JumpOverlay | `+`/`-` | Time-relative jump |
| GotoLineOverlay | `g` | Line number jump |
| QuickFilterOverlay | `e`/`i` | Quick exclude/include |
| FieldFilterOverlay | `E`/`I` | Field-specific filter |
| CopyFormatOverlay | `y` | Copy format selector |
| CommandOverlay | `:` | Command input |
| HighlightOverlay | `H` | Highlight pattern input |
| SavePresetOverlay | (from FilterManager) | Preset naming |
| LoadPresetOverlay | (from FilterManager) | Preset loading |

### Architecture

```
MainWindow.handle_key(event)
  ├── overlay_stack not empty?
  │     ├── overlay_stack.handle_key(app, event)
  │     ├── check transitions (FilterManager → SavePreset/LoadPreset)
  │     └── check should_quit (Command :q)
  └── overlay_stack empty?
        ├── Normal mode → panel keys → log table keys
        └── Non-Normal mode → safety fallback (reset to Normal)
```

### Testing

- 764 tests pass (363 lib + 401 TUI)
- Clippy clean
- Zero behavioral changes — all keybindings preserved

Closes #438