### PR TITLE
fix: route key events to focused panel instead of log table

### DIFF
--- a/crates/scouty-tui/src/ui/windows/main_window.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window.rs
@@ -48,6 +48,8 @@ impl MainWindow {
                 if self.app.panel_state.focus == crate::panel::PanelFocus::LogTable {
                     self.app.panel_state.active = crate::panel::PanelId::all()[0];
                     self.app.panel_state.focus_panel();
+                    self.app.detail_tree_focus =
+                        self.app.panel_state.active == crate::panel::PanelId::Detail;
                     self.app.detail_open = self.app.panel_state.expanded
                         && self.app.panel_state.active == crate::panel::PanelId::Detail;
                     tracing::debug!(active = ?self.app.panel_state.active, "Tab: log table → panel");
@@ -60,6 +62,10 @@ impl MainWindow {
                     } else {
                         self.app.detail_tree_focus = false;
                         self.app.panel_state.next_panel();
+                        // Set detail_tree_focus when entering Detail panel
+                        if self.app.panel_state.active == crate::panel::PanelId::Detail {
+                            self.app.detail_tree_focus = true;
+                        }
                         tracing::debug!(active = ?self.app.panel_state.active, "Tab: → next panel");
                     }
                 }
@@ -72,6 +78,8 @@ impl MainWindow {
                     tracing::info!(target_panel = ?target, "BackTab: entering panels from log table (reverse)");
                     self.app.panel_state.active = target;
                     self.app.panel_state.focus_panel();
+                    self.app.detail_tree_focus =
+                        self.app.panel_state.active == crate::panel::PanelId::Detail;
                     self.app.detail_open = self.app.panel_state.expanded
                         && self.app.panel_state.active == crate::panel::PanelId::Detail;
                     tracing::debug!(active = ?self.app.panel_state.active, "Shift+Tab: log table → panel");
@@ -84,6 +92,10 @@ impl MainWindow {
                     } else {
                         self.app.detail_tree_focus = false;
                         self.app.panel_state.prev_panel();
+                        // Set detail_tree_focus when entering Detail panel
+                        if self.app.panel_state.active == crate::panel::PanelId::Detail {
+                            self.app.detail_tree_focus = true;
+                        }
                         tracing::debug!(active = ?self.app.panel_state.active, "Shift+Tab: → prev panel");
                     }
                 }
@@ -318,6 +330,8 @@ impl MainWindow {
     /// Handle a key event in Normal mode.
     /// Returns `WindowAction::Close` if the app should quit.
     pub fn handle_normal_key(&mut self, key: KeyEvent) -> WindowAction {
+        let panel_focused = self.app.panel_state.has_focus();
+
         // 1. Detail tree focus
         if self.app.detail_open
             && self.app.detail_tree_focus
@@ -327,7 +341,7 @@ impl MainWindow {
         }
 
         // 2. Region panel focus
-        if self.app.panel_state.has_focus()
+        if panel_focused
             && self.app.panel_state.active == crate::panel::PanelId::Region
             && self.handle_region_panel_key(key) == KeyAction::Handled
         {
@@ -335,7 +349,7 @@ impl MainWindow {
         }
 
         // 2b. Category panel focus
-        if self.app.panel_state.has_focus()
+        if panel_focused
             && self.app.panel_state.active == crate::panel::PanelId::Category
             && crate::ui::widgets::category_panel_keys::handle_key(&mut self.app, key)
                 == KeyAction::Handled
@@ -343,12 +357,23 @@ impl MainWindow {
             return WindowAction::Handled;
         }
 
-        // 3. Panel system keys
+        // 3. Panel system keys (Tab/BackTab/Esc/z — work regardless of focus)
         if self.handle_panel_keys(key) == KeyAction::Handled {
             return WindowAction::Handled;
         }
 
-        // 4. Log table / global keys via keymap
+        // 4. If a panel has focus, do NOT fall through to log table keys.
+        //    Only panel-specific keys and panel system keys (above) should work.
+        if panel_focused {
+            tracing::debug!(
+                panel = ?self.app.panel_state.active,
+                key_code = ?key.code,
+                "key not handled by focused panel, ignoring"
+            );
+            return WindowAction::Handled;
+        }
+
+        // 5. Log table / global keys via keymap (only when log table has focus)
         match self.handle_log_table_key(key) {
             Some(true) => WindowAction::Close, // quit
             Some(false) => WindowAction::Handled,

--- a/crates/scouty-tui/src/ui/windows/main_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window_tests.rs
@@ -124,6 +124,82 @@ mod tests {
     }
 
     #[test]
+    fn test_panel_focus_blocks_log_table_keys() {
+        // When a panel has focus, j/k should NOT move the log table cursor.
+        let mut mw = make_main_window();
+        // Tab into panel system (first panel = Detail)
+        mw.handle_key(key(KeyCode::Tab));
+        assert!(mw.app.panel_state.has_focus());
+        assert_eq!(
+            mw.app.panel_state.active,
+            crate::panel::PanelId::Detail
+        );
+
+        // 'q' should NOT quit when panel has focus
+        let result = mw.handle_normal_key(key(KeyCode::Char('q')));
+        assert_ne!(result, WindowAction::Close);
+    }
+
+    #[test]
+    fn test_tab_into_detail_sets_tree_focus() {
+        let mut mw = make_main_window();
+        // Tab into panels — first panel is Detail
+        mw.handle_key(key(KeyCode::Tab));
+        assert!(mw.app.panel_state.has_focus());
+        assert_eq!(
+            mw.app.panel_state.active,
+            crate::panel::PanelId::Detail
+        );
+        assert!(
+            mw.app.detail_tree_focus,
+            "detail_tree_focus should be set when Tab enters Detail panel"
+        );
+    }
+
+    #[test]
+    fn test_backtab_into_detail_sets_tree_focus() {
+        let mut mw = make_main_window();
+        // Tab into panels, then navigate with Tab until we wrap to Detail
+        // BackTab from log table goes to last panel (Category), then prev...
+        // Simpler: Tab in, Tab to Region, BackTab back to Detail
+        mw.handle_key(key(KeyCode::Tab)); // → Detail (focus)
+        mw.handle_key(key(KeyCode::Tab)); // → Region
+        assert_eq!(
+            mw.app.panel_state.active,
+            crate::panel::PanelId::Region
+        );
+        assert!(!mw.app.detail_tree_focus);
+
+        // BackTab back to Detail
+        let backtab = KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT);
+        mw.handle_key(backtab);
+        assert_eq!(
+            mw.app.panel_state.active,
+            crate::panel::PanelId::Detail
+        );
+        assert!(
+            mw.app.detail_tree_focus,
+            "detail_tree_focus should be set when BackTab enters Detail panel"
+        );
+    }
+
+    #[test]
+    fn test_stats_panel_focus_blocks_log_keys() {
+        // Stats panel is read-only but should still block log table keys
+        let mut mw = make_main_window();
+        // Manually set focus to Stats panel
+        mw.app.panel_state.active = crate::panel::PanelId::Stats;
+        mw.app.panel_state.focus_panel();
+        assert!(mw.app.panel_state.has_focus());
+
+        // j should NOT move the log table
+        let selected_before = mw.app.selected;
+        let result = mw.handle_normal_key(key(KeyCode::Char('j')));
+        assert_eq!(result, WindowAction::Handled);
+        assert_eq!(mw.app.selected, selected_before);
+    }
+
+    #[test]
     fn test_search_input_mode_typing() {
         let mut mw = make_main_window();
         mw.app.input_mode = InputMode::Search;


### PR DESCRIPTION
## Summary

Fix key event dispatch to respect panel focus state. Previously, when a panel (Detail, Region, Stats, Category) had focus, unhandled keys fell through to the log table handler, causing navigation keys like `j`/`k`/`PageUp`/`PageDown` to move the log table cursor instead of being consumed by the focused panel.

## Changes

- **Block log table key fallthrough when panel has focus**: Added a guard in `handle_normal_key` that returns `Handled` for any key not processed by the focused panel's handler or panel system keys (Tab/BackTab/Esc/z). This prevents log table from intercepting keys meant for panels.
- **Set `detail_tree_focus` on Tab/BackTab into Detail panel**: When Tab or Shift+Tab navigates into the Detail panel, `detail_tree_focus` is now correctly set to `true`, enabling the detail tree key handler to receive events.

## Testing

- Added 4 new tests:
  - `test_panel_focus_blocks_log_table_keys`: Verifies quit key is blocked when panel has focus
  - `test_tab_into_detail_sets_tree_focus`: Verifies Tab sets detail_tree_focus
  - `test_backtab_into_detail_sets_tree_focus`: Verifies BackTab sets detail_tree_focus
  - `test_stats_panel_focus_blocks_log_keys`: Verifies read-only Stats panel blocks log table keys
- All 440 existing tests pass

Closes #487