### PR TITLE
fix: snap density chart time bucket to human-friendly intervals

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -90,6 +90,9 @@ impl StatusBarWidget {
             43_200_000.0, // 12h
             86_400_000.0, // 24h
         ];
+        if ms <= 0.0 {
+            return INTERVALS_MS[0];
+        }
         for &iv in INTERVALS_MS {
             if ms <= iv {
                 return iv;

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
@@ -191,14 +191,18 @@ mod tests {
         assert_eq!(StatusBarWidget::snap_to_standard(180_000.0), 300_000.0); // 3m -> 5m
         assert_eq!(StatusBarWidget::snap_to_standard(480_000.0), 600_000.0); // 8m -> 10m
         assert_eq!(StatusBarWidget::snap_to_standard(700_000.0), 900_000.0); // ~11.7m -> 15m
-        assert_eq!(StatusBarWidget::snap_to_standard(2_700_000.0), 3_600_000.0); // 45m -> 1h
+        assert_eq!(StatusBarWidget::snap_to_standard(2_700_000.0), 3_600_000.0);
+        // 45m -> 1h
     }
 
     #[test]
     fn test_snap_to_standard_hours() {
         assert_eq!(StatusBarWidget::snap_to_standard(3_600_000.0), 3_600_000.0); // 1h exact
         assert_eq!(StatusBarWidget::snap_to_standard(5_000_000.0), 7_200_000.0); // -> 2h
-        assert_eq!(StatusBarWidget::snap_to_standard(10_000_000.0), 21_600_000.0); // -> 6h
+        assert_eq!(
+            StatusBarWidget::snap_to_standard(10_000_000.0),
+            21_600_000.0
+        ); // -> 6h
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix density chart time bucket size not snapping to human-friendly intervals for sub-5s values (e.g. showing `327ms` instead of `500ms`).

## Changes

Expanded `snap_to_standard()` to cover the full range using a 1-2-5 progression:
- **Sub-second:** 1ms, 2ms, 5ms, 10ms, 20ms, 50ms, 100ms, 200ms, 500ms
- **Seconds:** 1s, 2s, 5s, 10s, 15s, 30s
- **Minutes:** 1m, 2m, 5m, 10m, 15m, 30m
- **Hours:** 1h, 2h, 6h, 12h, 24h

Previously values below 5s were returned as-is. Also added 2m and 10m intervals for better granularity.

## Testing

- Updated and expanded `snap_to_standard` tests (sub-second, seconds, minutes, hours, beyond-24h)
- Updated `time_per_column_label` tests for new snap behavior
- All 20 status_bar_widget tests pass

Closes #533