### PR TITLE
fix: stable sort for top components in stats panel

### DIFF
--- a/crates/scouty-tui/src/ui/windows/stats_window.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window.rs
@@ -62,7 +62,7 @@ impl StatsData {
 
         // Top 10 components by count
         let mut top_components: Vec<(String, usize)> = component_map.into_iter().collect();
-        top_components.sort_by(|a, b| b.1.cmp(&a.1));
+        top_components.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         top_components.truncate(10);
 
         let fmt_ts = |ts: chrono::DateTime<chrono::Utc>| -> String {

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -143,10 +143,11 @@ mod tests {
     fn test_stats_compute_top_components() {
         let app = make_test_app();
         let stats = StatsData::compute(&app);
-        // auth=2, db=2, api=1
+        // auth=2, db=2, api=1 — secondary sort by name ensures stable order
         assert_eq!(stats.top_components.len(), 3);
-        // Top should be auth or db (both 2)
-        assert!(stats.top_components[0].1 >= stats.top_components[1].1);
+        assert_eq!(stats.top_components[0], ("auth".to_string(), 2));
+        assert_eq!(stats.top_components[1], ("db".to_string(), 2));
+        assert_eq!(stats.top_components[2], ("api".to_string(), 1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add secondary sort by component name when counts are equal in the stats panel's top components list, preventing the order from flickering/jumping between refreshes.

## Changes

- `stats_window.rs`: Added `.then_with(|| a.0.cmp(&b.0))` to the sort comparator so ties in count are broken alphabetically by component name
- `stats_window_tests.rs`: Updated test to assert exact deterministic ordering

## Testing

- All existing tests pass
- `test_stats_compute_top_components` now verifies exact order: auth(2), db(2), api(1)

Closes #501