### PR TITLE
Add Windows default config path support

### DIFF
--- a/crates/scouty-tui/src/config/filter_preset.rs
+++ b/crates/scouty-tui/src/config/filter_preset.rs
@@ -30,9 +30,8 @@ pub struct FilterPresetEntry {
 
 /// Directory for filter presets.
 fn presets_dir() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".scouty")
+    super::config_dir()
+        .unwrap_or_else(|| PathBuf::from(".").join(".scouty"))
         .join("filters")
 }
 

--- a/crates/scouty-tui/src/config/mod.rs
+++ b/crates/scouty-tui/src/config/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Supports layered config loading:
 //! 1. Built-in defaults (compiled in)
-//! 2. `/etc/scouty/config.yaml` (system-wide, if exists)
-//! 3. `~/.scouty/config.yaml` (per-user, if exists)
+//! 2. System config (Linux/macOS: `/etc/scouty/`, Windows: `%PROGRAMDATA%\scouty\`)
+//! 3. User config (Linux/macOS: `~/.scouty/`, Windows: `%APPDATA%\scouty\`)
 //! 4. `./scouty.yaml` (local/project-level, if exists)
 //! 5. CLI flags (`--theme`, `--config`, file arguments)
 
@@ -115,14 +115,29 @@ pub fn expand_default_paths(patterns: &[String]) -> Vec<String> {
     results
 }
 
-/// Return the system-wide config directory: `/etc/scouty/`.
+/// Return the system-wide config directory.
+///
+/// - Linux/macOS: `/etc/scouty/`
+/// - Windows: `%PROGRAMDATA%\scouty\`
 pub fn system_config_dir() -> PathBuf {
+    if cfg!(target_os = "windows") {
+        if let Ok(program_data) = std::env::var("PROGRAMDATA") {
+            return PathBuf::from(program_data).join("scouty");
+        }
+    }
     PathBuf::from("/etc/scouty")
 }
 
-/// Return the scouty config directory: `~/.scouty/`.
+/// Return the per-user scouty config directory.
+///
+/// - Linux/macOS: `~/.scouty/`
+/// - Windows: `%APPDATA%\scouty\`
 pub fn config_dir() -> Option<PathBuf> {
-    dirs::home_dir().map(|h| h.join(".scouty"))
+    if cfg!(target_os = "windows") {
+        dirs::config_dir().map(|d| d.join("scouty"))
+    } else {
+        dirs::home_dir().map(|h| h.join(".scouty"))
+    }
 }
 
 /// Deep-merge two serde_yaml Values.

--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -148,8 +148,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // config::resolve_theme().
                 let mut custom_dirs: Vec<std::path::PathBuf> = Vec::new();
                 custom_dirs.push(config::system_config_dir().join("themes"));
-                if let Some(home) = dirs::home_dir() {
-                    custom_dirs.push(home.join(".scouty").join("themes"));
+                if let Some(dir) = config::config_dir() {
+                    custom_dirs.push(dir.join("themes"));
                 }
                 let mut seen_custom: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
@@ -362,9 +362,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Initialize tracing (only when --log is passed) ──
     let _tracing_guard = if let Some(ref level) = log_level {
-        let log_dir = dirs::home_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("."))
-            .join(".scouty")
+        let log_dir = config::config_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from(".").join(".scouty"))
             .join("log");
         let _ = std::fs::create_dir_all(&log_dir);
 


### PR DESCRIPTION
## Summary

Add platform-appropriate default config paths on Windows, alongside existing Linux/macOS paths.

### Windows paths added:
- **System**: `%PROGRAMDATA%\scouty\` (via `PROGRAMDATA` env var)
- **User**: `%APPDATA%\scouty\` (via `dirs::config_dir()`)
- **Local**: `./scouty.yaml` (unchanged)

### Changes:
- `system_config_dir()`: returns `%PROGRAMDATA%\scouty` on Windows, `/etc/scouty` elsewhere
- `config_dir()`: returns `%APPDATA%\scouty` on Windows, `~/.scouty` elsewhere
- Updated filter presets, theme scanning, and log directory to use `config_dir()` consistently instead of hardcoded `~/.scouty`
- Priority order preserved: Local > User > System (same as Linux/macOS)
- No changes to existing Linux/macOS behavior (`cfg!(target_os = "windows")` guards)

All 497 existing tests pass.

Closes #572