### PR TITLE
Add --theme-list CLI argument and theme descriptions

### DIFF
--- a/crates/scouty-tui/src/config/theme.rs
+++ b/crates/scouty-tui/src/config/theme.rs
@@ -433,23 +433,8 @@ impl Theme {
         }
     }
 
-    /// List all built-in theme names.
-    pub fn builtin_names() -> &'static [&'static str] {
-        &[
-            "default",
-            "dark",
-            "light",
-            "solarized",
-            "landmine",
-            "mizuiro",
-            "amai",
-            "maid",
-            "gyaru",
-        ]
-    }
-
-    /// Return (name, description) pairs for all built-in themes.
-    pub fn builtin_descriptions() -> &'static [(&'static str, &'static str)] {
+    /// Single source of truth for all built-in theme names and descriptions.
+    pub fn builtin_catalog() -> &'static [(&'static str, &'static str)] {
         &[
             ("default", "Balanced dark theme with soft, modern colors"),
             ("dark", "Muted dark theme — lower contrast, softer colors"),
@@ -459,7 +444,7 @@ impl Theme {
             ),
             (
                 "solarized",
-                "Ethan Schoonover's solarized palette, warm and precise",
+                "Ethan Schoonover’s solarized palette, warm and precise",
             ),
             (
                 "landmine",
@@ -480,20 +465,23 @@ impl Theme {
             ("gyaru", "Shibuya bold — gold and hot pink glamour"),
         ]
     }
+
+    /// List all built-in theme names.
+    pub fn builtin_names() -> Vec<&'static str> {
+        Self::builtin_catalog().iter().map(|(n, _)| *n).collect()
+    }
+
+    /// Return (name, description) pairs for all built-in themes.
+    pub fn builtin_descriptions() -> &'static [(&'static str, &'static str)] {
+        Self::builtin_catalog()
+    }
+
     /// Get the description for a built-in theme.
     pub fn builtin_description(name: &str) -> Option<&'static str> {
-        match name {
-            "default" => Some("Dark theme with blue accents and warm highlights"),
-            "dark" => Some("Low-contrast dark theme with muted, softer colors"),
-            "light" => Some("Light background with dark text for bright environments"),
-            "solarized" => Some("Ethan Schoonover's Solarized Dark palette"),
-            "landmine" => Some("Jirai Kei: black base with pink and red accents"),
-            "mizuiro" => Some("Clear aqua: deep navy base with water blue and sky blue"),
-            "amai" => Some("Sweet Lolita: dark rose base with candy pink and lavender"),
-            "maid" => Some("Classic maid: black and white high contrast with wine red"),
-            "gyaru" => Some("Shibuya bold: dark bronze base with gold and hot pink"),
-            _ => None,
-        }
+        Self::builtin_catalog()
+            .iter()
+            .find(|(n, _)| *n == name)
+            .map(|(_, d)| *d)
     }
 
     /// Muted dark theme — lower contrast, softer colors.

--- a/crates/scouty-tui/src/config/theme_tests.rs
+++ b/crates/scouty-tui/src/config/theme_tests.rs
@@ -79,6 +79,17 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn all_builtins_have_non_empty_description() {
+        for (name, desc) in Theme::builtin_catalog() {
+            assert!(
+                !desc.is_empty(),
+                "builtin theme '{}' has empty description",
+                name
+            );
+        }
+    }
 }
 
 mod no_ansi16_tests {

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -146,11 +146,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let mut entries: Vec<(&str, String)> =
                     builtins.iter().map(|(n, d)| (*n, d.to_string())).collect();
 
-                // Scan ~/.scouty/themes/ for user custom themes
+                // Scan custom theme directories: system (/etc/scouty/themes/) and
+                // user (~/.scouty/themes/), matching the search order used by
+                // config::resolve_theme().
+                let mut custom_dirs: Vec<std::path::PathBuf> = Vec::new();
+                custom_dirs.push(config::system_config_dir().join("themes"));
                 if let Some(home) = dirs::home_dir() {
-                    let themes_dir = home.join(".scouty").join("themes");
+                    custom_dirs.push(home.join(".scouty").join("themes"));
+                }
+                let mut seen_custom: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for themes_dir in &custom_dirs {
                     if themes_dir.is_dir() {
-                        if let Ok(read_dir) = std::fs::read_dir(&themes_dir) {
+                        if let Ok(read_dir) = std::fs::read_dir(themes_dir) {
                             let mut user_files: Vec<_> = read_dir
                                 .filter_map(|e| e.ok())
                                 .filter(|e| {
@@ -169,8 +177,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     .unwrap_or_default()
                                     .to_string_lossy()
                                     .to_string();
-                                // Leak the string so we get a &'static-like lifetime
-                                // (process exits immediately after printing)
+                                if seen_custom.contains(&stem) {
+                                    continue;
+                                }
+                                seen_custom.insert(stem.clone());
                                 let leaked: &str = Box::leak(stem.into_boxed_str());
                                 entries.push((leaked, "(custom)".to_string()));
                             }


### PR DESCRIPTION
## Summary

Add a `--theme-list` CLI argument that lists all available themes (built-in + custom) with descriptions, then exits.

## Changes

- **`Theme::builtin_description()`**: New method returning a one-line description for each built-in theme (e.g. "Dark theme with blue accents and warm highlights")
- **`--theme-list` CLI flag**: Prints all built-in themes with descriptions, scans `~/.scouty/themes/` for user custom `.yaml` themes, then exits (like `--version`)
- **Help text**: Added `--theme-list` to `--help` output

## Example output

```
Built-in themes:
  default      Dark theme with blue accents and warm highlights
  dark         Low-contrast dark theme with muted, softer colors
  light        Light background with dark text for bright environments
  solarized    Ethan Schoonover's Solarized Dark palette
  landmine     Jirai Kei: black base with pink and red accents
  mizuiro      Clear aqua: deep navy base with water blue and sky blue
  amai         Sweet Lolita: dark rose base with candy pink and lavender
  maid         Classic maid: black and white high contrast with wine red
  gyaru        Shibuya bold: dark bronze base with gold and hot pink

Custom themes (~/.scouty/themes/):
  (none)
```

## Test plan

- `cargo fmt --all --check` ✅
- `cargo clippy` ✅
- `cargo build` ✅
- `cargo test` (494 passed) ✅

Closes #552