### PR TITLE
fix: NotifySyncdResponse inherits context from NotifySyncd

### DIFF
--- a/crates/scouty/src/parser/sairedis_parser.rs
+++ b/crates/scouty/src/parser/sairedis_parser.rs
@@ -27,6 +27,7 @@ pub struct SairedisParser {
     last_get_context: RefCell<Option<String>>,
     /// Last component from a `g` (Get) operation.
     last_get_component: RefCell<Option<String>>,
+    /// Last context from a NotifySyncd (`a`) request, used to associate state with NotifySyncdResponse (`A`) operations.
     last_notify_context: RefCell<Option<String>>,
     /// Last context from a `q` (Query) operation.
     last_query_context: RefCell<Option<String>>,

--- a/crates/scouty/src/parser/sairedis_parser_tests.rs
+++ b/crates/scouty/src/parser/sairedis_parser_tests.rs
@@ -564,7 +564,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn test_notify_syncd_response_inherits_context() {
         let p = SairedisParser::new();
         // First parse a NotifySyncd request to set context
@@ -591,6 +590,7 @@ mod tests {
         assert_eq!(r2.context.as_deref(), Some("INIT_VIEW"));
         assert_eq!(r2.message, "SAI_STATUS_SUCCESS");
     }
+    #[test]
 
     fn test_notify_syncd_response_status_extraction() {
         let p = SairedisParser::new();


### PR DESCRIPTION
## Summary

NotifySyncdResponse (`A`) handler now inherits context from NotifySyncd (`a`), following the same stateful pattern as `last_get_context`/`last_get_component` and `last_query_context`/`last_query_component`.

## Changes

- Added `last_notify_context: RefCell<Option<String>>` field to `SairedisParser`
- `a` (NotifySyncd) handler saves context to `last_notify_context`
- `A` (NotifySyncdResponse) handler reads context from `last_notify_context`
- Added test `test_notify_syncd_response_inherits_context`

Closes #526