### PR TITLE
fix: use initial sample lines for stdin streaming parser detection

### DIFF
--- a/crates/scouty-tui/src/main.rs
+++ b/crates/scouty-tui/src/main.rs
@@ -680,11 +680,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             None
         };
 
-    // Set up stdin streaming parser (for incremental stdin follow)
+    // Set up stdin streaming parser (for incremental stdin follow).
+    // Re-use sample_lines from the initial batch so the parser factory
+    // can content-sniff the format (e.g. syslog) instead of falling
+    // through to the plain-text fallback.
     let stdin_parser = if stdin_rx.is_some() {
         use scouty::traits::LogLoader;
         let loader = scouty::loader::stdin::StdinLoader::new();
-        let info = loader.info().clone();
+        let mut info = loader.info().clone();
+        info.sample_lines = main_window
+            .app
+            .records
+            .iter()
+            .take(10)
+            .map(|r| r.raw.clone())
+            .collect();
         Some((
             ParserFactory::create_parser_group(&info),
             info,


### PR DESCRIPTION
## Summary

When piping stdin to scouty in TUI mode (`cat /var/log/syslog | scouty`), lines beyond the initial 50-line batch were parsed with the wrong parser. The streaming stdin parser was created from a fresh `StdinLoader` with empty `sample_lines`, so the `ParserFactory` skipped content sniffing and fell through to the plain-text fallback.

## Root Cause

In `main.rs`, the stdin streaming parser was created like:

```rust
let loader = scouty::loader::stdin::StdinLoader::new();
let info = loader.info().clone(); // empty sample_lines!
ParserFactory::create_parser_group(&info) // no format detected → fallback
```

The initial 50 lines were parsed correctly by `App::load_stdin()` (which sets `sample_lines`), but subsequent lines used this empty-sample parser group.

## Fix

Populate `sample_lines` from the already-parsed initial records before creating the streaming parser group. This lets the factory detect the log format (syslog, JSON, SWSS, etc.) for all subsequent lines.

## Testing

- `cargo test` — all 497 tests pass
- Manual: `cat syslog | scouty-tui --no-tui --format json` correctly extracts hostname, timestamp, pid, message fields
- Manual: tested with 100-line syslog file to confirm lines beyond the 50-line initial batch are parsed correctly
- File mode (`scouty-tui /var/log/syslog`) remains unchanged

Closes #576