### PR TITLE
fix: stabilize top components sort order in stats panel

### DIFF
--- a/crates/scouty-tui/src/ui/windows/stats_window.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window.rs
@@ -62,7 +62,7 @@ impl StatsData {
 
         // Top 10 components by count
         let mut top_components: Vec<(String, usize)> = component_map.into_iter().collect();
-        top_components.sort_by(|a, b| b.1.cmp(&a.1));
+        top_components.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         top_components.truncate(10);
 
         let fmt_ts = |ts: chrono::DateTime<chrono::Utc>| -> String {

--- a/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
+++ b/crates/scouty-tui/src/ui/windows/stats_window_tests.rs
@@ -145,8 +145,14 @@ mod tests {
         let stats = StatsData::compute(&app);
         // auth=2, db=2, api=1
         assert_eq!(stats.top_components.len(), 3);
-        // Top should be auth or db (both 2)
-        assert!(stats.top_components[0].1 >= stats.top_components[1].1);
+        // With stable sort: same count sorted alphabetically by name
+        // auth=2, db=2 (alphabetical), then api=1
+        assert_eq!(stats.top_components[0].0, "auth");
+        assert_eq!(stats.top_components[1].0, "db");
+        assert_eq!(stats.top_components[2].0, "api");
+        assert_eq!(stats.top_components[0].1, 2);
+        assert_eq!(stats.top_components[1].1, 2);
+        assert_eq!(stats.top_components[2].1, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Stabilize the top components list order in the stats panel by adding a secondary sort key (component name) when counts are equal.

## Problem

The top components list keeps jumping/flickering between refreshes because components with the same count have no deterministic ordering.

## Fix

Added `.then_with(|| a.0.cmp(&b.0))` to the sort comparator so that components with equal counts are sorted alphabetically by name.

## Testing

Updated existing test to verify stable ordering. All 5 stats_window tests pass.

Closes #501