### PR TITLE
Add sairedis a/A op codes (NotifySyncd request/response)

### DIFF
--- a/crates/scouty/src/parser/sairedis_parser.rs
+++ b/crates/scouty/src/parser/sairedis_parser.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 /// Known op codes for sairedis logs.
-const KNOWN_OPS: &[u8] = b"crsgGpCRSBqQn";
+const KNOWN_OPS: &[u8] = b"crsgGpCRSBqQnaA";
 
 /// Parser for SONiC sairedis log format.
 ///
@@ -183,6 +183,16 @@ impl SairedisParser {
             b'n' => {
                 let (name, msg) = Self::parse_notification(detail);
                 (format!("Notification: {}", name), None, None, msg)
+            }
+            // NotifySyncd request: a (key = INIT_VIEW, APPLY_VIEW, etc.)
+            b'a' => {
+                let key = str_from_bytes(detail);
+                ("NotifySyncd".to_string(), None, Some(key.clone()), key)
+            }
+            // NotifySyncd response: A (SAI status code)
+            b'A' => {
+                let status = str_from_bytes(detail);
+                ("NotifySyncdResponse".to_string(), None, None, status)
             }
             // Unknown op code: graceful fallback
             _ => {

--- a/crates/scouty/src/parser/sairedis_parser_tests.rs
+++ b/crates/scouty/src/parser/sairedis_parser_tests.rs
@@ -456,4 +456,71 @@ mod tests {
             "Notification: fdb_event".to_string()
         )));
     }
+
+    #[test]
+    fn test_notify_syncd_request() {
+        let p = SairedisParser::new();
+        let r = p
+            .parse(
+                "2025-01-15.10:30:45.123456|a|INIT_VIEW",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        assert_eq!(r.function.as_deref(), Some("NotifySyncd"));
+        assert_eq!(r.context.as_deref(), Some("INIT_VIEW"));
+        assert_eq!(r.message, "INIT_VIEW");
+    }
+
+    #[test]
+    fn test_notify_syncd_request_apply_view() {
+        let p = SairedisParser::new();
+        let r = p
+            .parse(
+                "2025-01-15.10:30:45.123456|a|APPLY_VIEW",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        assert_eq!(r.function.as_deref(), Some("NotifySyncd"));
+        assert_eq!(r.context.as_deref(), Some("APPLY_VIEW"));
+    }
+
+    #[test]
+    fn test_notify_syncd_response() {
+        let p = SairedisParser::new();
+        let r = p
+            .parse(
+                "2025-01-15.10:30:45.123456|A|SAI_STATUS_SUCCESS",
+                "test",
+                "loader",
+                1,
+            )
+            .unwrap();
+        assert_eq!(r.function.as_deref(), Some("NotifySyncdResponse"));
+        assert_eq!(r.message, "SAI_STATUS_SUCCESS");
+        assert!(r.context.is_none());
+    }
+
+    #[test]
+    fn test_notify_syncd_response_empty() {
+        let p = SairedisParser::new();
+        let r = p
+            .parse("2025-01-15.10:30:45.123456|A|", "test", "loader", 1)
+            .unwrap();
+        assert_eq!(r.function.as_deref(), Some("NotifySyncdResponse"));
+        assert_eq!(r.message, "");
+    }
+
+    #[test]
+    fn test_looks_like_sairedis_notify_syncd() {
+        assert!(looks_like_sairedis(
+            "2025-01-15.10:30:45.123456|a|INIT_VIEW"
+        ));
+        assert!(looks_like_sairedis(
+            "2025-01-15.10:30:45.123456|A|SAI_STATUS_SUCCESS"
+        ));
+    }
 }


### PR DESCRIPTION
Per spec update (PR #484): sairedis recorder has `a`/`A` op codes that were missing.

## Changes
- `a` → NotifySyncd request: key extraction (INIT_VIEW, APPLY_VIEW, INSPECT_ASIC, INVOKE_DUMP)
- `A` → NotifySyncdResponse: SAI status code display
- Added to `KNOWN_OPS` and `looks_like_sairedis()` detection
- 5 new tests (804 total pass)

Follows the same request/response pattern as `g`/`G` and `q`/`Q`.

Closes #485