### PR TITLE
[PM Spec] Add missing sairedis op codes: a/A (NotifySyncd)

### DIFF
--- a/crates/scouty/spec/parsers.md
+++ b/crates/scouty/spec/parsers.md
@@ -65,7 +65,7 @@ Parses `|`-delimited SWSS logs: `YYYY-MM-DD.HH:MM:SS.ffffff|<content...>`
 
 Parses SAI Redis operation logs: `YYYY-MM-DD.HH:MM:SS.ffffff|<op>|<detail...>`
 
-**13 op codes:** `c` (Create), `r` (Remove), `s` (Set), `g` (Get), `G` (GetResponse), `p` (CounterPoll), `C`/`R`/`S`/`B` (Bulk ops), `q` (Query), `Q` (QueryResponse), `n` (Notification)
+**15 op codes:** `c` (Create), `r` (Remove), `s` (Set), `g` (Get), `G` (GetResponse), `a` (NotifySyncd), `A` (NotifySyncdResponse), `p` (CounterPoll), `C`/`R`/`S`/`B` (Bulk ops), `q` (Query), `Q` (QueryResponse), `n` (Notification)
 
 **Key decisions:**
 - **Stateful parsing** for `G`/`Q` responses: parser maintains `last_sync_op_context` from preceding `g`/`q`


### PR DESCRIPTION
Added 2 missing op codes to SAI Redis parser spec:

- `a|<key>` — **NotifySyncd request**: signals syncd to perform INIT_VIEW, APPLY_VIEW, INSPECT_ASIC, or INVOKE_DUMP
- `A|<status>` — **NotifySyncdResponse**: SAI status code (e.g., SAI_STATUS_SUCCESS)

Source: `sonic-sairedis/lib/Recorder.cpp` lines 412-427

Total op codes: 13 → 15