### PR TITLE
Follow Mode Phase 1: CLI flag + file watcher + incremental loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/crates/scouty-tui/Cargo.toml
+++ b/crates/scouty-tui/Cargo.toml
@@ -22,3 +22,6 @@ glob = "0.3"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -1765,6 +1765,69 @@ impl App {
         }
     }
 
+    /// Append new records from follow mode. Incrementally updates
+    /// filtered_indices and auto-scrolls if follow_mode is active.
+    pub fn append_records(&mut self, new_records: Vec<Arc<LogRecord>>) {
+        if new_records.is_empty() {
+            return;
+        }
+
+        let was_at_bottom = self.follow_mode
+            && (self.filtered_indices.is_empty()
+                || self.selected + 1 >= self.filtered_indices.len());
+
+        let base_idx = self.records.len();
+        let count = new_records.len();
+        self.records.extend(new_records);
+        self.total_records = self.records.len();
+
+        // Incrementally filter new records (don't re-filter all)
+        for i in base_idx..base_idx + count {
+            let record = &self.records[i];
+
+            // Level filter
+            if let Some(ref lf) = self.level_filter {
+                if !lf.matches_level(record.level.as_ref()) {
+                    continue;
+                }
+            }
+
+            // Include/exclude filters
+            let mut pass = true;
+            for f in &self.filters {
+                let matches = eval::eval(&f.expr, record);
+                if f.exclude && matches {
+                    pass = false;
+                    break;
+                }
+                if !f.exclude && !matches {
+                    pass = false;
+                    break;
+                }
+            }
+
+            if pass {
+                self.filtered_indices.push(i);
+            }
+        }
+
+        // Recompute column widths
+        self.col_widths = Self::compute_col_widths(&self.records, &self.filtered_indices);
+
+        // Auto-scroll if in follow mode and was at bottom
+        if was_at_bottom && !self.filtered_indices.is_empty() {
+            self.selected = self.filtered_indices.len() - 1;
+            self.ensure_selected_visible();
+        }
+
+        tracing::debug!(
+            new = count,
+            total = self.total_records,
+            filtered = self.filtered_indices.len(),
+            "records appended"
+        );
+    }
+
     /// Exit follow mode (called on manual scroll up).
     pub fn exit_follow(&mut self) {
         self.follow_mode = false;

--- a/crates/scouty-tui/src/follow.rs
+++ b/crates/scouty-tui/src/follow.rs
@@ -1,0 +1,138 @@
+//! Follow mode — watches a file for new data and yields new lines incrementally.
+
+#[cfg(test)]
+#[path = "follow_tests.rs"]
+mod follow_tests;
+
+use scouty::parser::factory::ParserFactory;
+use scouty::record::LogRecord;
+use scouty::traits::LoaderInfo;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Get the current size of a file in bytes.
+pub fn file_size(path: &Path) -> std::io::Result<u64> {
+    Ok(std::fs::metadata(path)?.len())
+}
+
+/// File watcher that tracks read position and yields new parsed records on poll.
+pub struct FileFollower {
+    path: PathBuf,
+    offset: u64,
+    /// Partial line buffer (when file doesn't end with newline yet).
+    partial: String,
+    /// Loader info for parser creation.
+    info: LoaderInfo,
+    /// Next record ID to assign.
+    next_record_id: u64,
+}
+
+impl FileFollower {
+    /// Create a new follower starting from the given byte offset.
+    /// `start_record_id` is the next record ID to assign to new records.
+    pub fn new(
+        path: impl Into<PathBuf>,
+        start_offset: u64,
+        info: LoaderInfo,
+        start_record_id: u64,
+    ) -> Self {
+        Self {
+            path: path.into(),
+            offset: start_offset,
+            partial: String::new(),
+            info,
+            next_record_id: start_record_id,
+        }
+    }
+
+    /// Poll for new complete lines, parse them into LogRecords.
+    /// Returns empty vec if no new data.
+    pub fn poll(&mut self) -> std::io::Result<Vec<Arc<LogRecord>>> {
+        let lines = self.poll_lines()?;
+        if lines.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let group = ParserFactory::create_parser_group(&self.info);
+        let mut records = Vec::new();
+
+        for line in lines {
+            if let Some(mut record) =
+                group.parse(&line, &self.info.id, &self.info.id, self.next_record_id)
+            {
+                record.raw = line;
+                records.push(Arc::new(record));
+                self.next_record_id += 1;
+            }
+        }
+
+        Ok(records)
+    }
+
+    /// Poll for new raw lines (without parsing).
+    fn poll_lines(&mut self) -> std::io::Result<Vec<String>> {
+        let metadata = std::fs::metadata(&self.path)?;
+        let current_size = metadata.len();
+
+        // File truncated — reset to beginning
+        if current_size < self.offset {
+            tracing::info!(
+                path = %self.path.display(),
+                old_offset = self.offset,
+                new_size = current_size,
+                "File truncated, resetting"
+            );
+            self.offset = 0;
+            self.partial.clear();
+        }
+
+        // No new data
+        if current_size == self.offset {
+            return Ok(Vec::new());
+        }
+
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.offset))?;
+        let mut reader = BufReader::new(file);
+
+        let mut lines = Vec::new();
+        let mut buf = std::mem::take(&mut self.partial);
+
+        loop {
+            let mut line_buf = String::new();
+            let bytes_read = reader.read_line(&mut line_buf)?;
+            if bytes_read == 0 {
+                break;
+            }
+            self.offset += bytes_read as u64;
+            buf.push_str(&line_buf);
+
+            if buf.ends_with('\n') {
+                let trimmed = buf.trim_end_matches('\n').trim_end_matches('\r');
+                if !trimmed.is_empty() {
+                    lines.push(trimmed.to_string());
+                }
+                buf.clear();
+            }
+        }
+
+        // Leftover partial line
+        if !buf.is_empty() {
+            self.partial = buf;
+        }
+
+        Ok(lines)
+    }
+
+    /// The path being followed.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Current byte offset.
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+}

--- a/crates/scouty-tui/src/follow_tests.rs
+++ b/crates/scouty-tui/src/follow_tests.rs
@@ -1,0 +1,159 @@
+//! Tests for FileFollower.
+
+#[cfg(test)]
+mod tests {
+    use crate::follow::{file_size, FileFollower};
+    use scouty::traits::{LoaderInfo, LoaderType};
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn test_info(path: &str) -> LoaderInfo {
+        LoaderInfo {
+            id: path.to_string(),
+            loader_type: LoaderType::TextFile,
+            multiline_enabled: false,
+            sample_lines: Vec::new(),
+            file_mod_year: None,
+        }
+    }
+
+    #[test]
+    fn test_poll_new_lines() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let info = test_info(&path.display().to_string());
+
+        let mut follower = FileFollower::new(&path, 0, info, 0);
+        writeln!(tmp, "2024-01-01 line1").unwrap();
+        writeln!(tmp, "2024-01-01 line2").unwrap();
+        tmp.flush().unwrap();
+
+        let records = follower.poll().unwrap();
+        assert_eq!(records.len(), 2);
+
+        // No new data
+        let records = follower.poll().unwrap();
+        assert!(records.is_empty());
+
+        // Append
+        writeln!(tmp, "2024-01-01 line3").unwrap();
+        tmp.flush().unwrap();
+
+        let records = follower.poll().unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn test_follow_from_offset() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "existing").unwrap();
+        tmp.flush().unwrap();
+
+        let path = tmp.path().to_path_buf();
+        let size = file_size(&path).unwrap();
+        let info = test_info(&path.display().to_string());
+
+        let mut follower = FileFollower::new(&path, size, info, 0);
+
+        // Should not return existing content
+        let records = follower.poll().unwrap();
+        assert!(records.is_empty());
+
+        // Append new line
+        writeln!(tmp, "new_line").unwrap();
+        tmp.flush().unwrap();
+
+        let records = follower.poll().unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn test_follow_truncation() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "original_line1").unwrap();
+            writeln!(f, "original_line2").unwrap();
+        }
+
+        let info = test_info(&path.display().to_string());
+        let mut follower = FileFollower::new(&path, 0, info, 0);
+        let records = follower.poll().unwrap();
+        assert_eq!(records.len(), 2);
+
+        // Truncate and write new content
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "new").unwrap();
+        }
+
+        let records = follower.poll().unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn test_follow_partial_line() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            write!(f, "partial").unwrap();
+        }
+
+        let info = test_info(&path.display().to_string());
+        let mut follower = FileFollower::new(&path, 0, info, 0);
+        let records = follower.poll().unwrap();
+        assert!(records.is_empty());
+
+        // Complete the line
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            writeln!(f, "_complete").unwrap();
+        }
+
+        let records = follower.poll().unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn test_follow_empty_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let info = test_info(&path.display().to_string());
+        let mut follower = FileFollower::new(&path, 0, info, 0);
+        let records = follower.poll().unwrap();
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn test_file_size() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "hello").unwrap();
+        tmp.flush().unwrap();
+        let size = file_size(tmp.path()).unwrap();
+        assert!(size > 0);
+    }
+
+    #[test]
+    fn test_record_ids_increment() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let info = test_info(&path.display().to_string());
+
+        let mut follower = FileFollower::new(&path, 0, info, 100);
+        writeln!(tmp, "2024-01-01 line1").unwrap();
+        writeln!(tmp, "2024-01-01 line2").unwrap();
+        tmp.flush().unwrap();
+
+        let records = follower.poll().unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].id, 100);
+        assert_eq!(records[1].id, 101);
+    }
+}

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -3,6 +3,7 @@
 mod app;
 pub mod config;
 mod density;
+pub mod follow;
 pub mod keybinding;
 pub mod panel;
 mod pipe;
@@ -76,6 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut pipe_format: Option<String> = None;
     let mut pipe_fields: Option<String> = None;
     let mut log_level: Option<String> = None;
+    let mut follow_flag = false;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
@@ -117,6 +119,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
                 eprintln!("  --config <path>   Load additional config file (overrides file-based configs)");
                 eprintln!("  --regions <path>  Load region definitions (file or directory)");
+                eprintln!("  --follow, -f      Follow file for new data (like tail -f)");
                 eprintln!("  --log [level]     Enable logging to ~/.scouty/log/ (default: info)");
                 eprintln!("  --generate-config          Generate default config to stdout");
                 eprintln!(
@@ -269,6 +272,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             arg if arg.starts_with("--fields=") => {
                 pipe_fields = Some(arg.trim_start_matches("--fields=").to_string());
+                i += 1;
+            }
+            "--follow" | "-f" => {
+                follow_flag = true;
                 i += 1;
             }
             _ => {
@@ -523,7 +530,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         app.theme = config::resolve_theme(&cfg, theme_override.as_deref());
 
         // Apply general settings
-        if piped && cfg.general.follow_on_pipe {
+        if follow_flag || (piped && cfg.general.follow_on_pipe) {
             app.follow_mode = true;
             app.scroll_to_bottom();
         }
@@ -532,6 +539,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Wrap app + keymap in MainWindow for the new architecture
     let mut main_window = ui::windows::main_window::MainWindow::new(app, keymap);
+
+    // Set up file follower if follow mode requested for file input
+    let mut file_follower: Option<follow::FileFollower> =
+        if follow_flag && !piped && files.len() == 1 {
+            let path = std::path::Path::new(files[0]);
+            match follow::file_size(path) {
+                Ok(size) => {
+                    use scouty::loader::file::FileLoader;
+                    use scouty::traits::LogLoader;
+                    let mut loader = FileLoader::new(files[0], false);
+                    let _ = loader.load();
+                    let info = loader.info().clone();
+                    Some(follow::FileFollower::new(
+                        path,
+                        size,
+                        info,
+                        main_window.app.total_records as u64,
+                    ))
+                }
+                Err(e) => {
+                    tracing::warn!(%e, "cannot start file follower");
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
     loop {
         // Pre-compute density cache using exact position text width
@@ -568,7 +602,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ui::render(frame, &mut main_window.app);
         })?;
 
-        if !event::poll(Duration::from_millis(250))? {
+        // Poll file follower for new records
+        if main_window.app.follow_mode {
+            if let Some(ref mut follower) = file_follower {
+                match follower.poll() {
+                    Ok(new_records) => {
+                        if !new_records.is_empty() {
+                            let count = new_records.len();
+                            // Process through category pipeline
+                            if let Some(ref mut proc) = main_window.app.category_processor {
+                                proc.process_records(&new_records);
+                            }
+                            main_window.app.append_records(new_records);
+                            tracing::debug!(count, "follow: appended new records");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(%e, "follow: error polling file");
+                    }
+                }
+            }
+        }
+
+        if !event::poll(Duration::from_millis(100))? {
             main_window.app.tick_status_clear();
             continue;
         }


### PR DESCRIPTION
Add `--follow` / `-f` CLI flag to tail a log file for new data, similar to `tail -f`.

## Changes

- **CLI flag:** `--follow` / `-f` enables follow mode for a single file
- **FileFollower:** Polls file for new bytes, tracks byte offset, handles partial lines
- **Incremental parsing:** New lines parsed with same parser group as initial load, record IDs continue
- **Pipeline integration:** New records flow through existing filter pipeline and category processor
- **Truncation handling:** Detects file shrinkage and resets to beginning
- **Event loop:** Poll interval reduced to 100ms for follow responsiveness

## New files

- `crates/scouty-tui/src/follow.rs` — FileFollower implementation
- `crates/scouty-tui/src/follow_tests.rs` — 7 new tests

## Test results

790 tests pass (363 scouty + 427 scouty-tui), fmt + clippy clean.

Closes #468