### PR TITLE
Fix tab bar highlight not clearing when panel loses focus

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/detail_panel_keys.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_keys.rs
@@ -45,6 +45,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> KeyAction {
         }
         KeyCode::Esc => {
             app.detail_tree_focus = false;
+            app.panel_state.focus_log_table();
             true
         }
         _ => false,

--- a/crates/scouty-tui/src/ui/widgets/detail_panel_keys_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/detail_panel_keys_tests.rs
@@ -33,8 +33,16 @@ mod tests {
     #[test]
     fn test_esc_exits_focus() {
         let mut app = test_app();
+        // Set up: panel has focus and tree is focused
+        app.panel_state.focus_panel();
+        app.detail_tree_focus = true;
+        assert_eq!(
+            app.panel_state.focus,
+            crate::panel::PanelFocus::PanelContent
+        );
         assert_eq!(handle_key(&mut app, key(KeyCode::Esc)), KeyAction::Handled);
         assert!(!app.detail_tree_focus);
+        assert_eq!(app.panel_state.focus, crate::panel::PanelFocus::LogTable);
     }
 
     #[test]

--- a/crates/scouty-tui/src/ui/windows/main_window.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window.rs
@@ -93,6 +93,12 @@ impl MainWindow {
                 self.app.panel_state.toggle_maximize();
                 true
             }
+            KeyCode::Esc if self.app.panel_state.has_focus() => {
+                self.app.detail_tree_focus = false;
+                self.app.panel_state.focus_log_table();
+                tracing::debug!("Esc: panel → log table");
+                true
+            }
             _ => false,
         };
         if handled {


### PR DESCRIPTION
## Bug

When pressing Esc from the Detail panel, the tab bar still highlighted the active tab because `panel_state.focus` wasn't reset to `LogTable`.

**Root cause:** Detail panel's Esc handler only set `detail_tree_focus = false` without calling `panel_state.focus_log_table()`, unlike Region and Category panels which both call it.

## Fix

- Detail panel Esc now calls `focus_log_table()` (matching Region/Category behavior)
- Added Esc handler in `handle_panel_keys()` as fallback for Stats panel (which has no key handler)
- Updated test to verify Esc returns focus to LogTable

783 tests pass, fmt + clippy clean.

Closes #471