### PR TITLE
Move theme description into Theme struct and rename --generate-theme to --theme-dump

### DIFF
--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -301,7 +301,7 @@ ssh:
     .to_string()
 }
 
-/// Generate a built-in theme as commented YAML for `--generate-theme`.
+/// Generate a built-in theme as commented YAML for `--theme-dump`.
 /// Returns `None` if the theme name is unknown.
 pub fn generate_theme(name: &str) -> Option<String> {
     let theme = Theme::builtin(name)?;

--- a/crates/scouty-tui/src/config/theme.rs
+++ b/crates/scouty-tui/src/config/theme.rs
@@ -375,6 +375,9 @@ impl Default for PanelTabTheme {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Theme {
+    /// Optional human-readable description for theme listing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     pub log_levels: LogLevelTheme,
     pub table: TableTheme,
     pub status_bar: StatusBarTheme,
@@ -390,6 +393,7 @@ pub struct Theme {
 impl Default for Theme {
     fn default() -> Self {
         Self {
+            description: Some("Balanced dark theme with soft, modern colors".to_string()),
             log_levels: LogLevelTheme::default(),
             table: TableTheme::default(),
             status_bar: StatusBarTheme::default(),
@@ -433,61 +437,42 @@ impl Theme {
         }
     }
 
-    /// Single source of truth for all built-in theme names and descriptions.
-    pub fn builtin_catalog() -> &'static [(&'static str, &'static str)] {
-        &[
-            ("default", "Balanced dark theme with soft, modern colors"),
-            ("dark", "Muted dark theme — lower contrast, softer colors"),
-            (
-                "light",
-                "Light background with dark text for bright environments",
-            ),
-            (
-                "solarized",
-                "Ethan Schoonover’s solarized palette, warm and precise",
-            ),
-            (
-                "landmine",
-                "Jirai Kei aesthetic — black and pink with bold accents",
-            ),
-            (
-                "mizuiro",
-                "Clear, transparent aqua theme with cool blue tones",
-            ),
-            (
-                "amai",
-                "Sweet Lolita — dreamy pastel pink and soft lavender",
-            ),
-            (
-                "maid",
-                "Classic maid — black & white high contrast with wine red",
-            ),
-            ("gyaru", "Shibuya bold — gold and hot pink glamour"),
-        ]
-    }
+    /// All built-in theme names in display order.
+    const BUILTIN_NAMES: &'static [&'static str] = &[
+        "default",
+        "dark",
+        "light",
+        "solarized",
+        "landmine",
+        "mizuiro",
+        "amai",
+        "maid",
+        "gyaru",
+    ];
 
     /// List all built-in theme names.
     pub fn builtin_names() -> Vec<&'static str> {
-        Self::builtin_catalog().iter().map(|(n, _)| *n).collect()
+        Self::BUILTIN_NAMES.to_vec()
     }
 
     /// Return (name, description) pairs for all built-in themes.
-    pub fn builtin_descriptions() -> &'static [(&'static str, &'static str)] {
-        Self::builtin_catalog()
-    }
-
-    /// Get the description for a built-in theme.
-    pub fn builtin_description(name: &str) -> Option<&'static str> {
-        Self::builtin_catalog()
+    /// Descriptions come from the `description` field on each Theme struct.
+    pub fn builtin_descriptions() -> Vec<(String, String)> {
+        Self::BUILTIN_NAMES
             .iter()
-            .find(|(n, _)| *n == name)
-            .map(|(_, d)| *d)
+            .filter_map(|name| {
+                let theme = Self::builtin(name)?;
+                let desc = theme.description.unwrap_or_default();
+                Some((name.to_string(), desc))
+            })
+            .collect()
     }
 
     /// Muted dark theme — lower contrast, softer colors.
     pub fn dark() -> Self {
         use Color::*;
         Self {
+            description: Some("Muted dark theme — lower contrast, softer colors".to_string()),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(Red),
                 error: StyleEntry::fg(Rgb(205, 92, 92)),
@@ -571,6 +556,9 @@ impl Theme {
     pub fn light() -> Self {
         use Color::*;
         Self {
+            description: Some(
+                "Light background with dark text for bright environments".to_string(),
+            ),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(Rgb(180, 0, 0)),
                 error: StyleEntry::fg(Rgb(180, 0, 0)),
@@ -666,6 +654,7 @@ impl Theme {
         let green = Rgb(133, 153, 0);
 
         Self {
+            description: Some("Ethan Schoonover's solarized palette, warm and precise".to_string()),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(red),
                 error: StyleEntry::fg(red),
@@ -765,6 +754,7 @@ impl Theme {
         let light_text = Rgb(200, 200, 200); // #C8C8C8
 
         Self {
+            description: Some("Jirai Kei aesthetic — black and pink with bold accents".to_string()),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(bright_pink),
                 error: StyleEntry::fg(rose_pink),
@@ -882,6 +872,7 @@ impl Theme {
         let amber_warn = Rgb(232, 167, 78); // #E8A74E
 
         Self {
+            description: Some("Clear, transparent aqua theme with cool blue tones".to_string()),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(coral_accent),
                 error: StyleEntry::fg(Rgb(207, 107, 94)), // #CF6B5E
@@ -1000,6 +991,7 @@ impl Theme {
         let position_fg = Rgb(212, 178, 212); // #D4B2D4
 
         Self {
+            description: Some("Sweet Lolita — dreamy pastel pink and soft lavender".to_string()),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(hot_pink),
                 error: StyleEntry::fg(Rgb(232, 90, 122)), // #E85A7A
@@ -1113,6 +1105,9 @@ impl Theme {
         let amber_warn = Rgb(212, 160, 80); // #D4A050
 
         Self {
+            description: Some(
+                "Classic maid — black & white high contrast with wine red".to_string(),
+            ),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(bright_red),
                 error: StyleEntry::fg(wine_red),
@@ -1227,6 +1222,7 @@ impl Theme {
         let selected_bg = Rgb(58, 40, 24); // #3A2818
 
         Self {
+            description: Some("Shibuya bold — gold and hot pink glamour".to_string()),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(hot_pink),
                 error: StyleEntry::fg(Rgb(255, 105, 180)), // #FF69B4

--- a/crates/scouty-tui/src/config/theme_tests.rs
+++ b/crates/scouty-tui/src/config/theme_tests.rs
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn all_builtins_have_non_empty_description() {
-        for (name, desc) in Theme::builtin_catalog() {
+        for (name, desc) in Theme::builtin_descriptions() {
             assert!(
                 !desc.is_empty(),
                 "builtin theme '{}' has empty description",

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -124,9 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!("  --follow, -f      Follow file for new data (like tail -f)");
                 eprintln!("  --log [level]     Enable logging to ~/.scouty/log/ (default: info)");
                 eprintln!("  --generate-config          Generate default config to stdout");
-                eprintln!(
-                    "  --generate-theme <name>    Generate built-in theme to stdout (or 'list')"
-                );
+                eprintln!("  --theme-dump <name>        Dump built-in theme as YAML to stdout");
                 eprintln!("  --theme-list               List all available themes and exit");
                 eprintln!();
                 eprintln!("Pipe mode (auto when stdout is not a TTY):");
@@ -143,8 +141,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             "--theme-list" => {
                 let builtins = config::Theme::builtin_descriptions();
-                let mut entries: Vec<(&str, String)> =
-                    builtins.iter().map(|(n, d)| (*n, d.to_string())).collect();
+                let mut entries: Vec<(String, String)> = builtins;
 
                 // Scan custom theme directories: system (/etc/scouty/themes/) and
                 // user (~/.scouty/themes/), matching the search order used by
@@ -181,8 +178,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     continue;
                                 }
                                 seen_custom.insert(stem.clone());
-                                let leaked: &str = Box::leak(stem.into_boxed_str());
-                                entries.push((leaked, "(custom)".to_string()));
+
+                                // Try to read description from the theme YAML file
+                                let desc = std::fs::read_to_string(entry.path())
+                                    .ok()
+                                    .and_then(|content| config::Theme::from_yaml(&content).ok())
+                                    .and_then(|t| t.description)
+                                    .unwrap_or_else(|| "(custom)".to_string());
+                                entries.push((stem, desc));
                             }
                         }
                     }
@@ -200,7 +203,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 print!("{}", config::generate_default_config());
                 std::process::exit(0);
             }
-            "--generate-theme" => {
+            "--theme-dump" => {
                 if i + 1 < args.len() {
                     let name = &args[i + 1];
                     if name == "list" {
@@ -223,12 +226,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                 } else {
-                    eprintln!("Error: --generate-theme requires a theme name (or 'list')");
+                    eprintln!("Error: --theme-dump requires a theme name (or 'list')");
                     std::process::exit(1);
                 }
             }
-            arg if arg.starts_with("--generate-theme=") => {
-                let name = arg.trim_start_matches("--generate-theme=");
+            arg if arg.starts_with("--theme-dump=") => {
+                let name = arg.trim_start_matches("--theme-dump=");
                 if name == "list" {
                     for t in config::Theme::builtin_names() {
                         println!("{}", t);


### PR DESCRIPTION
## Summary

- **Description as Theme struct field**: All builtin theme constructors now set the `description` field on the Theme struct. This means:
  - `--theme-dump` YAML output naturally includes `description:`
  - Custom theme YAML files can specify `description:`
  - `--theme-list` reads description from the struct field (including custom themes)

- **Renamed CLI flag**: `--generate-theme` → `--theme-dump` (same behavior: dumps a named theme as YAML to stdout)

## Changes

- `theme.rs`: Set `description` in all 9 builtin theme constructors; replace static `builtin_catalog()` with `builtin_descriptions()` that reads from Theme instances
- `main.rs`: Rename `--generate-theme` to `--theme-dump`; read description from custom theme YAML in `--theme-list`
- `theme_tests.rs`: Update test to use new `builtin_descriptions()` API
- `mod.rs`: Minor comment update

## Test

All 495 tests pass.

Closes #555