### PR TITLE
Simplify bookmark display in status bar

### DIFF
--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -28,6 +28,16 @@ fn spans_display_width(spans: &[Span]) -> usize {
 }
 
 impl StatusBarWidget {
+    /// Build the right-side text for line 1 (position + optional bookmark indicator).
+    pub fn build_right_text(position: &str, bookmark_count: usize) -> String {
+        if bookmark_count > 0 {
+            let bookmark_text = format!("★{}", bookmark_count);
+            format!(" {} | {} ", bookmark_text, position.trim())
+        } else {
+            format!(" {} ", position)
+        }
+    }
+
     /// Return the shortcut hints for the current mode/panel state.
     pub fn shortcut_hints(
         panel_focused: bool,
@@ -156,18 +166,7 @@ impl StatusBarWidget {
             }
         };
 
-        let bookmark_text = if !app.bookmarks.is_empty() {
-            format!("★{}", app.bookmarks.len())
-        } else {
-            String::new()
-        };
-
-        let position_text = format!(" {} ", position);
-        let right_text = if bookmark_text.is_empty() {
-            position_text.clone()
-        } else {
-            format!(" {} | {} ", bookmark_text, position.trim())
-        };
+        let right_text = Self::build_right_text(&position, app.bookmarks.len());
         let right_width = UnicodeWidthStr::width(right_text.as_str()) as u16;
 
         // Account for follow indicator width in chart space
@@ -238,7 +237,7 @@ impl StatusBarWidget {
 
         let used_width = spans_display_width(&spans);
         let total_width = area.width as usize;
-        let right_len = right_text.len();
+        let right_len = UnicodeWidthStr::width(right_text.as_str());
         if used_width + right_len < total_width {
             let pad = total_width - used_width - right_len;
             spans.push(Span::styled(

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget_tests.rs
@@ -247,3 +247,75 @@ mod tests {
         assert_eq!(hints[0], ("Tab/S-Tab", "Switch"));
     }
 }
+
+#[cfg(test)]
+mod bookmark_display_tests {
+    use crate::ui::widgets::status_bar_widget::StatusBarWidget;
+    use unicode_width::UnicodeWidthStr;
+
+    #[test]
+    fn test_build_right_text_no_bookmarks() {
+        let result = StatusBarWidget::build_right_text("1/100", 0);
+        assert_eq!(result, " 1/100 ");
+    }
+
+    #[test]
+    fn test_build_right_text_with_bookmarks() {
+        let result = StatusBarWidget::build_right_text("1/100", 3);
+        assert_eq!(result, " ★3 | 1/100 ");
+    }
+
+    #[test]
+    fn test_build_right_text_with_bookmarks_single() {
+        let result = StatusBarWidget::build_right_text("42/500", 1);
+        assert_eq!(result, " ★1 | 42/500 ");
+    }
+
+    #[test]
+    fn test_build_right_text_trims_position() {
+        // position passed with surrounding spaces should be trimmed in bookmark branch
+        let result = StatusBarWidget::build_right_text(" 1/100 ", 2);
+        assert_eq!(result, " ★2 | 1/100 ");
+    }
+
+    #[test]
+    fn test_build_right_text_unicode_width_correct() {
+        // ★ is a fullwidth-ish character; verify display width is computed correctly
+        let result = StatusBarWidget::build_right_text("1/10", 5);
+        let display_width = UnicodeWidthStr::width(result.as_str());
+        // " ★5 | 1/10 " — each char's display width should sum correctly
+        // ' '=1, '★'=1, '5'=1, ' '=1, '|'=1, ' '=1, '1'=1, '/'=1, '1'=1, '0'=1, ' '=1 = 12
+        // but ★ may be width 1 or 2 depending on unicode-width version
+        assert!(display_width > 0);
+        // Crucially, display_width should differ from byte length since ★ is multi-byte
+        assert_ne!(
+            display_width,
+            result.len(),
+            "display width should differ from byte length due to ★"
+        );
+    }
+
+    #[test]
+    fn test_build_right_text_pipe_separator_present() {
+        let result = StatusBarWidget::build_right_text("1/100", 2);
+        assert!(
+            result.contains(" | "),
+            "should contain pipe separator when bookmarks present"
+        );
+    }
+
+    #[test]
+    fn test_build_right_text_pipe_separator_absent() {
+        let result = StatusBarWidget::build_right_text("1/100", 0);
+        assert!(
+            !result.contains("|"),
+            "should not contain pipe when no bookmarks"
+        );
+    }
+
+    #[test]
+    fn test_build_right_text_star_format() {
+        let result = StatusBarWidget::build_right_text("1/100", 42);
+        assert!(result.contains("★42"), "should contain ★N format");
+    }
+}


### PR DESCRIPTION
Simplify the status bar bookmark indicator from `Bookmarks: 3` to `★3`, with a `|` separator between bookmark count and line position (e.g. `★3 | 1/20`).

This saves horizontal space and makes the status bar more compact.

Closes #535