### PR TITLE
Rename default theme back to mizuiro (keep as default)

### DIFF
--- a/crates/scouty-tui/src/config/config_tests.rs
+++ b/crates/scouty-tui/src/config/config_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     #[test]
     fn default_config() {
         let cfg = Config::default();
-        assert_eq!(cfg.theme, "default");
+        assert_eq!(cfg.theme, "mizuiro");
     }
 
     #[test]
@@ -18,7 +18,7 @@ mod tests {
     #[test]
     fn config_from_empty_yaml() {
         let cfg: Config = serde_yaml::from_str("{}").unwrap();
-        assert_eq!(cfg.theme, "default");
+        assert_eq!(cfg.theme, "mizuiro");
     }
 
     #[test]
@@ -131,7 +131,7 @@ mod tests {
         let merged = super::super::deep_merge(base, overlay);
         // theme key removed → deserialization uses default
         let cfg: Config = serde_yaml::from_value(merged).unwrap();
-        assert_eq!(cfg.theme, "default");
+        assert_eq!(cfg.theme, "mizuiro");
     }
 
     #[test]
@@ -174,7 +174,7 @@ mod tests {
         let cfg: Config = serde_yaml::from_value(merged).unwrap();
         assert!((cfg.general.detail_panel_ratio - 0.5).abs() < f64::EPSILON);
         assert!(cfg.general.follow_on_pipe); // default preserved
-        assert_eq!(cfg.theme, "default"); // default preserved
+        assert_eq!(cfg.theme, "mizuiro"); // default preserved
     }
 
     #[test]
@@ -192,7 +192,7 @@ mod tests {
     fn test_generate_default_config_is_valid_yaml() {
         let yaml = super::super::generate_default_config();
         let cfg: super::super::Config = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(cfg.theme, "default");
+        assert_eq!(cfg.theme, "mizuiro");
         assert_eq!(cfg.ssh.connect_timeout, 10);
     }
 
@@ -223,7 +223,7 @@ mod tests {
     fn test_builtin_names() {
         let names = super::super::Theme::builtin_names();
         assert_eq!(names.len(), 6);
-        assert!(names.contains(&"default"));
+        assert!(names.contains(&"mizuiro"));
         assert!(names.contains(&"landmine"));
         assert!(names.contains(&"amai"));
         assert!(names.contains(&"maid"));

--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -22,7 +22,7 @@ use tracing::{instrument, warn};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
-    /// Theme name: "default" or a custom theme file name (without .yaml).
+    /// Theme name: "mizuiro" or a custom theme file name (without .yaml).
     pub theme: String,
     /// Keybinding overrides.
     #[serde(default)]
@@ -78,7 +78,7 @@ impl Default for SshConfig {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            theme: "default".to_string(),
+            theme: "mizuiro".to_string(),
             keybindings: crate::keybinding::KeybindingConfig::default(),
             general: GeneralConfig::default(),
             default_paths: Vec::new(),
@@ -222,7 +222,7 @@ pub fn load_config() -> Config {
 pub fn resolve_theme(config: &Config, cli_theme: Option<&str>) -> Theme {
     let theme_name = cli_theme.unwrap_or(&config.theme);
 
-    if theme_name == "default" {
+    if theme_name == "mizuiro" {
         return Theme::default();
     }
 
@@ -264,8 +264,8 @@ pub fn generate_default_config() -> String {
 # Place at ~/.scouty/config.yaml (user) or ./scouty.yaml (project)
 # See: https://github.com/r12f/scouty
 
-# Theme selection (built-in: default, landmine, amai, maid, gyaru, dopamine)
-theme: default
+# Theme selection (built-in: mizuiro, landmine, amai, maid, gyaru, dopamine)
+theme: mizuiro
 
 # Default log paths when no files specified (glob patterns supported)
 default_paths: []

--- a/crates/scouty-tui/src/config/theme.rs
+++ b/crates/scouty-tui/src/config/theme.rs
@@ -392,6 +392,13 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
+        Self::mizuiro()
+    }
+}
+
+impl Theme {
+    /// Mizuiro theme — Clear, transparent aqua theme with cool blue tones (default).
+    pub fn mizuiro() -> Self {
         use Color::*;
         let deep_navy = Rgb(10, 22, 40); // #0A1628
         let dark_ocean = Rgb(15, 32, 56); // #0F2038
@@ -410,7 +417,9 @@ impl Default for Theme {
         let amber_warn = Rgb(232, 167, 78); // #E8A74E
 
         Self {
-            description: Some("Clear, transparent aqua theme with cool blue tones".to_string()),
+            description: Some(
+                "Mizuiro — Clear, transparent aqua theme with cool blue tones".to_string(),
+            ),
             log_levels: LogLevelTheme {
                 fatal: StyleEntry::fg_bold(coral_accent),
                 error: StyleEntry::fg(Rgb(207, 107, 94)), // #CF6B5E
@@ -507,9 +516,7 @@ impl Default for Theme {
             },
         }
     }
-}
 
-impl Theme {
     /// Load a theme from YAML string, merging over defaults.
     pub fn from_yaml(yaml: &str) -> Result<Self, String> {
         serde_yaml::from_str(yaml).map_err(|e| format!("invalid theme YAML: {e}"))
@@ -518,7 +525,7 @@ impl Theme {
     /// Built-in preset: look up by name. Returns None for unknown names.
     pub fn builtin(name: &str) -> Option<Self> {
         match name {
-            "default" => Some(Self::default()),
+            "mizuiro" => Some(Self::mizuiro()),
             "landmine" => Some(Self::landmine()),
             "amai" => Some(Self::amai()),
             "maid" => Some(Self::maid()),
@@ -530,7 +537,7 @@ impl Theme {
 
     /// All built-in theme names in display order.
     const BUILTIN_NAMES: &'static [&'static str] =
-        &["default", "landmine", "amai", "maid", "gyaru", "dopamine"];
+        &["mizuiro", "landmine", "amai", "maid", "gyaru", "dopamine"];
 
     /// List all built-in theme names.
     pub fn builtin_names() -> Vec<&'static str> {


### PR DESCRIPTION
Follow-up to PR #560: rename the theme back from `default` to `mizuiro` per boss's clarification. Mizuiro keeps its original name — it's just the default when no `--theme` is specified.

Changes:
- Rename theme from `default` to `mizuiro` (function name, BUILTIN_NAMES, builtin() match, description)
- `Theme::default()` delegates to `Self::mizuiro()`
- Update config defaults and generated YAML to use `mizuiro`
- Update all tests accordingly

Final 5 built-in themes: `mizuiro` (default), `landmine`, `amai`, `maid`, `gyaru`