### PR TITLE
Fix highlight colors becoming identical after delete + add

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -2139,7 +2139,15 @@ impl App {
         match Regex::new(pattern) {
             Ok(regex) => {
                 let palette = &self.theme.highlight_palette;
-                let color_idx = self.highlight_rules.len() % palette.len().max(1);
+                let palette_len = palette.len().max(1);
+                let used_colors: std::collections::HashSet<usize> = self
+                    .highlight_rules
+                    .iter()
+                    .filter_map(|r| palette.iter().position(|c| c.0 == r.color))
+                    .collect();
+                let color_idx = (0..palette_len)
+                    .find(|i| !used_colors.contains(i))
+                    .unwrap_or(self.highlight_rules.len() % palette_len);
                 let color = palette.get(color_idx).map(|c| c.0).unwrap_or(Color::Red);
                 self.highlight_rules.push(HighlightRule {
                     pattern: pattern.to_string(),


### PR DESCRIPTION
## Problem

When adding two highlights, deleting the first, then adding another, the two remaining highlights end up with the same color. This happens because the color index was computed as `highlight_rules.len() % palette.len()`, which doesn't account for palette indices already in use.

## Fix

When adding a new highlight, collect the palette indices already used by existing highlights and pick the first unused index. Falls back to the old behavior (len-based) when all palette slots are taken.

Closes #568