### PR TITLE
refactor: generic panel key dispatch via PanelId methods

### DIFF
--- a/crates/scouty-tui/src/panel.rs
+++ b/crates/scouty-tui/src/panel.rs
@@ -69,6 +69,52 @@ impl PanelId {
         ]
     }
 
+    /// Dispatch a key event to this panel's key handler.
+    ///
+    /// This is the generic dispatch point — adding a new panel only requires
+    /// adding a match arm here (and the panel's key handler module), with
+    /// zero changes to main_window dispatch logic.
+    pub fn dispatch_key(
+        self,
+        app: &mut crate::app::App,
+        key: crossterm::event::KeyEvent,
+    ) -> crate::ui::framework::KeyAction {
+        use crate::ui::framework::KeyAction;
+        match self {
+            PanelId::Detail => {
+                crate::ui::widgets::detail_panel_keys::handle_key(app, key)
+            }
+            PanelId::Region => {
+                crate::ui::widgets::region_panel_keys::handle_key(app, key)
+            }
+            PanelId::Category => {
+                crate::ui::widgets::category_panel_keys::handle_key(app, key)
+            }
+            PanelId::Stats => {
+                // Stats panel is read-only, no panel-specific keys
+                KeyAction::Unhandled
+            }
+        }
+    }
+
+    /// Return shortcut hints for this panel when it has focus.
+    pub fn shortcut_hints(self) -> Vec<(&'static str, &'static str)> {
+        match self {
+            PanelId::Detail => {
+                crate::ui::widgets::detail_panel_keys::shortcut_hints()
+            }
+            PanelId::Region => {
+                crate::ui::widgets::region_panel_keys::shortcut_hints()
+            }
+            PanelId::Stats => {
+                crate::ui::widgets::stats_panel_keys::shortcut_hints()
+            }
+            PanelId::Category => {
+                crate::ui::widgets::category_panel_keys::shortcut_hints()
+            }
+        }
+    }
+
     /// Next panel in tab order.
     pub fn next(self) -> PanelId {
         let all = Self::all();
@@ -199,5 +245,15 @@ impl PanelState {
     /// Whether the panel has keyboard focus.
     pub fn has_focus(&self) -> bool {
         self.focus == PanelFocus::PanelContent
+    }
+
+    /// Dispatch a key event to the currently active panel.
+    /// Only call when `has_focus()` is true.
+    pub fn dispatch_key(
+        &self,
+        app: &mut crate::app::App,
+        key: crossterm::event::KeyEvent,
+    ) -> crate::ui::framework::KeyAction {
+        self.active.dispatch_key(app, key)
     }
 }

--- a/crates/scouty-tui/src/panel_tests.rs
+++ b/crates/scouty-tui/src/panel_tests.rs
@@ -348,4 +348,43 @@ mod tests {
         assert_eq!(state.active, PanelId::Region);
         assert_eq!(state.focus, PanelFocus::PanelContent);
     }
+
+    #[test]
+    fn test_dispatch_key_all_panels_callable() {
+        // Verify dispatch_key works for every PanelId without panicking.
+        // This ensures adding a new panel requires implementing dispatch_key.
+        let mut app = crate::app::App::load_stdin(Vec::new()).unwrap();
+        let key = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('x'),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        for &panel in PanelId::all() {
+            // Should not panic — every panel has a dispatch_key arm
+            let _action = panel.dispatch_key(&mut app, key);
+        }
+    }
+
+    #[test]
+    fn test_shortcut_hints_all_panels() {
+        // Every panel should return hints without panicking.
+        for &panel in PanelId::all() {
+            let hints = panel.shortcut_hints();
+            // Hints is a vec (possibly empty for Stats)
+            assert!(hints.len() <= 20, "sanity: too many hints for {:?}", panel);
+        }
+    }
+
+    #[test]
+    fn test_dispatch_key_detail_handles_j() {
+        // Detail panel should handle 'j' key
+        let mut app = crate::app::App::load_stdin(Vec::new()).unwrap();
+        app.detail_open = true;
+        app.detail_tree_focus = true;
+        let key = crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('j'),
+            crossterm::event::KeyModifiers::NONE,
+        );
+        let action = PanelId::Detail.dispatch_key(&mut app, key);
+        assert_eq!(action, crate::ui::framework::KeyAction::Handled);
+    }
 }

--- a/crates/scouty-tui/src/ui/windows/main_window.rs
+++ b/crates/scouty-tui/src/ui/windows/main_window.rs
@@ -31,12 +31,7 @@ impl MainWindow {
         }
     }
 
-    /// Handle keys when region panel has focus.
-    fn handle_region_panel_key(&mut self, key: KeyEvent) -> KeyAction {
-        crate::ui::widgets::region_panel_keys::handle_key(&mut self.app, key)
-    }
-
-    /// Handle panel system keys (Tab/BackTab, z).
+        /// Handle panel system keys (Tab/BackTab, z).
     fn handle_panel_keys(&mut self, key: KeyEvent) -> KeyAction {
         let handled = match key.code {
             KeyCode::Tab if key.modifiers.is_empty() => {
@@ -313,22 +308,10 @@ impl MainWindow {
     /// Handle a key event in Normal mode.
     /// Returns `WindowAction::Close` if the app should quit.
     pub fn handle_normal_key(&mut self, key: KeyEvent) -> WindowAction {
-        // 1. Focused panel gets priority
+        // 1. Focused panel gets priority (generic dispatch — no match on PanelId)
         if self.app.panel_state.has_focus() {
-            let action = match self.app.panel_state.active {
-                crate::panel::PanelId::Detail => {
-                    crate::ui::widgets::detail_panel_keys::handle_key(&mut self.app, key)
-                }
-                crate::panel::PanelId::Region => self.handle_region_panel_key(key),
-                crate::panel::PanelId::Category => {
-                    crate::ui::widgets::category_panel_keys::handle_key(&mut self.app, key)
-                }
-                crate::panel::PanelId::Stats => {
-                    // Stats panel is read-only, no panel-specific keys
-                    KeyAction::Unhandled
-                }
-            };
-            if action == KeyAction::Handled {
+            let active = self.app.panel_state.active;
+            if active.dispatch_key(&mut self.app, key) == KeyAction::Handled {
                 return WindowAction::Handled;
             }
         }
@@ -436,21 +419,8 @@ impl Window for MainWindow {
             && self.app.panel_state.focus == crate::panel::PanelFocus::PanelContent;
 
         if panel_focused {
-            // Collect panel-specific hints first, then common panel hints
-            let mut hints: Vec<(&str, &str)> = match self.app.panel_state.active {
-                crate::panel::PanelId::Detail => {
-                    crate::ui::widgets::detail_panel_keys::shortcut_hints()
-                }
-                crate::panel::PanelId::Region => {
-                    crate::ui::widgets::region_panel_keys::shortcut_hints()
-                }
-                crate::panel::PanelId::Stats => {
-                    crate::ui::widgets::stats_panel_keys::shortcut_hints()
-                }
-                crate::panel::PanelId::Category => {
-                    crate::ui::widgets::category_panel_keys::shortcut_hints()
-                }
-            };
+            // Generic panel hints dispatch — no match on PanelId
+            let mut hints: Vec<(&str, &str)> = self.app.panel_state.active.shortcut_hints();
             // Common panel hints from MainWindow
             hints.push(("Tab/S-Tab", "Switch"));
             hints.push(("z", "Max"));


### PR DESCRIPTION
## Summary

Refactor panel key dispatch to be generic — `handle_normal_key` no longer matches on `PanelId` to dispatch keys. Adding a new panel requires zero changes to main_window dispatch logic.

## Changes

- **`PanelId::dispatch_key()`**: New method on `PanelId` that routes key events to the appropriate panel handler. This is the single dispatch point for all panel key handling.
- **`PanelId::shortcut_hints()`**: New method that returns panel-specific shortcut hints generically.
- **`PanelState::dispatch_key()`**: Convenience method that delegates to the active panel's `dispatch_key()`.
- **`handle_normal_key`**: Now calls `active.dispatch_key()` instead of matching on each `PanelId` variant.
- **`shortcut_hints`**: Now calls `active.shortcut_hints()` instead of matching on each variant.
- **Removed** unused `handle_region_panel_key` wrapper method.

## Testing

- 3 new tests:
  - `test_dispatch_key_all_panels_callable`: Verifies dispatch works for every panel
  - `test_shortcut_hints_all_panels`: Verifies hints for every panel
  - `test_dispatch_key_detail_handles_j`: Verifies Detail panel handles j key via dispatch
- All 440 tests pass ✅

Closes #490