### PR TITLE
fix: recalculate highlight color index after deletion

### DIFF
--- a/crates/scouty-tui/src/app.rs
+++ b/crates/scouty-tui/src/app.rs
@@ -2932,6 +2932,49 @@ mod tests {
         app.detail_scroll_left();
         assert_eq!(app.detail_horizontal_offset, 0);
     }
+
+    #[test]
+    fn test_highlight_color_no_duplicate_after_delete() {
+        let mut app = make_app(0);
+        // Add two highlight rules — they should get different colors.
+        app.add_highlight_rule("aaa").unwrap();
+        app.add_highlight_rule("bbb").unwrap();
+        let color0 = app.highlight_rules[0].color;
+        let color1 = app.highlight_rules[1].color;
+        assert_ne!(color0, color1, "initial rules should have different colors");
+
+        // Remove the first rule, then add a new one.
+        app.remove_highlight_rule(0);
+        assert_eq!(app.highlight_rules.len(), 1);
+        app.add_highlight_rule("ccc").unwrap();
+
+        // The new rule must NOT collide with the remaining rule.
+        let remaining_color = app.highlight_rules[0].color;
+        let new_color = app.highlight_rules[1].color;
+        assert_ne!(
+            remaining_color, new_color,
+            "new highlight should not reuse the color of the remaining rule"
+        );
+    }
+
+    #[test]
+    fn test_highlight_color_reuses_freed_slot() {
+        let mut app = make_app(0);
+        app.add_highlight_rule("aaa").unwrap();
+        let first_color = app.highlight_rules[0].color;
+
+        app.add_highlight_rule("bbb").unwrap();
+        // Remove the first rule to free its palette slot.
+        app.remove_highlight_rule(0);
+        app.add_highlight_rule("ccc").unwrap();
+
+        // The freed color (first_color) should be reused since it's the lowest free index.
+        let reused_color = app.highlight_rules[1].color;
+        assert_eq!(
+            first_color, reused_color,
+            "should reuse the freed palette slot"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

When highlight rules are deleted and new ones added, the color index assignment uses the current rule count (`self.highlight_rules.len() % palette.len()`), which can collide with colors of remaining rules.

**Repro steps:**
1. Add two highlight rules (get colors 0 and 1)
2. Delete the first rule (one rule left with color 1)
3. Add a new rule → gets `len() % palette = 1 % palette` → same color as the remaining rule

## Fix

Find the first unused palette index by checking existing rules' colors instead of using a simple counter. Falls back to round-robin when all palette colors are exhausted.

## Tests

Added two tests:
- `test_highlight_color_no_duplicate_after_delete` — verifies no collision after delete+add
- `test_highlight_color_reuses_freed_slot` — verifies freed palette slots are reclaimed

Closes #568