### PR TITLE
fix: add stable secondary sort for stats panel top components

### DIFF
--- a/crates/scouty-tui/src/ui/windows/stats_window.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window.rs
@@ -62,7 +62,7 @@ impl StatsData {
 
         // Top 10 components by count
         let mut top_components: Vec<(String, usize)> = component_map.into_iter().collect();
-        top_components.sort_by(|a, b| b.1.cmp(&a.1));
+        top_components.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         top_components.truncate(10);
 
         let fmt_ts = |ts: chrono::DateTime<chrono::Utc>| -> String {

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -143,10 +143,11 @@ mod tests {
     fn test_stats_compute_top_components() {
         let app = make_test_app();
         let stats = StatsData::compute(&app);
-        // auth=2, db=2, api=1
+        // auth=2, db=2, api=1 — secondary sort by name ensures stable order
         assert_eq!(stats.top_components.len(), 3);
-        // Top should be auth or db (both 2)
-        assert!(stats.top_components[0].1 >= stats.top_components[1].1);
+        assert_eq!(stats.top_components[0], ("auth".to_string(), 2));
+        assert_eq!(stats.top_components[1], ("db".to_string(), 2));
+        assert_eq!(stats.top_components[2], ("api".to_string(), 1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add a stable secondary sort (by name) for stats panel top components to prevent UI flickering when multiple components have the same primary sort value.

## Changes

When sorting top components in the stats panel, items with equal values would swap positions on every refresh, causing visual flickering. This adds a secondary sort by component name to ensure deterministic ordering.

Closes #501