### PR TITLE
fix: address density tick review comments from PR #540

### DIFF
--- a/crates/scouty-tui/src/density.rs
+++ b/crates/scouty-tui/src/density.rs
@@ -187,20 +187,18 @@ pub const TICK_INTERVAL: usize = 10;
 /// Compute the effective chart width (braille chars) that fits within
 /// `available` display columns, accounting for tick marks every `interval`.
 pub fn chart_width_for_available(available: usize, interval: usize) -> usize {
-    if interval == 0 || available <= interval {
+    if interval == 0 {
         return available;
     }
-    // Exact: find largest n where n + floor((n-1)/interval) <= available.
-    let mut n = (available * interval + 1) / (interval + 1);
-    // Try to increase n while the total (braille + ticks) still fits.
-    while n + (n.saturating_sub(1)) / interval < available {
-        n += 1;
+    // Find the largest n where n + floor(n / interval) <= available.
+    // Closed-form lower bound: n <= available * interval / (interval + 1).
+    let n = (available * interval) / (interval + 1);
+    // Check if n+1 also fits.
+    if (n + 1) + (n + 1) / interval <= available {
+        n + 1
+    } else {
+        n
     }
-    // Back off if we overshot.
-    while n > 0 && n + (n.saturating_sub(1)) / interval > available {
-        n -= 1;
-    }
-    n
 }
 
 #[cfg(test)]
@@ -208,10 +206,10 @@ mod tests {
     use super::*;
 
     fn tick_count(braille_len: usize, interval: usize) -> usize {
-        if interval == 0 || braille_len <= interval {
+        if interval == 0 {
             return 0;
         }
-        (braille_len - 1) / interval
+        braille_len / interval
     }
     use chrono::Duration;
 
@@ -306,25 +304,31 @@ mod tests {
     fn test_tick_count() {
         assert_eq!(tick_count(0, 10), 0);
         assert_eq!(tick_count(5, 10), 0);
-        assert_eq!(tick_count(10, 10), 0);
+        assert_eq!(tick_count(9, 10), 0);
+        assert_eq!(tick_count(10, 10), 1);
         assert_eq!(tick_count(11, 10), 1);
-        assert_eq!(tick_count(20, 10), 1);
+        assert_eq!(tick_count(20, 10), 2);
         assert_eq!(tick_count(21, 10), 2);
-        assert_eq!(tick_count(30, 10), 2);
-        assert_eq!(tick_count(31, 10), 3);
+        assert_eq!(tick_count(30, 10), 3);
     }
 
     #[test]
     fn test_chart_width_for_available() {
         use super::chart_width_for_available;
-        // 10 columns available, interval 10 => fits 10 braille (0 ticks)
-        assert_eq!(chart_width_for_available(10, 10), 10);
-        // 11 columns: 10 braille + 1 tick = 11, or 11 braille + 1 tick = 12 > 11
-        let w = chart_width_for_available(11, 10);
-        assert!(w + tick_count(w, 10) <= 11);
-        // 22 columns: 20 braille + 1 tick = 21 <= 22
+        // 10 columns available, interval 10 => fits 10 braille (1 tick: 10+1=11 > 10), so 9
+        let w = chart_width_for_available(10, 10);
+        assert!(w + tick_count(w, 10) <= 10);
+        // 11 columns: 10 braille + 1 tick = 11 fits
+        assert_eq!(chart_width_for_available(11, 10), 10);
+        // 22 columns: 20 braille + 2 ticks = 22 fits exactly
         let w = chart_width_for_available(22, 10);
-        assert!(w + tick_count(w, 10) <= 22);
-        assert!(w >= 20);
+        assert_eq!(w + tick_count(w, 10), 22);
+        assert_eq!(w, 20);
+        // Verify no waste: w+1 wouldn't fit
+        assert!((w + 1) + tick_count(w + 1, 10) > 22);
+        // Edge: available=0
+        assert_eq!(chart_width_for_available(0, 10), 0);
+        // Edge: interval=0
+        assert_eq!(chart_width_for_available(20, 0), 20);
     }
 }

--- a/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
+++ b/crates/scouty-tui/src/ui/widgets/status_bar_widget.rs
@@ -167,25 +167,6 @@ impl StatusBarWidget {
         };
 
         let right_text = Self::build_right_text(&position, app.bookmarks.len());
-        let right_width = UnicodeWidthStr::width(right_text.as_str()) as u16;
-
-        // Account for follow indicator width in chart space
-        let follow_width: u16 = if app.follow_mode {
-            if app.follow_new_count > 0 {
-                (format!("[FOLLOW ↓{}] ", app.follow_new_count).len() + 2) as u16
-            } else {
-                "[FOLLOW] ".len() as u16
-            }
-        } else {
-            0
-        };
-
-        let raw_chart_width = area.width.saturating_sub(right_width + follow_width + 2) as usize;
-        // Reserve space for dim tick marks inserted every 10 braille chars.
-        let chart_width = crate::density::chart_width_for_available(
-            raw_chart_width,
-            crate::density::TICK_INTERVAL,
-        );
 
         let mut spans: Vec<Span> = Vec::new();
 
@@ -208,43 +189,52 @@ impl StatusBarWidget {
             }
         }
 
-        if chart_width >= 4 && app.total() > 0 {
+        if app.total() > 0 {
             if let Some(cache) = &app.density_cache {
-                // Show time-per-column label before chart
-                if let Some(label) = Self::time_per_column_label(cache) {
-                    let source_label = app.density_source_label();
-                    let full_label = if source_label == "All" {
-                        label
-                    } else {
-                        match label.strip_suffix(']') {
-                            Some(prefix) => format!("{prefix} {source_label}]"),
-                            None => format!("{label} {source_label}"),
-                        }
-                    };
-                    spans.push(Span::styled(
-                        full_label,
-                        theme.status_bar.density_label.to_style(),
-                    ));
-                }
-
-                let cursor_char_idx = app.cursor_char_in_density();
-
-                // Dim tick mark every 10 braille chars for visual counting
-                let tick_interval = crate::density::TICK_INTERVAL;
-                let tick_style = theme.status_bar.density_tick.to_style();
-
-                for (i, ch) in cache.braille_text.chars().enumerate() {
-                    if i > 0 && i % tick_interval == 0 {
-                        spans.push(Span::styled("\u{250a}", tick_style));
+                if cache.chart_width < 4 {
+                    // Chart too small to display; skip.
+                } else {
+                    // Show time-per-column label before chart
+                    if let Some(label) = Self::time_per_column_label(cache) {
+                        let source_label = app.density_source_label();
+                        let full_label = if source_label == "All" {
+                            label
+                        } else {
+                            match label.strip_suffix(']') {
+                                Some(prefix) => format!("{prefix} {source_label}]"),
+                                None => format!("{label} {source_label}"),
+                            }
+                        };
+                        spans.push(Span::styled(
+                            full_label,
+                            theme.status_bar.density_label.to_style(),
+                        ));
                     }
 
-                    let style = if Some(i) == cursor_char_idx {
-                        theme.status_bar.cursor_marker.to_style()
-                    } else {
-                        theme.status_bar.density_normal.to_style()
-                    };
-                    spans.push(Span::styled(ch.to_string(), style));
-                }
+                    let cursor_char_idx = app.cursor_char_in_density();
+
+                    // Dim tick mark every 10 braille chars for visual counting
+                    let tick_interval = crate::density::TICK_INTERVAL;
+                    let tick_style = theme.status_bar.density_tick.to_style();
+
+                    let braille_len = cache.braille_text.chars().count();
+                    for (i, ch) in cache.braille_text.chars().enumerate() {
+                        if i > 0 && i % tick_interval == 0 {
+                            spans.push(Span::styled("\u{250a}", tick_style));
+                        }
+
+                        let style = if Some(i) == cursor_char_idx {
+                            theme.status_bar.cursor_marker.to_style()
+                        } else {
+                            theme.status_bar.density_normal.to_style()
+                        };
+                        spans.push(Span::styled(ch.to_string(), style));
+                    }
+                    // Trailing tick after the last group if it ends on a boundary.
+                    if braille_len > 0 && braille_len % tick_interval == 0 {
+                        spans.push(Span::styled("\u{250a}", tick_style));
+                    }
+                } // cache.chart_width >= 4
             }
         }
 


### PR DESCRIPTION
Follow-up to PR #540 addressing 4 review comments:

1. **Width consistency**: Removed redundant chart_width recomputation in status_bar_widget; now uses cache.chart_width for consistency with main loop density cache building.

2. **TICK_INTERVAL constant**: Already addressed in previous commit (uses `crate::density::TICK_INTERVAL` everywhere). Cleaned up unused `follow_width` and `right_width` variables.

3. **Theme-based tick color**: Already addressed in previous commit (uses `theme.status_bar.density_tick`).

4. **Precise chart_width_for_available**: Replaced loop-based approximation with closed-form formula: find max n where `n + n/interval <= available`. Added trailing tick mark rendering when braille length falls on interval boundary. Updated tests accordingly.

All 494 tests pass.